### PR TITLE
하트 사용 서비스 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/hearttransaction/domain/HeartTransaction.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/domain/HeartTransaction.java
@@ -7,6 +7,7 @@ import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
 import atwoz.atwoz.hearttransaction.exception.InvalidHeartAmountException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -24,6 +25,7 @@ public class HeartTransaction extends BaseEntity {
     private TransactionType transactionType;
 
     @Embedded
+    @Getter
     private HeartAmount heartAmount;
 
     @Embedded

--- a/src/main/java/atwoz/atwoz/hearttransaction/domain/HeartTransaction.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/domain/HeartTransaction.java
@@ -29,6 +29,7 @@ public class HeartTransaction extends BaseEntity {
     private HeartAmount heartAmount;
 
     @Embedded
+    @Getter
     private HeartBalance heartBalance;
 
     public static HeartTransaction of(Long memberId, TransactionType transactionType, HeartAmount heartAmount, HeartBalance heartBalance) {

--- a/src/main/java/atwoz/atwoz/hearttransaction/domain/HeartTransaction.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/domain/HeartTransaction.java
@@ -9,6 +9,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,31 +45,19 @@ public class HeartTransaction extends BaseEntity {
         validateHeartTransaction(transactionType, heartAmount);
     }
 
-    private void setMemberId(Long memberId) {
-        if (memberId == null) {
-            throw new IllegalArgumentException("memberId는 null이 될 수 없습니다.");
-        }
+    private void setMemberId(@NonNull Long memberId) {
         this.memberId = memberId;
     }
 
-    private void setTransactionType(TransactionType transactionType) {
-        if (transactionType == null) {
-            throw new IllegalArgumentException("transactionType은 null이 될 수 없습니다.");
-        }
+    private void setTransactionType(@NonNull TransactionType transactionType) {
         this.transactionType = transactionType;
     }
 
-    private void setHeartAmount(HeartAmount heartAmount) {
-        if (heartAmount == null) {
-            throw new IllegalArgumentException("heartAmount는 null이 될 수 없습니다.");
-        }
+    private void setHeartAmount(@NonNull HeartAmount heartAmount) {
         this.heartAmount = heartAmount;
     }
 
-    private void setHeartBalance(HeartBalance heartBalance) {
-        if (heartBalance == null) {
-            throw new IllegalArgumentException("heartBalance는 null이 될 수 없습니다.");
-        }
+    private void setHeartBalance(@NonNull HeartBalance heartBalance) {
         this.heartBalance = heartBalance;
     }
 

--- a/src/main/java/atwoz/atwoz/hearttransaction/domain/HeartTransactionRepository.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/domain/HeartTransactionRepository.java
@@ -1,0 +1,5 @@
+package atwoz.atwoz.hearttransaction.domain;
+
+public interface HeartTransactionRepository {
+    HeartTransaction save(HeartTransaction heartTransaction);
+}

--- a/src/main/java/atwoz/atwoz/hearttransaction/domain/vo/HeartAmount.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/domain/vo/HeartAmount.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Embeddable
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
 public final class HeartAmount {
     private static final Long MAX_USING_AMOUNT = 0L;
     private static final Long MIN_GAINING_AMOUNT = 1L;

--- a/src/main/java/atwoz/atwoz/hearttransaction/domain/vo/HeartAmount.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/domain/vo/HeartAmount.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Embeddable;
 import lombok.*;
 
 @Embeddable
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public final class HeartAmount {
     private static final Long MAX_USING_AMOUNT = 0L;
@@ -26,5 +25,9 @@ public final class HeartAmount {
 
     public boolean isGainingAmount() {
         return this.amount >= MIN_GAINING_AMOUNT;
+    }
+
+    private HeartAmount(@NonNull Long amount) {
+        this.amount = amount;
     }
 }

--- a/src/main/java/atwoz/atwoz/hearttransaction/domain/vo/HeartBalance.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/domain/vo/HeartBalance.java
@@ -3,9 +3,11 @@ package atwoz.atwoz.hearttransaction.domain.vo;
 import atwoz.atwoz.hearttransaction.exception.InvalidHeartAmountException;
 import atwoz.atwoz.hearttransaction.exception.InvalidHeartBalanceException;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Embeddable
+@EqualsAndHashCode
 public final class HeartBalance {
     private static final Long MIN_HEART_BALANCE = 0L;
     @Getter
@@ -81,7 +83,7 @@ public final class HeartBalance {
 
     private void validateUsingAmount(HeartAmount heartChangeAmount) {
         if (!heartChangeAmount.isUsingAmount()) {
-            throw new InvalidHeartAmountException("잘못된 하트 획득량 입니다. amount: " + heartChangeAmount.getAmount());
+            throw new InvalidHeartAmountException("잘못된 하트 사용량 입니다. amount: " + heartChangeAmount.getAmount());
         }
     }
 

--- a/src/main/java/atwoz/atwoz/hearttransaction/infra/HeartTransactionJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/infra/HeartTransactionJpaRepository.java
@@ -1,0 +1,8 @@
+package atwoz.atwoz.hearttransaction.infra;
+
+import atwoz.atwoz.hearttransaction.domain.HeartTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HeartTransactionJpaRepository extends JpaRepository<HeartTransaction, Long> {
+    HeartTransaction save(HeartTransaction heartTransaction);
+}

--- a/src/main/java/atwoz/atwoz/hearttransaction/infra/HeartTransactionJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/infra/HeartTransactionJpaRepository.java
@@ -4,5 +4,4 @@ import atwoz.atwoz.hearttransaction.domain.HeartTransaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HeartTransactionJpaRepository extends JpaRepository<HeartTransaction, Long> {
-    HeartTransaction save(HeartTransaction heartTransaction);
 }

--- a/src/main/java/atwoz/atwoz/hearttransaction/infra/HeartTransactionRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/hearttransaction/infra/HeartTransactionRepositoryImpl.java
@@ -1,0 +1,17 @@
+package atwoz.atwoz.hearttransaction.infra;
+
+import atwoz.atwoz.hearttransaction.domain.HeartTransaction;
+import atwoz.atwoz.hearttransaction.domain.HeartTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HeartTransactionRepositoryImpl implements HeartTransactionRepository {
+    private final HeartTransactionJpaRepository heartTransactionJpaRepository;
+
+    @Override
+    public HeartTransaction save(HeartTransaction heartTransaction) {
+        return heartTransactionJpaRepository.save(heartTransaction);
+    }
+}

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageService.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageService.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.heartusagepolicy.application;
+
+import atwoz.atwoz.hearttransaction.domain.HeartTransaction;
+import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
+import atwoz.atwoz.member.domain.member.Member;
+
+public interface HeartUsageService {
+    HeartTransaction useHeart(Member member, TransactionType transactionType);
+}

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageServiceImpl.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageServiceImpl.java
@@ -1,11 +1,12 @@
-package atwoz.atwoz.heartusagepolicy.domain;
+package atwoz.atwoz.heartusagepolicy.application;
 
 import atwoz.atwoz.hearttransaction.domain.HeartTransaction;
 import atwoz.atwoz.hearttransaction.domain.HeartTransactionRepository;
 import atwoz.atwoz.hearttransaction.domain.vo.HeartAmount;
 import atwoz.atwoz.hearttransaction.domain.vo.HeartBalance;
 import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
-import atwoz.atwoz.heartusagepolicy.application.HeartUsageService;
+import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicy;
+import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicyRepository;
 import atwoz.atwoz.heartusagepolicy.exception.HeartUsagePolicyNotFoundException;
 import atwoz.atwoz.member.domain.member.Member;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartPriceAmount.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartPriceAmount.java
@@ -13,7 +13,7 @@ public class HeartPriceAmount {
     }
 
     public Long getAmount() {
-        return price * -1;
+        return -price;
     }
 
     public Long getPrice() {

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartPriceAmount.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartPriceAmount.java
@@ -12,6 +12,14 @@ public class HeartPriceAmount {
         return new HeartPriceAmount(price);
     }
 
+    public Long getAmount() {
+        return price * -1;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
     protected HeartPriceAmount() {
         this.price = MIN_PRICE;
     }

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartPriceAmount.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartPriceAmount.java
@@ -2,6 +2,7 @@ package atwoz.atwoz.heartusagepolicy.domain;
 
 import atwoz.atwoz.heartusagepolicy.exception.InvalidHeartPriceAmountException;
 import jakarta.persistence.Embeddable;
+import lombok.NonNull;
 
 @Embeddable
 public class HeartPriceAmount {
@@ -29,7 +30,7 @@ public class HeartPriceAmount {
         this.price = price;
     }
 
-    private void validateMinPrice(Long price) {
+    private void validateMinPrice(@NonNull Long price) {
         if (price < MIN_PRICE) {
             throw new InvalidHeartPriceAmountException("price 값이 최소값보다 낮습니다. price=" + price);
         }

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsagePolicy.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsagePolicy.java
@@ -41,6 +41,14 @@ public class HeartUsagePolicy extends BaseEntity {
         return this.transactionType;
     }
 
+    public Long getAmount() {
+        return this.heartPriceAmount.getAmount();
+    }
+
+    public Long getPrice() {
+        return this.heartPriceAmount.getPrice();
+    }
+
     private void setTransactionType(TransactionType transactionType) {
         if (transactionType == null) {
             throw new IllegalArgumentException("TransactionType은 null이 될 수 없습니다.");

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsagePolicy.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsagePolicy.java
@@ -8,6 +8,7 @@ import atwoz.atwoz.member.domain.member.Gender;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -49,27 +50,18 @@ public class HeartUsagePolicy extends BaseEntity {
         return this.heartPriceAmount.getPrice();
     }
 
-    private void setTransactionType(TransactionType transactionType) {
-        if (transactionType == null) {
-            throw new IllegalArgumentException("TransactionType은 null이 될 수 없습니다.");
-        }
+    private void setTransactionType(@NonNull TransactionType transactionType) {
         if (!transactionType.isUsingType()) {
             throw new InvalidHeartTransactionTypeException("TransactionType이 UsingType이 아닙니다. transactionType: " + transactionType);
         }
         this.transactionType = transactionType;
     }
 
-    private void setGender(Gender gender) {
-        if (gender == null) {
-            throw new IllegalArgumentException("Gender는 null이 될 수 없습니다.");
-        }
+    private void setGender(@NonNull Gender gender) {
         this.gender = gender;
     }
 
-    private void setHeartPriceAmount(HeartPriceAmount heartPriceAmount) {
-        if (heartPriceAmount == null) {
-            throw new IllegalArgumentException("HeartItemPrice는 null이 될 수 없습니다.");
-        }
+    private void setHeartPriceAmount(@NonNull HeartPriceAmount heartPriceAmount) {
         this.heartPriceAmount = heartPriceAmount;
     }
 }

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsagePolicyRepository.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsagePolicyRepository.java
@@ -1,0 +1,10 @@
+package atwoz.atwoz.heartusagepolicy.domain;
+
+import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
+import atwoz.atwoz.member.domain.member.Gender;
+
+import java.util.Optional;
+
+public interface HeartUsagePolicyRepository {
+    Optional<HeartUsagePolicy> findByGenderAndTransactionType(Gender gender, TransactionType transactionType);
+}

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsageServiceImpl.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsageServiceImpl.java
@@ -1,0 +1,46 @@
+package atwoz.atwoz.heartusagepolicy.domain;
+
+import atwoz.atwoz.hearttransaction.domain.HeartTransaction;
+import atwoz.atwoz.hearttransaction.domain.HeartTransactionRepository;
+import atwoz.atwoz.hearttransaction.domain.vo.HeartAmount;
+import atwoz.atwoz.hearttransaction.domain.vo.HeartBalance;
+import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
+import atwoz.atwoz.heartusagepolicy.application.HeartUsageService;
+import atwoz.atwoz.heartusagepolicy.exception.HeartUsagePolicyNotFoundException;
+import atwoz.atwoz.member.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HeartUsageServiceImpl implements HeartUsageService {
+    private final HeartUsagePolicyRepository heartUsagePolicyRepository;
+    private final HeartTransactionRepository heartTransactionRepository;
+
+    @Override
+    @Transactional
+    public HeartTransaction useHeart(Member member, TransactionType transactionType) {
+        HeartAmount heartAmount = getHeartAmount(member, transactionType);
+        HeartBalance balanceAfterUsingHeart = deductHeartBalance(member, heartAmount);
+        return createHeartTransaction(member, transactionType, heartAmount, balanceAfterUsingHeart);
+    }
+
+    private HeartAmount getHeartAmount(Member member, TransactionType transactionType) {
+        HeartUsagePolicy heartUsagePolicy = heartUsagePolicyRepository.findByGenderAndTransactionType(member.getGender(), transactionType)
+                .orElseThrow(() -> new HeartUsagePolicyNotFoundException("해당하는 하트 사용 정책이 없습니다. gender: " + member.getGender() + ", transactionType: " + transactionType));
+        HeartAmount heartAmount = HeartAmount.from(heartUsagePolicy.getAmount());
+        return heartAmount;
+    }
+
+    private HeartBalance deductHeartBalance(Member member, HeartAmount heartAmount) {
+        member.useHeart(heartAmount);
+        HeartBalance balanceAfterUsingHeart = member.getHeartBalance();
+        return balanceAfterUsingHeart;
+    }
+
+    private HeartTransaction createHeartTransaction(Member member, TransactionType transactionType, HeartAmount heartAmount, HeartBalance balanceAfterUsingHeart) {
+        HeartTransaction heartTransaction = HeartTransaction.of(member.getId(), transactionType, heartAmount, balanceAfterUsingHeart);
+        return heartTransactionRepository.save(heartTransaction);
+    }
+}

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsageServiceImpl.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsageServiceImpl.java
@@ -29,6 +29,9 @@ public class HeartUsageServiceImpl implements HeartUsageService {
     private HeartAmount getHeartAmount(Member member, TransactionType transactionType) {
         HeartUsagePolicy heartUsagePolicy = heartUsagePolicyRepository.findByGenderAndTransactionType(member.getGender(), transactionType)
                 .orElseThrow(() -> new HeartUsagePolicyNotFoundException("해당하는 하트 사용 정책이 없습니다. gender: " + member.getGender() + ", transactionType: " + transactionType));
+        if (member.isVipMember()) {
+            return HeartAmount.from(0L);
+        }
         HeartAmount heartAmount = HeartAmount.from(heartUsagePolicy.getAmount());
         return heartAmount;
     }

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/exception/HeartUsagePolicyNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/exception/HeartUsagePolicyNotFoundException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.heartusagepolicy.exception;
+
+public class HeartUsagePolicyNotFoundException extends RuntimeException {
+    public HeartUsagePolicyNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/infra/HeartUsagePolicyJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/infra/HeartUsagePolicyJpaRepository.java
@@ -1,0 +1,12 @@
+package atwoz.atwoz.heartusagepolicy.infra;
+
+import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
+import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicy;
+import atwoz.atwoz.member.domain.member.Gender;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HeartUsagePolicyJpaRepository extends JpaRepository<HeartUsagePolicy, Long> {
+    Optional<HeartUsagePolicy> findByGenderAndTransactionType(Gender gender, TransactionType transactionType);
+}

--- a/src/main/java/atwoz/atwoz/heartusagepolicy/infra/HeartUsagePolicyRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/heartusagepolicy/infra/HeartUsagePolicyRepositoryImpl.java
@@ -1,0 +1,21 @@
+package atwoz.atwoz.heartusagepolicy.infra;
+
+import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
+import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicy;
+import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicyRepository;
+import atwoz.atwoz.member.domain.member.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class HeartUsagePolicyRepositoryImpl implements HeartUsagePolicyRepository {
+    private final HeartUsagePolicyJpaRepository heartUsagePolicyJpaRepository;
+
+    @Override
+    public Optional<HeartUsagePolicy> findByGenderAndTransactionType(Gender gender, TransactionType transactionType) {
+        return heartUsagePolicyJpaRepository.findByGenderAndTransactionType(gender, transactionType);
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/domain/member/Member.java
@@ -1,6 +1,8 @@
 package atwoz.atwoz.member.domain.member;
 
 import atwoz.atwoz.common.domain.SoftDeleteBaseEntity;
+import atwoz.atwoz.hearttransaction.domain.vo.HeartAmount;
+import atwoz.atwoz.hearttransaction.domain.vo.HeartBalance;
 import atwoz.atwoz.member.domain.member.vo.Nickname;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -40,10 +42,14 @@ public class Member extends SoftDeleteBaseEntity {
     @Column(columnDefinition = "varchar(50)")
     private ActivityStatus activityStatus;
 
+    @Embedded
+    private HeartBalance heartBalance;
+
     public static Member createFromPhoneNumber(String phoneNumber) {
         return Member.builder()
                 .phoneNumber(phoneNumber)
                 .activityStatus(ActivityStatus.ACTIVE)
+                .heartBalance(HeartBalance.init())
                 .build();
     }
 
@@ -62,4 +68,22 @@ public class Member extends SoftDeleteBaseEntity {
         return false;
     }
 
+    public void useHeart(HeartAmount heartAmount) {
+        HeartBalance balanceAfterUsingHeart = this.heartBalance.useHeart(heartAmount);
+        this.heartBalance = balanceAfterUsingHeart;
+    }
+
+    public void gainPurchaseHeart(HeartAmount heartAmount) {
+        HeartBalance balanceAfterGainingHeart = this.heartBalance.gainPurchaseHeart(heartAmount);
+        this.heartBalance = balanceAfterGainingHeart;
+    }
+
+    public void gainMissionHeart(HeartAmount heartAmount) {
+        HeartBalance balanceAfterGainingHeart = this.heartBalance.gainMissionHeart(heartAmount);
+        this.heartBalance = balanceAfterGainingHeart;
+    }
+
+    public HeartBalance getHeartBalance() {
+        return this.heartBalance;
+    }
 }

--- a/src/main/java/atwoz/atwoz/member/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/domain/member/Member.java
@@ -30,6 +30,8 @@ public class Member extends SoftDeleteBaseEntity {
 
     private Integer height;
 
+    private boolean isVip;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)")
     private Gender gender;
@@ -86,5 +88,9 @@ public class Member extends SoftDeleteBaseEntity {
 
     public HeartBalance getHeartBalance() {
         return this.heartBalance;
+    }
+
+    public boolean isVipMember() {
+        return this.isVip;
     }
 }

--- a/src/main/java/atwoz/atwoz/member/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/domain/member/Member.java
@@ -50,6 +50,7 @@ public class Member extends SoftDeleteBaseEntity {
                 .phoneNumber(phoneNumber)
                 .activityStatus(ActivityStatus.ACTIVE)
                 .heartBalance(HeartBalance.init())
+                .isVip(false)
                 .build();
     }
 

--- a/src/main/java/atwoz/atwoz/member/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/domain/member/Member.java
@@ -93,4 +93,8 @@ public class Member extends SoftDeleteBaseEntity {
     public boolean isVipMember() {
         return this.isVip;
     }
+
+    public Gender getGender() {
+        return this.gender;
+    }
 }

--- a/src/test/java/atwoz/atwoz/hearttransaction/domain/HeartTransactionTest.java
+++ b/src/test/java/atwoz/atwoz/hearttransaction/domain/HeartTransactionTest.java
@@ -30,7 +30,7 @@ class HeartTransactionTest {
 
             // when & then
             assertThatThrownBy(() -> HeartTransaction.of(memberId, transactionType, heartAmount, heartBalance))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(NullPointerException.class);
         }
 
         @Test

--- a/src/test/java/atwoz/atwoz/hearttransaction/domain/vo/HeartAmountTest.java
+++ b/src/test/java/atwoz/atwoz/hearttransaction/domain/vo/HeartAmountTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HeartAmountTest {
 
@@ -43,6 +43,16 @@ class HeartAmountTest {
             HeartAmount heartAmount = HeartAmount.from(amount);
             // then
             assertThat(heartAmount.getAmount()).isEqualTo(amount);
+        }
+
+        @Test
+        @DisplayName("amount가 null이면 NullPointerException 발생")
+        void throwsNullPointExceptionWhenAmountIsNull() {
+            // given
+            Long amount = null;
+            // when & then
+            assertThatThrownBy(() -> HeartAmount.from(amount))
+                    .isInstanceOf(NullPointerException.class);
         }
     }
 

--- a/src/test/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageServiceImplTest.java
+++ b/src/test/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageServiceImplTest.java
@@ -1,10 +1,12 @@
-package atwoz.atwoz.heartusagepolicy.domain;
+package atwoz.atwoz.heartusagepolicy.application;
 
 import atwoz.atwoz.hearttransaction.domain.HeartTransaction;
 import atwoz.atwoz.hearttransaction.domain.HeartTransactionRepository;
 import atwoz.atwoz.hearttransaction.domain.vo.HeartAmount;
 import atwoz.atwoz.hearttransaction.domain.vo.HeartBalance;
 import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
+import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicy;
+import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicyRepository;
 import atwoz.atwoz.heartusagepolicy.exception.HeartUsagePolicyNotFoundException;
 import atwoz.atwoz.member.domain.member.Gender;
 import atwoz.atwoz.member.domain.member.Member;

--- a/src/test/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageServiceImplTest.java
+++ b/src/test/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageServiceImplTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,13 +41,18 @@ class HeartUsageServiceImplTest {
     void shouldThrowExceptionWhenHeartUsagePolicyNotFound() {
         // given
         Member member = Member.createFromPhoneNumber("01012345678");
+        Gender gender = Gender.MALE;
+        setField(member, "gender", gender);
         TransactionType transactionType = TransactionType.MESSAGE;
-        when(heartUsagePolicyRepository.findByGenderAndTransactionType(any(), eq(transactionType)))
+        when(heartUsagePolicyRepository.findByGenderAndTransactionType(eq(gender), eq(transactionType)))
                 .thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> heartUsageService.useHeart(member, transactionType))
                 .isInstanceOf(HeartUsagePolicyNotFoundException.class);
+
+        verify(heartUsagePolicyRepository, atMostOnce()).findByGenderAndTransactionType(eq(gender), eq(transactionType));
+        verify(heartTransactionRepository, never()).save(any(HeartTransaction.class));
     }
 
     @Test
@@ -84,6 +89,9 @@ class HeartUsageServiceImplTest {
         // then
         assertThat(heartTransaction.getHeartAmount()).isEqualTo(expectedHeartAmount);
         assertThat(heartTransaction.getHeartBalance()).isEqualTo(heartBalanceBeforeUsingHeart);
+
+        verify(heartUsagePolicyRepository, atMostOnce()).findByGenderAndTransactionType(eq(gender), eq(transactionType));
+        verify(heartTransactionRepository, atMostOnce()).save(any(HeartTransaction.class));
     }
 
     @Test
@@ -120,5 +128,8 @@ class HeartUsageServiceImplTest {
         // then
         assertThat(heartTransaction.getHeartAmount()).isEqualTo(expectedHeartAmount);
         assertThat(heartTransaction.getHeartBalance()).isEqualTo(expectedHeartBalance);
+
+        verify(heartUsagePolicyRepository, atMostOnce()).findByGenderAndTransactionType(eq(gender), eq(transactionType));
+        verify(heartTransactionRepository, atMostOnce()).save(any(HeartTransaction.class));
     }
 }

--- a/src/test/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageServiceImplTest.java
+++ b/src/test/java/atwoz/atwoz/heartusagepolicy/application/HeartUsageServiceImplTest.java
@@ -5,6 +5,7 @@ import atwoz.atwoz.hearttransaction.domain.HeartTransactionRepository;
 import atwoz.atwoz.hearttransaction.domain.vo.HeartAmount;
 import atwoz.atwoz.hearttransaction.domain.vo.HeartBalance;
 import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
+import atwoz.atwoz.heartusagepolicy.domain.HeartPriceAmount;
 import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicy;
 import atwoz.atwoz.heartusagepolicy.domain.HeartUsagePolicyRepository;
 import atwoz.atwoz.heartusagepolicy.exception.HeartUsagePolicyNotFoundException;
@@ -23,8 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(MockitoExtension.class)
 class HeartUsageServiceImplTest {
@@ -53,21 +54,28 @@ class HeartUsageServiceImplTest {
     @DisplayName("VIP 멤버인 경우 하트 사용량 0으로 처리")
     void shouldUseZeroHeartAmountWhenMemberIsVip() {
         // given
-        Member member = mock(Member.class);
-        when(member.isVipMember()).thenReturn(true);
+        Member member = Member.createFromPhoneNumber("01012345678");
+        setField(member, "isVip", true);
         Long memberId = 1L;
-        when(member.getId()).thenReturn(memberId);
+        setField(member, "id", memberId);
         Gender gender = Gender.MALE;
-        when(member.getGender()).thenReturn(gender);
-        HeartBalance heartBalance = mock(HeartBalance.class);
-        when(member.getHeartBalance()).thenReturn(heartBalance);
-        HeartUsagePolicy heartUsagePolicy = mock(HeartUsagePolicy.class);
+        setField(member, "gender", gender);
+        HeartBalance heartBalanceBeforeUsingHeart = HeartBalance.init();
+        setField(heartBalanceBeforeUsingHeart, "purchaseHeartBalance", 100L);
+        setField(heartBalanceBeforeUsingHeart, "missionHeartBalance", 100L);
+        setField(member, "heartBalance", heartBalanceBeforeUsingHeart);
         TransactionType transactionType = TransactionType.MESSAGE;
-        when(heartUsagePolicyRepository.findByGenderAndTransactionType(any(), eq(transactionType)))
+        HeartPriceAmount heartPriceAmount = HeartPriceAmount.from(10L);
+        HeartUsagePolicy heartUsagePolicy = HeartUsagePolicy.of(transactionType, gender, heartPriceAmount);
+
+        when(heartUsagePolicyRepository.findByGenderAndTransactionType(eq(gender), eq(transactionType)))
                 .thenReturn(Optional.of(heartUsagePolicy));
-        HeartTransaction mockHeartTransaction = mock(HeartTransaction.class);
-        when(mockHeartTransaction.getHeartAmount()).thenReturn(HeartAmount.from(0L));
-        when(heartTransactionRepository.save(any())).thenReturn(mockHeartTransaction);
+        when(heartTransactionRepository.save(any(HeartTransaction.class)))
+                .thenAnswer(invocation -> {
+                    HeartTransaction heartTransaction = invocation.getArgument(0);
+                    setField(heartTransaction, "id", 1L);
+                    return heartTransaction;
+                });
         HeartAmount expectedHeartAmount = HeartAmount.from(0L);
 
         // when
@@ -75,33 +83,42 @@ class HeartUsageServiceImplTest {
 
         // then
         assertThat(heartTransaction.getHeartAmount()).isEqualTo(expectedHeartAmount);
+        assertThat(heartTransaction.getHeartBalance()).isEqualTo(heartBalanceBeforeUsingHeart);
     }
 
     @Test
     @DisplayName("VIP 멤버가 아닌 경우 하트 사용 정책에 따라 하트 사용량 계산")
     void shouldCalculateHeartAmountAccordingToHeartUsagePolicy() {
         // given
-        Member member = mock(Member.class);
-        when(member.isVipMember()).thenReturn(true);
+        Member member = Member.createFromPhoneNumber("01012345678");
         Long memberId = 1L;
-        when(member.getId()).thenReturn(memberId);
+        setField(member, "id", memberId);
         Gender gender = Gender.MALE;
-        when(member.getGender()).thenReturn(gender);
-        HeartBalance heartBalance = mock(HeartBalance.class);
-        when(member.getHeartBalance()).thenReturn(heartBalance);
-        HeartUsagePolicy heartUsagePolicy = mock(HeartUsagePolicy.class);
+        setField(member, "gender", gender);
+        HeartBalance heartBalanceBeforeUsingHeart = HeartBalance.init();
+        setField(heartBalanceBeforeUsingHeart, "purchaseHeartBalance", 100L);
+        setField(heartBalanceBeforeUsingHeart, "missionHeartBalance", 100L);
+        setField(member, "heartBalance", heartBalanceBeforeUsingHeart);
         TransactionType transactionType = TransactionType.MESSAGE;
-        when(heartUsagePolicyRepository.findByGenderAndTransactionType(any(), eq(transactionType)))
+        HeartPriceAmount heartPriceAmount = HeartPriceAmount.from(10L);
+        HeartUsagePolicy heartUsagePolicy = HeartUsagePolicy.of(transactionType, gender, heartPriceAmount);
+
+        when(heartUsagePolicyRepository.findByGenderAndTransactionType(eq(gender), eq(transactionType)))
                 .thenReturn(Optional.of(heartUsagePolicy));
-        HeartTransaction mockHeartTransaction = mock(HeartTransaction.class);
-        when(mockHeartTransaction.getHeartAmount()).thenReturn(HeartAmount.from(-10L));
-        when(heartTransactionRepository.save(any())).thenReturn(mockHeartTransaction);
+        when(heartTransactionRepository.save(any(HeartTransaction.class)))
+                .thenAnswer(invocation -> {
+                    HeartTransaction heartTransaction = invocation.getArgument(0);
+                    setField(heartTransaction, "id", 1L);
+                    return heartTransaction;
+                });
         HeartAmount expectedHeartAmount = HeartAmount.from(-10L);
+        HeartBalance expectedHeartBalance = heartBalanceBeforeUsingHeart.useHeart(expectedHeartAmount);
 
         // when
         HeartTransaction heartTransaction = heartUsageService.useHeart(member, transactionType);
 
         // then
         assertThat(heartTransaction.getHeartAmount()).isEqualTo(expectedHeartAmount);
+        assertThat(heartTransaction.getHeartBalance()).isEqualTo(expectedHeartBalance);
     }
 }

--- a/src/test/java/atwoz/atwoz/heartusagepolicy/domain/HeartPriceAmountTest.java
+++ b/src/test/java/atwoz/atwoz/heartusagepolicy/domain/HeartPriceAmountTest.java
@@ -30,4 +30,14 @@ class HeartPriceAmountTest {
         // then
         assertThat(heartPriceAmount).isNotNull();
     }
+
+    @Test
+    @DisplayName("price가 null이면 NullPointerException 발생")
+    void throwsNullPointExceptionWhenPriceIsNull() {
+        // given
+        Long price = null;
+        // when & then
+        assertThatThrownBy(() -> HeartPriceAmount.from(price))
+                .isInstanceOf(NullPointerException.class);
+    }
 }

--- a/src/test/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsagePolicyTest.java
+++ b/src/test/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsagePolicyTest.java
@@ -41,7 +41,7 @@ class HeartUsagePolicyTest {
             HeartPriceAmount heartPriceAmount = fieldName.equals("heartPriceAmount is null") ? null : HeartPriceAmount.from(10L);
             // when & then
             assertThatThrownBy(() -> HeartUsagePolicy.of(transactionType, gender, heartPriceAmount))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(NullPointerException.class);
         }
 
         @Test

--- a/src/test/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsageServiceImplTest.java
+++ b/src/test/java/atwoz/atwoz/heartusagepolicy/domain/HeartUsageServiceImplTest.java
@@ -1,0 +1,105 @@
+package atwoz.atwoz.heartusagepolicy.domain;
+
+import atwoz.atwoz.hearttransaction.domain.HeartTransaction;
+import atwoz.atwoz.hearttransaction.domain.HeartTransactionRepository;
+import atwoz.atwoz.hearttransaction.domain.vo.HeartAmount;
+import atwoz.atwoz.hearttransaction.domain.vo.HeartBalance;
+import atwoz.atwoz.hearttransaction.domain.vo.TransactionType;
+import atwoz.atwoz.heartusagepolicy.exception.HeartUsagePolicyNotFoundException;
+import atwoz.atwoz.member.domain.member.Gender;
+import atwoz.atwoz.member.domain.member.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HeartUsageServiceImplTest {
+    @InjectMocks
+    private HeartUsageServiceImpl heartUsageService;
+    @Mock
+    private HeartUsagePolicyRepository heartUsagePolicyRepository;
+    @Mock
+    private HeartTransactionRepository heartTransactionRepository;
+
+    @Test
+    @DisplayName("하트 사용 정책이 없는 경우 예외 발생")
+    void shouldThrowExceptionWhenHeartUsagePolicyNotFound() {
+        // given
+        Member member = Member.createFromPhoneNumber("01012345678");
+        TransactionType transactionType = TransactionType.MESSAGE;
+        when(heartUsagePolicyRepository.findByGenderAndTransactionType(any(), eq(transactionType)))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> heartUsageService.useHeart(member, transactionType))
+                .isInstanceOf(HeartUsagePolicyNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("VIP 멤버인 경우 하트 사용량 0으로 처리")
+    void shouldUseZeroHeartAmountWhenMemberIsVip() {
+        // given
+        Member member = mock(Member.class);
+        when(member.isVipMember()).thenReturn(true);
+        Long memberId = 1L;
+        when(member.getId()).thenReturn(memberId);
+        Gender gender = Gender.MALE;
+        when(member.getGender()).thenReturn(gender);
+        HeartBalance heartBalance = mock(HeartBalance.class);
+        when(member.getHeartBalance()).thenReturn(heartBalance);
+        HeartUsagePolicy heartUsagePolicy = mock(HeartUsagePolicy.class);
+        TransactionType transactionType = TransactionType.MESSAGE;
+        when(heartUsagePolicyRepository.findByGenderAndTransactionType(any(), eq(transactionType)))
+                .thenReturn(Optional.of(heartUsagePolicy));
+        HeartTransaction mockHeartTransaction = mock(HeartTransaction.class);
+        when(mockHeartTransaction.getHeartAmount()).thenReturn(HeartAmount.from(0L));
+        when(heartTransactionRepository.save(any())).thenReturn(mockHeartTransaction);
+        HeartAmount expectedHeartAmount = HeartAmount.from(0L);
+
+        // when
+        HeartTransaction heartTransaction = heartUsageService.useHeart(member, transactionType);
+
+        // then
+        assertThat(heartTransaction.getHeartAmount()).isEqualTo(expectedHeartAmount);
+    }
+
+    @Test
+    @DisplayName("VIP 멤버가 아닌 경우 하트 사용 정책에 따라 하트 사용량 계산")
+    void shouldCalculateHeartAmountAccordingToHeartUsagePolicy() {
+        // given
+        Member member = mock(Member.class);
+        when(member.isVipMember()).thenReturn(true);
+        Long memberId = 1L;
+        when(member.getId()).thenReturn(memberId);
+        Gender gender = Gender.MALE;
+        when(member.getGender()).thenReturn(gender);
+        HeartBalance heartBalance = mock(HeartBalance.class);
+        when(member.getHeartBalance()).thenReturn(heartBalance);
+        HeartUsagePolicy heartUsagePolicy = mock(HeartUsagePolicy.class);
+        TransactionType transactionType = TransactionType.MESSAGE;
+        when(heartUsagePolicyRepository.findByGenderAndTransactionType(any(), eq(transactionType)))
+                .thenReturn(Optional.of(heartUsagePolicy));
+        HeartTransaction mockHeartTransaction = mock(HeartTransaction.class);
+        when(mockHeartTransaction.getHeartAmount()).thenReturn(HeartAmount.from(-10L));
+        when(heartTransactionRepository.save(any())).thenReturn(mockHeartTransaction);
+        HeartAmount expectedHeartAmount = HeartAmount.from(-10L);
+
+        // when
+        HeartTransaction heartTransaction = heartUsageService.useHeart(member, transactionType);
+
+        // then
+        assertThat(heartTransaction.getHeartAmount()).isEqualTo(expectedHeartAmount);
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/domain/MemberTest.java
+++ b/src/test/java/atwoz/atwoz/member/domain/MemberTest.java
@@ -1,8 +1,11 @@
 package atwoz.atwoz.member.domain;
 
+import atwoz.atwoz.hearttransaction.domain.vo.HeartAmount;
+import atwoz.atwoz.hearttransaction.domain.vo.HeartBalance;
 import atwoz.atwoz.member.domain.member.Member;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class MemberTest {
@@ -20,5 +23,64 @@ public class MemberTest {
         Assertions.assertThat(member).isNotNull();
         Assertions.assertThat(member.isProfileSettingNeeded()).isTrue();
         Assertions.assertThat(member.isPermanentStop()).isFalse();
+    }
+
+    @Nested
+    @DisplayName("gainPurchaseHeart 메서드 테스트")
+    class GainPurchaseHeartMethodTest {
+        @Test
+        @DisplayName("멤버가 하트를 구매하면 구매 하트 잔액이 증가합니다.")
+        void shouldIncreasePurchaseHeartBalanceWhenMemberPurchasesHeart() {
+            // Given
+            Member member = Member.createFromPhoneNumber("01012345678");
+            HeartAmount purchaseHeartAmount = HeartAmount.from(100L);
+            HeartBalance expectedHeartBalance = HeartBalance.init().gainPurchaseHeart(purchaseHeartAmount);
+
+            // When
+            member.gainPurchaseHeart(purchaseHeartAmount);
+
+            // Then
+            Assertions.assertThat(member.getHeartBalance()).isEqualTo(expectedHeartBalance);
+        }
+    }
+
+    @Nested
+    @DisplayName("useHeart 메서드 테스트")
+    class UseHeartMethodTest {
+        @Test
+        @DisplayName("멤버가 하트를 사용하면 하트 잔액이 차감됩니다.")
+        void shouldDeductHeartBalanceWhenMemberUsesHeart() {
+            // Given
+            Member member = Member.createFromPhoneNumber("01012345678");
+            member.gainPurchaseHeart(HeartAmount.from(100L));
+            HeartAmount usingheartAmount = HeartAmount.from(-10L);
+            HeartAmount expectedHeartAmount = HeartAmount.from(90L);
+            HeartBalance expectedHeartBalance = HeartBalance.init().gainPurchaseHeart(expectedHeartAmount);
+
+            // When
+            member.useHeart(usingheartAmount);
+
+            // Then
+            Assertions.assertThat(member.getHeartBalance()).isEqualTo(expectedHeartBalance);
+        }
+    }
+
+    @Nested
+    @DisplayName("gainMissionHeart 메서드 테스트")
+    class GainMissionHeartMethodTest {
+        @Test
+        @DisplayName("멤버가 미션을 수행하면 미션 하트 잔액이 증가합니다.")
+        void shouldIncreaseMissionHeartBalanceWhenMemberCompletesMission() {
+            // Given
+            Member member = Member.createFromPhoneNumber("01012345678");
+            HeartAmount missionHeartAmount = HeartAmount.from(100L);
+            HeartBalance expectedHeartBalance = HeartBalance.init().gainMissionHeart(missionHeartAmount);
+
+            // When
+            member.gainMissionHeart(missionHeartAmount);
+
+            // Then
+            Assertions.assertThat(member.getHeartBalance()).isEqualTo(expectedHeartBalance);
+        }
     }
 }


### PR DESCRIPTION
### 관련 이슈
- closes #24 

<br>

### 작업 내용
- HeartUsageService 구현
- HeartTransaction repository 구현
- HeartUsagePolicy repository 구현
- Member에 HeartBalance 및 관련 메서드 추가
- Member에 isVip 및 관련 메서드 추가

<br>

### 참고 자료
-

<br>

### 노트
- 브랜치 이름에 오타가 있는데 크게 중요한 사항은 아닌 것 같아 그대로 푸시했어요
- HeartUsageServiceImpl 테스트 코드에서 고민이 되는 부분이 좀 있는데
  - 도메인 애그리거트를 mock 할지
  - mock 하지 않으면
    - member id를 설정할 수 없어서 EntityManager로 save 해줘야하고
    - gender 설정 메서드, isVip 설정 메서드를 이번 pr에서 정의해야하고
    - 작업 범위가 pr의 목적에 비해 과하게 넓어지는 듯 하네요
  - mock 을 하면
    - 사용하는 도메인 애그리거트의 많은 메서드에 대해서 처리해줘야해서 테스트 코드가 복잡해지고
    - 테스트 코드는 로직 보다는 단순히 메서드를 잘 호출하는지 검사하는 느낌이 드네요
  - 비즈니스 로직은 도메인에 담기니까 테스트 코드에서 서비스 테스트 코드에서는 비즈니스 로직 검증이 아닌 도메인 객체를 잘 사용하고 있는지만 확인하면 되는 것 같긴한데 혹시 관련해서 좋은 방법이나 아이디어 있으면 코멘트 부탁드립니다! @atwoz-dev/server 
