### PR TITLE
하트 구매 옵션 애그리거트 정의

### DIFF
--- a/src/main/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseAmount.java
+++ b/src/main/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseAmount.java
@@ -1,0 +1,35 @@
+package atwoz.atwoz.heartpurchaseoption.domain;
+
+import atwoz.atwoz.heartpurchaseoption.exception.InvalidHeartPurchaseAmountException;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+@Embeddable
+@EqualsAndHashCode
+public class HeartPurchaseAmount {
+    private static final Long MIN_AMOUNT = 1L;
+
+    @Getter
+    private final Long amount;
+
+    public static HeartPurchaseAmount from(Long amount) {
+        return new HeartPurchaseAmount(amount);
+    }
+
+    private HeartPurchaseAmount(@NonNull Long amount) {
+        validateMinAmount(amount);
+        this.amount = amount;
+    }
+
+    private void validateMinAmount(Long amount) {
+        if (amount < MIN_AMOUNT) {
+            throw new InvalidHeartPurchaseAmountException("amount 값이 최소값보다 낮습니다. amount=" + amount);
+        }
+    }
+
+    protected HeartPurchaseAmount() {
+        this.amount = MIN_AMOUNT;
+    }
+}

--- a/src/main/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseOption.java
+++ b/src/main/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseOption.java
@@ -1,0 +1,48 @@
+package atwoz.atwoz.heartpurchaseoption.domain;
+
+import atwoz.atwoz.common.domain.SoftDeleteBaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HeartPurchaseOption extends SoftDeleteBaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private HeartPurchaseAmount amount;
+
+    @Embedded
+    private Price price;
+
+    private String name;
+
+    public static HeartPurchaseOption of(HeartPurchaseAmount amount, Price price, String name) {
+        return new HeartPurchaseOption(amount, price, name);
+    }
+
+    private HeartPurchaseOption(HeartPurchaseAmount amount, Price price, String name) {
+        setAmount(amount);
+        setPrice(price);
+        setName(name);
+    }
+
+    private void setAmount(@NonNull HeartPurchaseAmount amount) {
+        this.amount = amount;
+    }
+
+    private void setPrice(@NonNull Price price) {
+        this.price = price;
+    }
+
+    private void setName(@NonNull String name) {
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name 값이 비어있습니다.");
+        }
+        this.name = name;
+    }
+}

--- a/src/main/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseOption.java
+++ b/src/main/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseOption.java
@@ -1,6 +1,8 @@
 package atwoz.atwoz.heartpurchaseoption.domain;
 
 import atwoz.atwoz.common.domain.SoftDeleteBaseEntity;
