### PR TITLE
주문 애그리거트 정의

### DIFF
--- a/src/main/java/atwoz/atwoz/order/domain/Order.java
+++ b/src/main/java/atwoz/atwoz/order/domain/Order.java
@@ -1,0 +1,101 @@
+package atwoz.atwoz.order.domain;
+
+import atwoz.atwoz.common.domain.BaseEntity;
+import atwoz.atwoz.order.exception.InvalidOrderStatusException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private Long heartPurchaseOptionId;
+
+    @Enumerated
+    @Column(columnDefinition = "varchar(50)")
+    private PaymentMethod paymentMethod;
+
+    @Enumerated
+    @Column(columnDefinition = "varchar(50)")
+    @Getter
+    private OrderStatus status;
+
+    public static Order of(Long memberId, Long heartPurchaseOptionId, PaymentMethod paymentMethod) {
+        return new Order(memberId, heartPurchaseOptionId, paymentMethod);
+    }
+
+    public void pay() {
+        if (!isPayable()) {
+            throw new InvalidOrderStatusException("REQUESTED 상태의 주문만 결제할 수 있습니다. orderStatus=" + status);
+        }
+        setStatus(OrderStatus.PAID);
+    }
+
+    public void complete() {
+        if (!isCompletable()) {
+            throw new InvalidOrderStatusException("PAID 상태의 주문만 완료할 수 있습니다. orderStatus=" + status);
+        }
+        setStatus(OrderStatus.COMPLETED);
+    }
+
+    public void refund() {
+        if (!isRefundable()) {
+            throw new InvalidOrderStatusException("PAID, COMPLETED 상태의 주문만 환불할 수 있습니다. orderStatus=" + status);
+        }
+        setStatus(OrderStatus.REFUNDED);
+    }
+
+    public void cancel() {
+        if (!isCancelable()) {
+            throw new InvalidOrderStatusException("REQUESTED 상태의 주문만 취소할 수 있습니다. orderStatus=" + status);
+        }
+        setStatus(OrderStatus.CANCELED);
+    }
+
+    private Order(Long memberId, Long heartPurchaseOptionId, PaymentMethod paymentMethod) {
+        setMemberId(memberId);
+        setHeartPurchaseOptionId(heartPurchaseOptionId);
+        setPaymentMethod(paymentMethod);
+        setStatus(OrderStatus.REQUESTED);
+    }
+
+    private void setMemberId(@NonNull Long memberId) {
+        this.memberId = memberId;
+    }
+
+    private void setHeartPurchaseOptionId(@NonNull Long heartPurchaseOptionId) {
+        this.heartPurchaseOptionId = heartPurchaseOptionId;
+    }
+
+    private void setPaymentMethod(@NonNull PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    private void setStatus(@NonNull OrderStatus status) {
+        this.status = status;
+    }
+
+    private boolean isPayable() {
+        return status == OrderStatus.REQUESTED;
+    }
+
+    private boolean isCompletable() {
+        return status == OrderStatus.PAID;
+    }
+
+    private boolean isRefundable() {
+        return status == OrderStatus.COMPLETED || status == OrderStatus.PAID;
+    }
+
+    private boolean isCancelable() {
+        return status == OrderStatus.REQUESTED;
+    }
+}

--- a/src/main/java/atwoz/atwoz/order/domain/OrderStatus.java
+++ b/src/main/java/atwoz/atwoz/order/domain/OrderStatus.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.order.domain;
+
+public enum OrderStatus {
+    REQUESTED,
+    PAID,
+    COMPLETED,
+    REFUNDED,
+    CANCELED
+}

--- a/src/main/java/atwoz/atwoz/order/domain/PaymentMethod.java
+++ b/src/main/java/atwoz/atwoz/order/domain/PaymentMethod.java
@@ -1,0 +1,6 @@
+package atwoz.atwoz.order.domain;
+
+public enum PaymentMethod {
+    GOOGLE_PLAY,
+    APP_STORE
+}

