### PR TITLE
직업 도메인 정의 및 테스트 코드 작성

### DIFF
--- a/src/main/java/atwoz/atwoz/job/domain/Job.java
+++ b/src/main/java/atwoz/atwoz/job/domain/Job.java
@@ -1,15 +1,12 @@
 package atwoz.atwoz.job.domain;
 
 import atwoz.atwoz.common.domain.BaseEntity;
-import atwoz.atwoz.job.exception.InvalidJobCodeException;
 import atwoz.atwoz.job.exception.InvalidJobNameException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -21,31 +18,19 @@ public class Job extends BaseEntity {
     private String name;
     private String code;
 
-    @Builder
-    private Job(String name, String code) {
+
+    public Job(String name) {
         validateName(name);
-        validateCode(code);
         this.name = name;
-        this.code = code;
     }
 
     public String getName() {
         return name;
     }
 
-    public String getCode() {
-        return code;
-    }
-
     private static void validateName(String name) {
         if (name == null) {
             throw new InvalidJobNameException();
-        }
-    }
-
-    private static void validateCode(String code) {
-        if (code == null) {
-            throw new InvalidJobCodeException();
         }
     }
 }

--- a/src/main/java/atwoz/atwoz/job/domain/Job.java
+++ b/src/main/java/atwoz/atwoz/job/domain/Job.java
@@ -1,0 +1,51 @@
+package atwoz.atwoz.job.domain;
+
+import atwoz.atwoz.common.domain.BaseEntity;
+import atwoz.atwoz.job.exception.InvalidJobCodeException;
+import atwoz.atwoz.job.exception.InvalidJobNameException;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Job extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String code;
+
+    @Builder
+    private Job(String name, String code) {
+        validateName(name);
+        validateCode(code);
+        this.name = name;
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    private static void validateName(String name) {
+        if (name == null) {
+            throw new InvalidJobNameException();
+        }
+    }
+
+    private static void validateCode(String code) {
+        if (code == null) {
+            throw new InvalidJobCodeException();
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/job/domain/Job.java
+++ b/src/main/java/atwoz/atwoz/job/domain/Job.java
@@ -16,8 +16,6 @@ public class Job extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
-    private String code;
-
 
     public Job(String name) {
         validateName(name);

--- a/src/main/java/atwoz/atwoz/job/exception/InvalidJobCodeException.java
+++ b/src/main/java/atwoz/atwoz/job/exception/InvalidJobCodeException.java
@@ -1,7 +1,0 @@
-package atwoz.atwoz.job.exception;
-
-public class InvalidJobCodeException extends RuntimeException {
-    public InvalidJobCodeException() {
-        super("유효하지 않은 직업 코드입니다.");
-    }
-}

--- a/src/main/java/atwoz/atwoz/job/exception/InvalidJobCodeException.java
+++ b/src/main/java/atwoz/atwoz/job/exception/InvalidJobCodeException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.job.exception;
+
+public class InvalidJobCodeException extends RuntimeException {
+    public InvalidJobCodeException() {
+        super("유효하지 않은 직업 코드입니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/job/exception/InvalidJobNameException.java
+++ b/src/main/java/atwoz/atwoz/job/exception/InvalidJobNameException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.job.exception;
+
+public class InvalidJobNameException extends RuntimeException {
+    public InvalidJobNameException() {
+        super("유효하지 않은 직업명입니다.");
+    }
+}

--- a/src/test/java/atwoz/atwoz/job/domain/JobTest.java
+++ b/src/test/java/atwoz/atwoz/job/domain/JobTest.java
@@ -1,0 +1,59 @@
+package atwoz.atwoz.job.domain;
+
+import atwoz.atwoz.job.exception.InvalidJobCodeException;
+import atwoz.atwoz.job.exception.InvalidJobNameException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class JobTest {
+
+    @Test
+    @DisplayName("직업명이 null인 경우, 유효하지 않다.")
+    public void invalidWhenJobNameIsNull() {
+        // Given
+        String name = null;
+        String code = "JOB_CODE";
+
+
+        // When & Then
+        Assertions.assertThatThrownBy(() -> Job.builder()
+                        .name(name)
+                        .code(code)
+                        .build())
+                .isInstanceOf(InvalidJobNameException.class);
+    }
+
+    @Test
+    @DisplayName("직업 코드가 null인 경우, 유효하지 않다.")
+    public void invalidWhenJobCodeIsNull() {
+        // Given
+        String name = "JOB_NAME";
+        String code = null;
+
+        // When & Then
+        Assertions.assertThatThrownBy(() -> Job.builder()
+                        .name(name)
+                        .code(code)
+                        .build())
+                .isInstanceOf(InvalidJobCodeException.class);
+    }
+
+    @Test
+    @DisplayName("직업명과 코드가 null이 아닌 경우, 유효하다.")
+    public void isValidWhenJobCodeAndJobNameAreNotNull() {
+        // Given
+        String name = "JOB_NAME";
+        String code = "JOB_CODE";
+
+        // When
+        Job job = Job.builder()
+                .name(name)
+                .code(code)
+                .build();
+
+        // Then
+        Assertions.assertThat(job.getName()).isEqualTo(name);
+        Assertions.assertThat(job.getCode()).isEqualTo(code);
+    }
+}

--- a/src/test/java/atwoz/atwoz/job/domain/JobTest.java
+++ b/src/test/java/atwoz/atwoz/job/domain/JobTest.java
@@ -1,6 +1,5 @@
 package atwoz.atwoz.job.domain;
 
-import atwoz.atwoz.job.exception.InvalidJobCodeException;
 import atwoz.atwoz.job.exception.InvalidJobNameException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -13,47 +12,22 @@ public class JobTest {
     public void invalidWhenJobNameIsNull() {
         // Given
         String name = null;
-        String code = "JOB_CODE";
-
 
         // When & Then
-        Assertions.assertThatThrownBy(() -> Job.builder()
-                        .name(name)
-                        .code(code)
-                        .build())
+        Assertions.assertThatThrownBy(() -> new Job(name))
                 .isInstanceOf(InvalidJobNameException.class);
     }
 
     @Test
-    @DisplayName("직업 코드가 null인 경우, 유효하지 않다.")
-    public void invalidWhenJobCodeIsNull() {
-        // Given
-        String name = "JOB_NAME";
-        String code = null;
-
-        // When & Then
-        Assertions.assertThatThrownBy(() -> Job.builder()
-                        .name(name)
-                        .code(code)
-                        .build())
-                .isInstanceOf(InvalidJobCodeException.class);
-    }
-
-    @Test
-    @DisplayName("직업명과 코드가 null이 아닌 경우, 유효하다.")
+    @DisplayName("직업명이 null이 아닌 경우, 유효하다.")
     public void isValidWhenJobCodeAndJobNameAreNotNull() {
         // Given
         String name = "JOB_NAME";
-        String code = "JOB_CODE";
 
         // When
-        Job job = Job.builder()
-                .name(name)
-                .code(code)
-                .build();
+        Job job = new Job(name);
 
         // Then
         Assertions.assertThat(job.getName()).isEqualTo(name);
-        Assertions.assertThat(job.getCode()).isEqualTo(code);
     }
 }


### PR DESCRIPTION
### 관련 이슈
- closes #29

<br>

### 작업 내용
- 직업 도메인 정의
- 테스트 코드 작성

<br>

### 참고 자료
-

<br>

### 노트
<img width="276" alt="image" src="https://github.com/user-attachments/assets/11cd5e44-4c4f-4145-864c-a3458620cadb" />

- 직업 코드를 위한 컬럼 `String code`를 추가하고 ERD에 함께 반영하였습니다.
- 노션에 보이지 않아서 그런데, 만약 직업에 PREFIX (JOB_) 과 같은 규칙이 있었던 것 같아서요! 만약 규칙이 있다면, Code 는 값타입으로 하고 static 변수로 PREFIX를 넣은 후에 따로 Validation 처리하겠습니다!

#### 변경사항
- 직업 코드를 사용하지 않기로 했던 것을 잊었네요.. 그에 관련 코드 삭제하고, 빌더 제거하고 단순 생성자로 정의하였습니다!