+import atwoz.atwoz.heartpurchaseoption.exception.InvalidHeartPurchaseAmountException;
+import atwoz.atwoz.heartpurchaseoption.exception.InvalidHeartPurchaseOptionException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -41,7 +43,7 @@ public class HeartPurchaseOption extends SoftDeleteBaseEntity {
 
     private void setName(@NonNull String name) {
         if (name.isBlank()) {
-            throw new IllegalArgumentException("name 값이 비어있습니다.");
+            throw new InvalidHeartPurchaseOptionException("name 값이 비어있습니다.");
         }
         this.name = name;
     }

--- a/src/main/java/atwoz/atwoz/heartpurchaseoption/domain/Price.java
+++ b/src/main/java/atwoz/atwoz/heartpurchaseoption/domain/Price.java
@@ -1,0 +1,35 @@
+package atwoz.atwoz.heartpurchaseoption.domain;
+
+import atwoz.atwoz.heartpurchaseoption.exception.InvalidPriceException;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+@Embeddable
+@EqualsAndHashCode
+public class Price {
+    private static final Long MIN_PRICE = 1L;
+
+    @Getter
+    private final Long value;
+
+    public static Price from(Long value) {
+        return new Price(value);
+    }
+
+    protected Price() {
+        this.value = MIN_PRICE;
+    }
+
+    private Price(@NonNull Long value) {
+        validateMinPrice(value);
+        this.value = value;
+    }
+
+    private void validateMinPrice(Long value) {
+        if (value < MIN_PRICE) {
+            throw new InvalidPriceException("price 값이 최소값보다 낮습니다. price=" + value);
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/heartpurchaseoption/exception/InvalidHeartPurchaseAmountException.java
+++ b/src/main/java/atwoz/atwoz/heartpurchaseoption/exception/InvalidHeartPurchaseAmountException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.heartpurchaseoption.exception;
+
+public class InvalidHeartPurchaseAmountException extends RuntimeException {
+    public InvalidHeartPurchaseAmountException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/atwoz/atwoz/heartpurchaseoption/exception/InvalidHeartPurchaseOptionException.java
+++ b/src/main/java/atwoz/atwoz/heartpurchaseoption/exception/InvalidHeartPurchaseOptionException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.heartpurchaseoption.exception;
+
+public class InvalidHeartPurchaseOptionException extends RuntimeException {
+    public InvalidHeartPurchaseOptionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/atwoz/atwoz/heartpurchaseoption/exception/InvalidPriceException.java
+++ b/src/main/java/atwoz/atwoz/heartpurchaseoption/exception/InvalidPriceException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.heartpurchaseoption.exception;
+
+public class InvalidPriceException extends RuntimeException {
+    public InvalidPriceException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseAmountTest.java
+++ b/src/test/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseAmountTest.java
@@ -1,0 +1,46 @@
+package atwoz.atwoz.heartpurchaseoption.domain;
+
+import atwoz.atwoz.heartpurchaseoption.exception.InvalidHeartPurchaseAmountException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HeartPurchaseAmountTest {
+
+    @Test
+    @DisplayName("amount 값이 1보다 작으면 예외가 발생한다.")
+    void throwsExceptionWhenAmountIsLessThanOne() {
+        // given
+        Long amount = 0L;
+
+        // when, then
+        assertThatThrownBy(() -> HeartPurchaseAmount.from(amount))
+                .isInstanceOf(InvalidHeartPurchaseAmountException.class);
+    }
+
+    @Test
+    @DisplayName("amount 값이 null이면 예외가 발생한다.")
+    void throwsExceptionWhenAmountIsNull() {
+        // given
+        Long amount = null;
+
+        // when, then
+        assertThatThrownBy(() -> HeartPurchaseAmount.from(amount))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("amount 값이 0보다 크면 객체가 생성된다.")
+    void createObjectWhenAmountIsGreaterThanZero() {
+        // given
+        Long amount = 1L;
+
+        // when
+        HeartPurchaseAmount heartPurchaseAmount = HeartPurchaseAmount.from(amount);
+
+        // then
+        assertThat(heartPurchaseAmount.getAmount()).isEqualTo(amount);
+    }
+}

--- a/src/test/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseOptionTest.java
+++ b/src/test/java/atwoz/atwoz/heartpurchaseoption/domain/HeartPurchaseOptionTest.java
@@ -1,0 +1,67 @@
+package atwoz.atwoz.heartpurchaseoption.domain;
+
+import atwoz.atwoz.heartpurchaseoption.exception.InvalidHeartPurchaseOptionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HeartPurchaseOptionTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"amount is null", "price is null", "name is null"})
+    @DisplayName("of 메서드에서 필드 값이 null이면 예외를 던집니다.")
+    void throwsExceptionWhenFieldValueIsNull(String fieldName) {
+        // given
+        HeartPurchaseAmount amount = fieldName.equals("amount is null") ? null : HeartPurchaseAmount.from(10L);
+        Price price = fieldName.equals("price is null") ? null : Price.from(1000L);
+        String name = fieldName.equals("name is null") ? null : "name";
+
+        // when & then
+        assertThatThrownBy(() -> HeartPurchaseOption.of(amount, price, name))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("name 값이 빈 문자열이면 예외가 발생한다.")
+    void throwsExceptionWhenNameIsEmpty() {
+        // given
+        HeartPurchaseAmount amount = HeartPurchaseAmount.from(10L);
+        Price price = Price.from(1000L);
+        String name = "";
+
+        // when, then
+        assertThatThrownBy(() -> HeartPurchaseOption.of(amount, price, name))
+                .isInstanceOf(InvalidHeartPurchaseOptionException.class);
+    }
+
+    @Test
+    @DisplayName("name 값이 공백이면 예외가 발생한다.")
+    void throwsExceptionWhenNameIsBlank() {
+        // given
+        HeartPurchaseAmount amount = HeartPurchaseAmount.from(10L);
+        Price price = Price.from(1000L);
+        String name = "   ";
+
+        // when, then
+        assertThatThrownBy(() -> HeartPurchaseOption.of(amount, price, name))
+                .isInstanceOf(InvalidHeartPurchaseOptionException.class);
+    }
+
+    @Test
+    @DisplayName("amount, price, name 값이 주어지면 객체가 생성된다.")
+    void createObjectWhenAmountPriceNameAreGiven() {
+        // given
+        HeartPurchaseAmount amount = HeartPurchaseAmount.from(10L);
+        Price price = Price.from(1000L);
+        String name = "name";
+
+        // when
+        HeartPurchaseOption heartPurchaseOption = HeartPurchaseOption.of(amount, price, name);
+
+        // then
+        assertThat(heartPurchaseOption).isNotNull();
+    }
+}

--- a/src/test/java/atwoz/atwoz/heartpurchaseoption/domain/PriceTest.java
+++ b/src/test/java/atwoz/atwoz/heartpurchaseoption/domain/PriceTest.java
@@ -1,0 +1,45 @@
+package atwoz.atwoz.heartpurchaseoption.domain;
+
+import atwoz.atwoz.heartpurchaseoption.exception.InvalidPriceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PriceTest {
+    @Test
+    @DisplayName("price 값이 1보다 작으면 예외가 발생한다.")
+    void throwsExceptionWhenPriceIsLessThanOne() {
+        // given
+        Long value = 0L;
+
+        // when, then
+        assertThatThrownBy(() -> Price.from(value))
+                .isInstanceOf(InvalidPriceException.class);
+    }
+
+    @Test
+    @DisplayName("price 값이 null이면 예외가 발생한다.")
+    void throwsExceptionWhenPriceIsNull() {
+        // given
+        Long value = null;
+
+        // when, then
+        assertThatThrownBy(() -> Price.from(value))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("price 값이 0보다 크면 객체가 생성된다.")
+    void createObjectWhenPriceIsGreaterThanZero() {
+        // given
+        Long value = 1L;
+
+        // when
+        Price price = Price.from(value);
+
+        // then
+        assertThat(price.getValue()).isEqualTo(value);
+    }
+}


### PR DESCRIPTION
### 관련 이슈
- closes #36 

<br>

### 작업 내용
- 하트 구매 옵션 애그리거트 정의
- 테스트 코드 작성

<br>

### 참고 자료
-

<br>

### 노트
- 변경 대신에 soft delete 후 새로 생성하여 사용할 수 있도록 `extends SoftDeleteBaseEntity` 했습니다
- ERD 에는 상품 Item 으로 정의되어 있는 테이블을 좀 더 명확하게 하트 구매 옵션 HeartPurchaseOptions 라는 이름으로 애그리거트 정의
