### PR TITLE
관리자 로그인 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/application/AdminAuthMapper.java
+++ b/src/main/java/atwoz/atwoz/admin/application/AdminAuthMapper.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 import static lombok.AccessLevel.PRIVATE;
 
 @NoArgsConstructor(access = PRIVATE)
-public class AdminMapper {
+public class AdminAuthMapper {
 
     public static Admin toAdmin(AdminSignupRequest request, Password password) {
         return Admin.builder()

--- a/src/main/java/atwoz/atwoz/admin/application/AdminAuthService.java
+++ b/src/main/java/atwoz/atwoz/admin/application/AdminAuthService.java
@@ -32,7 +32,7 @@ public class AdminAuthService {
     public AdminSignupResponse signup(AdminSignupRequest request) {
         validateEmailUniqueness(request);
         Admin newAdmin = createAdmin(request);
-        return AdminMapper.toSignupResponse(newAdmin);
+        return AdminAuthMapper.toSignupResponse(newAdmin);
     }
 
     // TODO: refresh token redis 관련 로직 추가
@@ -44,7 +44,7 @@ public class AdminAuthService {
         Instant now = Instant.now();
         String accessToken = createAccessToken(admin.getId(), now);
         String refreshToken = createRefreshToken(admin.getId(), now);
-        return AdminMapper.toLoginResponse(accessToken, refreshToken);
+        return AdminAuthMapper.toLoginResponse(accessToken, refreshToken);
     }
 
     private void validateEmailUniqueness(AdminSignupRequest request) {
@@ -55,7 +55,7 @@ public class AdminAuthService {
 
     private Admin createAdmin(AdminSignupRequest request) {
         Password password = Password.fromRaw(request.password(), passwordHasher);
-        Admin newAdmin = AdminMapper.toAdmin(request, password);
+        Admin newAdmin = AdminAuthMapper.toAdmin(request, password);
         return adminRepository.save(newAdmin);
     }
 

--- a/src/main/java/atwoz/atwoz/admin/application/AdminAuthService.java
+++ b/src/main/java/atwoz/atwoz/admin/application/AdminAuthService.java
@@ -1,16 +1,24 @@
 package atwoz.atwoz.admin.application;
 
+import atwoz.atwoz.admin.application.dto.AdminLoginRequest;
+import atwoz.atwoz.admin.application.dto.AdminLoginResponse;
 import atwoz.atwoz.admin.application.dto.AdminSignupRequest;
 import atwoz.atwoz.admin.application.dto.AdminSignupResponse;
+import atwoz.atwoz.admin.application.exception.AdminNotFoundException;
 import atwoz.atwoz.admin.application.exception.DuplicateEmailException;
+import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
 import atwoz.atwoz.admin.domain.admin.Admin;
 import atwoz.atwoz.admin.domain.admin.Password;
 import atwoz.atwoz.admin.domain.repository.AdminRepository;
 import atwoz.atwoz.admin.domain.service.PasswordHasher;
+import atwoz.atwoz.common.auth.context.Role;
+import atwoz.atwoz.common.auth.jwt.JwtProvider;
 import atwoz.atwoz.common.domain.vo.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
 
 @Service
 @RequiredArgsConstructor
@@ -18,12 +26,25 @@ public class AdminAuthService {
 
     private final AdminRepository adminRepository;
     private final PasswordHasher passwordHasher;
+    private final JwtProvider jwtProvider;
 
     @Transactional
-    public AdminSignupResponse signUp(AdminSignupRequest request) {
+    public AdminSignupResponse signup(AdminSignupRequest request) {
         validateEmailUniqueness(request);
         Admin newAdmin = createAdmin(request);
-        return AdminMapper.toSignUpResponse(newAdmin);
+        return AdminMapper.toSignupResponse(newAdmin);
+    }
+
+    // TODO: refresh token redis 관련 로직 추가
+    @Transactional(readOnly = true)
+    public AdminLoginResponse login(AdminLoginRequest request) {
+        Admin admin = findAdminWith(request.email());
+        validatePassword(request.password(), admin.getHashedPassword());
+
+        Instant now = Instant.now();
+        String accessToken = createAccessToken(admin.getId(), now);
+        String refreshToken = createRefreshToken(admin.getId(), now);
+        return AdminMapper.toLoginResponse(accessToken, refreshToken);
     }
 
     private void validateEmailUniqueness(AdminSignupRequest request) {
@@ -36,5 +57,24 @@ public class AdminAuthService {
         Password password = Password.fromRaw(request.password(), passwordHasher);
         Admin newAdmin = AdminMapper.toAdmin(request, password);
         return adminRepository.save(newAdmin);
+    }
+
+    private Admin findAdminWith(String email) {
+        return adminRepository.findByEmail(Email.from(email))
+                .orElseThrow(AdminNotFoundException::new);
+    }
+
+    private void validatePassword(String requestPassword, String hashedPassword) {
+        if (!passwordHasher.matches(requestPassword, hashedPassword)) {
+            throw new PasswordMismatchException();
+        }
+    }
+
+    private String createAccessToken(Long id, Instant now) {
+        return jwtProvider.createAccessToken(id, Role.ADMIN, now);
+    }
+
+    private String createRefreshToken(Long id, Instant now) {
+        return jwtProvider.createRefreshToken(id, Role.ADMIN, now);
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/application/AdminMapper.java
+++ b/src/main/java/atwoz/atwoz/admin/application/AdminMapper.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.admin.application;
 
+import atwoz.atwoz.admin.application.dto.AdminLoginResponse;
 import atwoz.atwoz.admin.application.dto.AdminSignupRequest;
 import atwoz.atwoz.admin.application.dto.AdminSignupResponse;
 import atwoz.atwoz.admin.domain.admin.Admin;
@@ -23,12 +24,16 @@ public class AdminMapper {
                 .build();
     }
 
-    public static AdminSignupResponse toSignUpResponse(Admin admin) {
+    public static AdminSignupResponse toSignupResponse(Admin admin) {
         return new AdminSignupResponse(
                 admin.getId(),
                 admin.getEmail().getAddress(),
                 admin.getName().getValue(),
                 admin.getPhoneNumber().getValue()
         );
+    }
+
+    public static AdminLoginResponse toLoginResponse(String accessToken, String refreshToken) {
+        return new AdminLoginResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/application/dto/AdminLoginRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/application/dto/AdminLoginRequest.java
@@ -1,0 +1,14 @@
+package atwoz.atwoz.admin.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "유효한 이메일 주소를 입력해주세요.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password
+) {
+}

--- a/src/main/java/atwoz/atwoz/admin/application/dto/AdminLoginResponse.java
+++ b/src/main/java/atwoz/atwoz/admin/application/dto/AdminLoginResponse.java
@@ -1,0 +1,4 @@
+package atwoz.atwoz.admin.application.dto;
+
+public record AdminLoginResponse(String accessToken, String refreshToken) {
+}

--- a/src/main/java/atwoz/atwoz/admin/application/dto/AdminSignupRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/application/dto/AdminSignupRequest.java
@@ -5,25 +5,25 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record AdminSignupRequest(
-        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @NotBlank(message = "이메일을 입력해주세요.")
         @Email(message = "유효한 이메일 주소를 입력해주세요.")
         String email,
 
-        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
         @Pattern(
                 regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{10,20}$",
                 message = "비밀번호는 영문, 숫자, 특수문자를 포함한 10-20자리여야 합니다."
         )
         String password,
 
-        @NotBlank(message = "이름은 필수 입력 항목입니다.")
+        @NotBlank(message = "이름을 입력해주세요.")
         @Pattern(
                 regexp = "^[a-zA-Z0-9가-힣]{1,10}$",
                 message = "이름은 한글, 영문, 숫자를 포함하여 1-10자만 가능합니다."
         )
         String name,
 
-        @NotBlank(message = "전화번호는 필수 입력 항목입니다.")
+        @NotBlank(message = "전화번호를 입력해주세요.")
         @Pattern(
                 regexp = "^010\\d{8}$",
                 message = "전화번호는 01012345678 형식이어야 합니다."

--- a/src/main/java/atwoz/atwoz/admin/application/exception/AdminNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/admin/application/exception/AdminNotFoundException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.admin.application.exception;
+
+public class AdminNotFoundException extends RuntimeException {
+    public AdminNotFoundException() {
+        super("존재하지 않는 관리자입니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/admin/application/exception/DuplicateEmailException.java
+++ b/src/main/java/atwoz/atwoz/admin/application/exception/DuplicateEmailException.java
@@ -1,7 +1,7 @@
 package atwoz.atwoz.admin.application.exception;
 
 public class DuplicateEmailException extends RuntimeException {
-    public DuplicateEmailException(String email) {
-        super("이미 사용 중인 이메일입니다. Email: " + email);
+    public DuplicateEmailException() {
+        super("이미 사용 중인 이메일입니다.");
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/application/exception/PasswordMismatchException.java
+++ b/src/main/java/atwoz/atwoz/admin/application/exception/PasswordMismatchException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.admin.application.exception;
+
+public class PasswordMismatchException extends RuntimeException {
+    public PasswordMismatchException() {
+        super("비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/admin/domain/admin/Admin.java
+++ b/src/main/java/atwoz/atwoz/admin/domain/admin/Admin.java
@@ -11,22 +11,25 @@ import static jakarta.persistence.EnumType.STRING;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 public class Admin extends SoftDeleteBaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
     private Long id;
 
     @Embedded
+    @Getter
     private Email email;
 
     @Embedded
     private Password password;
 
     @Embedded
+    @Getter
     private Name name;
 
     @Embedded
+    @Getter
     private PhoneNumber phoneNumber;
 
     private String comment;
@@ -64,5 +67,9 @@ public class Admin extends SoftDeleteBaseEntity {
 
     private void setPhoneNumber(@NonNull PhoneNumber phoneNumber) {
         this.phoneNumber = phoneNumber;
+    }
+
+    public String getHashedPassword() {
+        return password.getHashedValue();
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/presentation/AdminAuthController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/AdminAuthController.java
@@ -1,12 +1,16 @@
 package atwoz.atwoz.admin.presentation;
 
 import atwoz.atwoz.admin.application.AdminAuthService;
+import atwoz.atwoz.admin.application.dto.AdminLoginRequest;
+import atwoz.atwoz.admin.application.dto.AdminLoginResponse;
 import atwoz.atwoz.admin.application.dto.AdminSignupRequest;
 import atwoz.atwoz.admin.application.dto.AdminSignupResponse;
 import atwoz.atwoz.common.presentation.BaseResponse;
 import atwoz.atwoz.common.presentation.StatusType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,8 +25,28 @@ public class AdminAuthController {
     private final AdminAuthService adminAuthService;
 
     @PostMapping("/signup")
-    public ResponseEntity<BaseResponse<AdminSignupResponse>> signUp(@Valid @RequestBody AdminSignupRequest request) {
+    public ResponseEntity<BaseResponse<AdminSignupResponse>> signup(@Valid @RequestBody AdminSignupRequest request) {
         AdminSignupResponse data = adminAuthService.signup(request);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, data));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<Void>> login(@Valid @RequestBody AdminLoginRequest request) {
+        AdminLoginResponse response = adminAuthService.login(request);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + response.accessToken());
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", response.refreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(60 * 60 * 24 * 7 * 4)
+                .build();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/presentation/AdminAuthController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/AdminAuthController.java
@@ -22,7 +22,7 @@ public class AdminAuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<AdminSignupResponse>> signUp(@Valid @RequestBody AdminSignupRequest request) {
-        AdminSignupResponse data = adminAuthService.signUp(request);
+        AdminSignupResponse data = adminAuthService.signup(request);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, data));
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/presentation/AdminExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/AdminExceptionHandler.java
@@ -1,22 +1,43 @@
 package atwoz.atwoz.admin.presentation;
 
+import atwoz.atwoz.admin.application.exception.AdminNotFoundException;
 import atwoz.atwoz.admin.application.exception.DuplicateEmailException;
+import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
 import atwoz.atwoz.common.presentation.BaseResponse;
 import atwoz.atwoz.common.presentation.StatusType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
-@RestControllerAdvice(basePackageClasses = AdminAuthController.class)
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class AdminExceptionHandler {
 
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<BaseResponse<Void>> handleDuplicateEmailException(DuplicateEmailException e) {
-        log.error("관리자에 회원가입에 실패했습니다. {}", e.getMessage(), e);
+        log.warn("관리자 회원가입에 실패했습니다. {}", e.getMessage());
 
         return ResponseEntity.badRequest()
                 .body(BaseResponse.from(StatusType.INVALID_DUPLICATE_VALUE));
+    }
+
+    @ExceptionHandler(AdminNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleAdminNotFoundException(AdminNotFoundException e) {
+        log.warn("관리자 로그인에 실패했습니다. {}", e.getMessage());
+
+        return ResponseEntity.status(401)
+                .body(BaseResponse.from(StatusType.UNAUTHORIZED));
+    }
+
+    @ExceptionHandler(PasswordMismatchException.class)
+    public ResponseEntity<BaseResponse<Void>> handlePasswordMismatchException(PasswordMismatchException e) {
+        log.warn("관리자 로그인에 실패했습니다. {}", e.getMessage());
+
+        return ResponseEntity.status(401)
+                .body(BaseResponse.from(StatusType.UNAUTHORIZED));
     }
 }

--- a/src/test/java/atwoz/atwoz/admin/application/AdminAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/application/AdminAuthServiceTest.java
@@ -1,14 +1,22 @@
 package atwoz.atwoz.admin.application;
 
+import atwoz.atwoz.admin.application.dto.AdminLoginRequest;
+import atwoz.atwoz.admin.application.dto.AdminLoginResponse;
 import atwoz.atwoz.admin.application.dto.AdminSignupRequest;
 import atwoz.atwoz.admin.application.dto.AdminSignupResponse;
+import atwoz.atwoz.admin.application.exception.AdminNotFoundException;
 import atwoz.atwoz.admin.application.exception.DuplicateEmailException;
+import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
 import atwoz.atwoz.admin.domain.admin.Admin;
 import atwoz.atwoz.admin.domain.admin.InvalidPasswordException;
 import atwoz.atwoz.admin.domain.repository.AdminRepository;
 import atwoz.atwoz.admin.domain.service.PasswordHasher;
+import atwoz.atwoz.common.auth.context.Role;
+import atwoz.atwoz.common.auth.jwt.JwtProvider;
 import atwoz.atwoz.common.domain.vo.Email;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,76 +40,150 @@ class AdminAuthServiceTest {
     @Mock
     private PasswordHasher passwordHasher;
 
+    @Mock
+    private JwtProvider jwtProvider;
+
     @InjectMocks
     private AdminAuthService adminAuthService;
 
-    @Test
-    @DisplayName("중복되지 않은 이메일과 유효한 비밀번호로 회원가입 할 수 있습니다.")
-    void canSignupWhenRequestIsValid() {
-        // given
-        String email = "test@example.com";
-        String rawPassword = "password123^^";
-        AdminSignupRequest request = new AdminSignupRequest(email, rawPassword, "홍길동", "01012345678");
+    @Nested
+    @DisplayName("회원가입")
+    class Signup {
+        @Test
+        @DisplayName("중복되지 않은 이메일과 유효한 비밀번호로 회원가입 할 수 있습니다.")
+        void canSignupWhenRequestIsValid() {
+            // given
+            String email = "test@example.com";
+            String rawPassword = "password123^^";
+            AdminSignupRequest request = new AdminSignupRequest(email, rawPassword, "홍길동", "01012345678");
 
-        when(adminRepository.findByEmail(Email.from(email)))
-                .thenReturn(Optional.empty());
-        when(passwordHasher.hash(rawPassword))
-                .thenReturn("hashed-password123^^");
-        when(adminRepository.save(any(Admin.class)))
-                .thenAnswer(invocation -> {
-                    Admin admin = invocation.getArgument(0, Admin.class);
-                    setField(admin, "id", 1L);
-                    return admin;
-                });
+            when(adminRepository.findByEmail(Email.from(email)))
+                    .thenReturn(Optional.empty());
+            when(passwordHasher.hash(rawPassword))
+                    .thenReturn("hashed-password123^^");
+            when(adminRepository.save(any(Admin.class)))
+                    .thenAnswer(invocation -> {
+                        Admin admin = invocation.getArgument(0, Admin.class);
+                        setField(admin, "id", 1L);
+                        return admin;
+                    });
 
-        // when
-        AdminSignupResponse response = adminAuthService.signup(request);
+            // when
+            AdminSignupResponse response = adminAuthService.signup(request);
 
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.id()).isEqualTo(1L);
-        assertThat(response.email()).isEqualTo(email);
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.id()).isEqualTo(1L);
+            assertThat(response.email()).isEqualTo(email);
 
-        verify(adminRepository).findByEmail(Email.from(email));
-        verify(passwordHasher).hash(rawPassword);
-        verify(adminRepository).save(any(Admin.class));
+            verify(adminRepository).findByEmail(Email.from(email));
+            verify(passwordHasher).hash(rawPassword);
+            verify(adminRepository).save(any(Admin.class));
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 이메일로 회원가입을 시도하면 DuplicateEmailException이 발생합니다.")
+        void throwDuplicateEmailExceptionWhenEmailAlreadyExists() {
+            // given
+            String email = "exists@example.com";
+            AdminSignupRequest request = new AdminSignupRequest(email, "password123^^", "홍길동", "01012345678");
+
+            when(adminRepository.findByEmail(Email.from(email)))
+                    .thenReturn(Optional.of(mock(Admin.class)));
+
+            // when & then
+            assertThatThrownBy(() -> adminAuthService.signup(request))
+                    .isInstanceOf(DuplicateEmailException.class);
+
+            verify(adminRepository, never()).save(any(Admin.class));
+            verify(passwordHasher, never()).hash(anyString());
+        }
+
+        @Test
+        @DisplayName("비밀번호 규칙을 만족하지 못하면 InvalidPasswordException이 발생합니다.")
+        void throwInvalidPasswordExceptionWhenPasswordIsInvalid() {
+            // given
+            String email = "test2@example.com";
+            String invalidPassword = "short12^^";
+            AdminSignupRequest request = new AdminSignupRequest(email, invalidPassword, "홍길동", "01012345678");
+
+            when(adminRepository.findByEmail(Email.from(email)))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> adminAuthService.signup(request))
+                    .isInstanceOf(InvalidPasswordException.class);
+
+            verify(adminRepository).findByEmail(Email.from(email));
+            verify(passwordHasher, never()).hash(anyString());
+            verify(adminRepository, never()).save(any(Admin.class));
+        }
     }
 
-    @Test
-    @DisplayName("이미 존재하는 이메일로 회원가입을 시도하면 DuplicateEmailException이 발생합니다.")
-    void throwDuplicateEmailExceptionWhenEmailAlreadyExists() {
-        // given
-        String email = "exists@example.com";
-        AdminSignupRequest request = new AdminSignupRequest(email, "password123^^", "홍길동", "01012345678");
+    @Nested
+    @DisplayName("로그인")
+    class Login {
 
-        when(adminRepository.findByEmail(Email.from(email)))
-                .thenReturn(Optional.of(mock(Admin.class)));
+        private static final String EMAIL = "test@example.com";
+        private static final String RAW_PASSWORD = "password123^^";
+        private static final String HASHED_PASSWORD = "hashed-pw";
 
-        // when & then
-        assertThatThrownBy(() -> adminAuthService.signup(request))
-                .isInstanceOf(DuplicateEmailException.class);
+        private final Admin admin = mock(Admin.class);
+        private final AdminLoginRequest request = new AdminLoginRequest(EMAIL, RAW_PASSWORD);
 
-        verify(adminRepository, never()).save(any(Admin.class));
-        verify(passwordHasher, never()).hash(anyString());
-    }
+        @BeforeEach
+        void setUp() {
+            when(admin.getId()).thenReturn(1L);
+            when(admin.getHashedPassword()).thenReturn(HASHED_PASSWORD);
+        }
 
-    @Test
-    @DisplayName("비밀번호 규칙을 만족하지 못하면 InvalidPasswordException이 발생합니다.")
-    void throwInvalidPasswordExceptionWhenPasswordIsInvalid() {
-        // given
-        String email = "test2@example.com";
-        String invalidPassword = "short12^^";
-        AdminSignupRequest request = new AdminSignupRequest(email, invalidPassword, "홍길동", "01012345678");
+        @Test
+        @DisplayName("유효한 이메일과 비밀번호로 로그인하면 access token과 refresh token을 발급받습니다.")
+        void issueTokensWhenLoginIsValid() {
+            // given
+            when(adminRepository.findByEmail(Email.from(EMAIL)))
+                    .thenReturn(Optional.of(admin));
+            when(passwordHasher.matches(RAW_PASSWORD, HASHED_PASSWORD))
+                    .thenReturn(true);
 
-        when(adminRepository.findByEmail(Email.from(email)))
-                .thenReturn(Optional.empty());
+            when(jwtProvider.createAccessToken(eq(1L), eq(Role.ADMIN), any()))
+                    .thenReturn("accessToken");
+            when(jwtProvider.createRefreshToken(eq(1L), eq(Role.ADMIN), any()))
+                    .thenReturn("refreshToken");
 
-        // when & then
-        assertThatThrownBy(() -> adminAuthService.signup(request))
-                .isInstanceOf(InvalidPasswordException.class);
+            // when
+            AdminLoginResponse response = adminAuthService.login(request);
 
-        verify(adminRepository).findByEmail(Email.from(email));
-        verify(passwordHasher, never()).hash(anyString());
-        verify(adminRepository, never()).save(any(Admin.class));
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.accessToken()).isEqualTo("accessToken");
+            assertThat(response.refreshToken()).isEqualTo("refreshToken");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일로 로그인을 시도하면 AdminNotFoundException이 발생합니다.")
+        void loginThrowsAdminNotFoundException() {
+            // given
+            when(adminRepository.findByEmail(Email.from(EMAIL)))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> adminAuthService.login(request))
+                    .isInstanceOf(AdminNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호가 일치하지 않으면 PasswordMismatchException이 발생합니다.")
+        void loginThrowsPasswordMismatchException() {
+            // given
+            when(adminRepository.findByEmail(Email.from(EMAIL)))
+                    .thenReturn(Optional.of(admin));
+            when(passwordHasher.matches(RAW_PASSWORD, HASHED_PASSWORD))
+                    .thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> adminAuthService.login(request))
+                    .isInstanceOf(PasswordMismatchException.class);
+        }
     }
 }

--- a/src/test/java/atwoz/atwoz/admin/application/AdminAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/application/AdminAuthServiceTest.java
@@ -37,7 +37,7 @@ class AdminAuthServiceTest {
 
     @Test
     @DisplayName("중복되지 않은 이메일과 유효한 비밀번호로 회원가입 할 수 있습니다.")
-    void canSignUpWhenRequestIsValid() {
+    void canSignupWhenRequestIsValid() {
         // given
         String email = "test@example.com";
         String rawPassword = "password123^^";
@@ -55,7 +55,7 @@ class AdminAuthServiceTest {
                 });
 
         // when
-        AdminSignupResponse response = adminAuthService.signUp(request);
+        AdminSignupResponse response = adminAuthService.signup(request);
 
         // then
         assertThat(response).isNotNull();
@@ -78,7 +78,7 @@ class AdminAuthServiceTest {
                 .thenReturn(Optional.of(mock(Admin.class)));
 
         // when & then
-        assertThatThrownBy(() -> adminAuthService.signUp(request))
+        assertThatThrownBy(() -> adminAuthService.signup(request))
                 .isInstanceOf(DuplicateEmailException.class);
 
         verify(adminRepository, never()).save(any(Admin.class));
@@ -97,7 +97,7 @@ class AdminAuthServiceTest {
                 .thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> adminAuthService.signUp(request))
+        assertThatThrownBy(() -> adminAuthService.signup(request))
                 .isInstanceOf(InvalidPasswordException.class);
 
         verify(adminRepository).findByEmail(Email.from(email));

--- a/src/test/java/atwoz/atwoz/admin/domain/admin/PasswordTest.java
+++ b/src/test/java/atwoz/atwoz/admin/domain/admin/PasswordTest.java
@@ -86,7 +86,7 @@ class PasswordTest {
 
         // when & then
         assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
-                .isInstanceOf(InvalidPasswordException.class);
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/src/test/java/atwoz/atwoz/common/domain/vo/NameTest.java
+++ b/src/test/java/atwoz/atwoz/common/domain/vo/NameTest.java
@@ -56,7 +56,7 @@ class NameTest {
 
         // when & then
         assertThatThrownBy(() -> Name.from(invalidName))
-                .isInstanceOf(InvalidNameException.class);
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/src/test/java/atwoz/atwoz/common/domain/vo/PhoneNumberTest.java
+++ b/src/test/java/atwoz/atwoz/common/domain/vo/PhoneNumberTest.java
@@ -53,7 +53,7 @@ class PhoneNumberTest {
 
         // when & then
         assertThatThrownBy(() -> PhoneNumber.from(invalidPhoneNumber))
-                .isInstanceOf(InvalidPhoneNumberException.class);
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test


### PR DESCRIPTION
### 관련 이슈
- closes #35 

<br>

### 작업 내용
- 관리자 로그인 구현

<br>

### 노트
- ExceptionHandler에서 @Order를 사용한 이유: 글로벌에서 예외를 `Exception`으로 잡고 있어서 순서를 명시적으로 안정해주면 빈 생성 순서에 따라 글로벌에서 먼저 잡힐 수 있으므로
- 관리자 로그아웃은 redis 도입되면 수정하면서 같이 구현하겠습니다!