--- a/src/main/java/atwoz/atwoz/order/exception/InvalidOrderStatusException.java
+++ b/src/main/java/atwoz/atwoz/order/exception/InvalidOrderStatusException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.order.exception;
+
+public class InvalidOrderStatusException extends RuntimeException {
+    public InvalidOrderStatusException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/atwoz/atwoz/order/domain/OrderTest.java
+++ b/src/test/java/atwoz/atwoz/order/domain/OrderTest.java
@@ -1,0 +1,277 @@
+package atwoz.atwoz.order.domain;
+
+import atwoz.atwoz.order.exception.InvalidOrderStatusException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrderTest {
+    @Nested
+    @DisplayName("Order 객체 생성 테스트")
+    class CreateOrderTest {
+        @ParameterizedTest
+        @ValueSource(strings = {"memberId is null", "heartPurchaseOptionId is null", "paymentMethod is null"})
+        @DisplayName("Order의 파라미터가 Null이면 NullPointerException 발생")
+        void throwsNullPointerExceptionWhenParameterIsNull(String condition) {
+            // given
+            Long memberId = condition.equals("memberId is null") ? null : 1L;
+            Long heartPurchaseOptionId = condition.equals("heartPurchaseOptionId is null") ? null : 1L;
+            PaymentMethod paymentMethod = condition.equals("paymentMethod is null") ? null : PaymentMethod.GOOGLE_PLAY;
+            // when & then
+            assertThatThrownBy(() -> Order.of(memberId, heartPurchaseOptionId, paymentMethod))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Order의 파라미터가 Null이 아니면 Order 객체 REQUESTED 상태로 생성")
+        void createOrderSuccessWhenParameterIsNotNull() {
+            // given
+            Long memberId = 1L;
+            Long heartPurchaseOptionId = 1L;
+            PaymentMethod paymentMethod = PaymentMethod.GOOGLE_PLAY;
+            // when
+            Order order = Order.of(memberId, heartPurchaseOptionId, paymentMethod);
+            // then
+            assertThat(order).isNotNull();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.REQUESTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("Order 객체의 상태가 REQUESTED일 때")
+    class OrderStatusRequested {
+        Order order;
+
+        @BeforeEach
+        void setUp() {
+            // given
+            order = Order.of(1L, 1L, PaymentMethod.GOOGLE_PLAY);
+        }
+
+        @Test
+        @DisplayName("pay() 메서드 호출 시 PAID 상태로 변경")
+        void changeStatusToPaidWhenPayMethodIsCalled() {
+            // when
+            order.pay();
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+        }
+
+        @Test
+        @DisplayName("complete() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenCompleteMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::complete)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("refund() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenRefundMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::refund)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("cancel() 메서드 호출 시 CANCELED 상태로 변경")
+        void changeStatusToCanceledWhenCancelMethodIsCalled() {
+            // when
+            order.cancel();
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+        }
+    }
+
+    @Nested
+    @DisplayName("Order 객체의 상태가 PAID일 때")
+    class OrderStatusPaid {
+        Order order;
+
+        @BeforeEach
+        void setUp() {
+            // given
+            order = Order.of(1L, 1L, PaymentMethod.GOOGLE_PLAY);
+            order.pay();
+        }
+
+        @Test
+        @DisplayName("complete() 메서드 호출 시 COMPLETED 상태로 변경")
+        void changeStatusToCompletedWhenCompleteMethodIsCalled() {
+            // when
+            order.complete();
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("pay() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenPayMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::pay)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("refund() 메서드 호출 시 REFUNDED 상태로 변경")
+        void changeStatusToRefundedWhenRefundMethodIsCalled() {
+            // when
+            order.refund();
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUNDED);
+        }
+
+        @Test
+        @DisplayName("cancel() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenCancelMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::cancel)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Order 객체의 상태가 COMPLETED일 때")
+    class OrderStatusCompleted {
+        Order order;
+
+        @BeforeEach
+        void setUp() {
+            // given
+            order = Order.of(1L, 1L, PaymentMethod.GOOGLE_PLAY);
+            order.pay();
+            order.complete();
+        }
+
+        @Test
+        @DisplayName("refund() 메서드 호출 시 REFUNDED 상태로 변경")
+        void changeStatusToRefundedWhenRefundMethodIsCalled() {
+            // when
+            order.refund();
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUNDED);
+        }
+
+        @Test
+        @DisplayName("pay() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenPayMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::pay)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("complete() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenCompleteMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::complete)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("cancel() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenCancelMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::cancel)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Order 객체의 상태가 REFUNDED일 때")
+    class OrderStatusRefunded {
+        Order order;
+
+        @BeforeEach
+        void setUp() {
+            // given
+            order = Order.of(1L, 1L, PaymentMethod.GOOGLE_PLAY);
+            order.pay();
+            order.complete();
+            order.refund();
+        }
+
+        @Test
+        @DisplayName("pay() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenPayMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::pay)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("complete() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenCompleteMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::complete)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("refund() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenRefundMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::refund)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("cancel() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenCancelMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::cancel)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Order 객체의 상태가 CANCELED일 때")
+    class OrderStatusCanceled {
+        Order order;
+
+        @BeforeEach
+        void setUp() {
+            // given
+            order = Order.of(1L, 1L, PaymentMethod.GOOGLE_PLAY);
+            order.cancel();
+        }
+
+        @Test
+        @DisplayName("pay() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenPayMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::pay)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("complete() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenCompleteMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::complete)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("refund() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenRefundMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::refund)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+
+        @Test
+        @DisplayName("cancel() 메서드 호출 시 InvalidOrderStatusException 발생")
+        void throwsInvalidOrderStatusExceptionWhenCancelMethodIsCalled() {
+            // when & then
+            assertThatThrownBy(order::cancel)
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+    }
+}


### PR DESCRIPTION
### 관련 이슈
- closes #38 

<br>

### 작업 내용
- Order 애그리거트 정의
- 테스트 코드 작성

<br>

### 참고 자료
-

<br>

### 노트
- Order의 ERD 에서 Type 과 PaymentMethod 가 분리되어 있는데 이를 PaymentMethod로 합쳤습니다.
- 저희가 지원하는 google play, app store 결제는 그 자체가 결제 수단이고 그 뒤에서 카드로 결제하든 뭐든 저희는 동일하게 google play, app store 를 통해서 처리해야하기 때문에 PaymentMethod 로 합쳤어요
- 그리고 order 진행 상황을 저장하기 위한 OrderStatus를 추가했습니다.
