### PR TITLE
관리자 로그아웃 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/application/AdminAuthService.java
+++ b/src/main/java/atwoz/atwoz/admin/application/AdminAuthService.java
@@ -6,7 +6,6 @@ import atwoz.atwoz.admin.application.dto.AdminSignupRequest;
 import atwoz.atwoz.admin.application.dto.AdminSignupResponse;
 import atwoz.atwoz.admin.application.exception.AdminNotFoundException;
 import atwoz.atwoz.admin.application.exception.DuplicateEmailException;
-import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
 import atwoz.atwoz.admin.domain.*;
 import atwoz.atwoz.auth.domain.TokenProvider;
 import atwoz.atwoz.auth.domain.TokenRepository;
@@ -36,7 +35,7 @@ public class AdminAuthService {
     @Transactional
     public AdminLoginResponse login(AdminLoginRequest request) {
         Admin admin = findAdminByEmail(request.email());
-        matchPassword(request.password(), admin.getPassword());
+        admin.matchPassword(request.password(), passwordHasher);
 
         Instant issuedAt = Instant.now();
         String accessToken = createAccessToken(admin.getId(), issuedAt);
@@ -64,12 +63,6 @@ public class AdminAuthService {
     private Admin findAdminByEmail(String email) {
         return adminRepository.findByEmail(Email.from(email))
                 .orElseThrow(AdminNotFoundException::new);
-    }
-
-    private void matchPassword(String requestPassword, Password password) {
-        if (!password.matches(requestPassword, passwordHasher)) {
-            throw new PasswordMismatchException();
-        }
     }
 
     private String createAccessToken(Long id, Instant issuedAt) {

--- a/src/main/java/atwoz/atwoz/admin/application/AdminAuthService.java
+++ b/src/main/java/atwoz/atwoz/admin/application/AdminAuthService.java
@@ -33,10 +33,10 @@ public class AdminAuthService {
         return AdminAuthMapper.toSignupResponse(newAdmin);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public AdminLoginResponse login(AdminLoginRequest request) {
-        Admin admin = findAdminBy(request.email());
-        validatePassword(request.password(), admin.getHashedPassword());
+        Admin admin = findAdminByEmail(request.email());
+        matchPassword(request.password(), admin.getPassword());
 
         Instant issuedAt = Instant.now();
         String accessToken = createAccessToken(admin.getId(), issuedAt);
@@ -61,13 +61,13 @@ public class AdminAuthService {
         return adminRepository.save(newAdmin);
     }
 
-    private Admin findAdminBy(String email) {
+    private Admin findAdminByEmail(String email) {
         return adminRepository.findByEmail(Email.from(email))
                 .orElseThrow(AdminNotFoundException::new);
     }
 
-    private void validatePassword(String requestPassword, String hashedPassword) {
-        if (!passwordHasher.matches(requestPassword, hashedPassword)) {
+    private void matchPassword(String requestPassword, Password password) {
+        if (!password.matches(requestPassword, passwordHasher)) {
             throw new PasswordMismatchException();
         }
     }

--- a/src/main/java/atwoz/atwoz/admin/application/exception/PasswordMismatchException.java
+++ b/src/main/java/atwoz/atwoz/admin/application/exception/PasswordMismatchException.java
@@ -1,7 +1,0 @@
-package atwoz.atwoz.admin.application.exception;
-
-public class PasswordMismatchException extends RuntimeException {
-    public PasswordMismatchException() {
-        super("비밀번호가 일치하지 않습니다.");
-    }
-}

--- a/src/main/java/atwoz/atwoz/admin/domain/Admin.java
+++ b/src/main/java/atwoz/atwoz/admin/domain/Admin.java
@@ -1,6 +1,6 @@
 package atwoz.atwoz.admin.domain;
 
-import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
+import atwoz.atwoz.admin.domain.exception.IncorrectPasswordException;
 import atwoz.atwoz.common.entity.SoftDeleteBaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -70,7 +70,7 @@ public class Admin extends SoftDeleteBaseEntity {
 
     public void matchPassword(String rawPassword, PasswordHasher passwordHasher) {
         if (!password.matches(rawPassword, passwordHasher)) {
-            throw new PasswordMismatchException();
+            throw new IncorrectPasswordException();
         }
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/domain/Admin.java
+++ b/src/main/java/atwoz/atwoz/admin/domain/Admin.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.admin.domain;
 
+import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
 import atwoz.atwoz.common.entity.SoftDeleteBaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -65,5 +66,11 @@ public class Admin extends SoftDeleteBaseEntity {
 
     private void setPhoneNumber(@NonNull PhoneNumber phoneNumber) {
         this.phoneNumber = phoneNumber;
+    }
+
+    public void matchPassword(String rawPassword, PasswordHasher passwordHasher) {
+        if (!password.matches(rawPassword, passwordHasher)) {
+            throw new PasswordMismatchException();
+        }
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/domain/Admin.java
+++ b/src/main/java/atwoz/atwoz/admin/domain/Admin.java
@@ -19,6 +19,7 @@ public class Admin extends SoftDeleteBaseEntity {
     private Email email;
 
     @Embedded
+    @Getter
     private Password password;
 
     @Embedded
@@ -64,9 +65,5 @@ public class Admin extends SoftDeleteBaseEntity {
 
     private void setPhoneNumber(@NonNull PhoneNumber phoneNumber) {
         this.phoneNumber = phoneNumber;
-    }
-
-    public String getHashedPassword() {
-        return password.getHashedValue();
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/domain/Password.java
+++ b/src/main/java/atwoz/atwoz/admin/domain/Password.java
@@ -42,4 +42,8 @@ public class Password {
         }
         this.hashedValue = hashedValue;
     }
+
+    public boolean matches(String rawValue, PasswordHasher hasher) {
+        return hasher.matches(rawValue, hashedValue);
+    }
 }

--- a/src/main/java/atwoz/atwoz/admin/domain/exception/IncorrectPasswordException.java
+++ b/src/main/java/atwoz/atwoz/admin/domain/exception/IncorrectPasswordException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.admin.domain.exception;
+
+public class IncorrectPasswordException extends RuntimeException {
+    public IncorrectPasswordException() {
+        super("비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/admin/presentation/AdminAuthController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/AdminAuthController.java
@@ -13,15 +13,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/admin")
 @RequiredArgsConstructor
 public class AdminAuthController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
 
     private final RefreshTokenCookieProperties refreshTokenCookieProperties;
     private final AdminAuthService adminAuthService;
@@ -37,7 +36,7 @@ public class AdminAuthController {
         AdminLoginResponse response = adminAuthService.login(request);
 
         HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + response.accessToken());
+        headers.set(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + response.accessToken());
         ResponseCookie refreshTokenCookie = ResponseCookie.from(refreshTokenCookieProperties.name(), response.refreshToken())
                 .httpOnly(refreshTokenCookieProperties.httpOnly())
                 .secure(refreshTokenCookieProperties.secure())
@@ -49,6 +48,25 @@ public class AdminAuthController {
 
         return ResponseEntity.ok()
                 .headers(headers)
+                .body(BaseResponse.from(StatusType.OK));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logout(
+            @CookieValue(value = "refresh_token", required = false) String refreshToken
+    ) {
+        adminAuthService.logout(refreshToken);
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from(refreshTokenCookieProperties.name(), "")
+                .httpOnly(refreshTokenCookieProperties.httpOnly())
+                .secure(refreshTokenCookieProperties.secure())
+                .sameSite(refreshTokenCookieProperties.sameSite())
+                .path(refreshTokenCookieProperties.path())
+                .maxAge(0)
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
                 .body(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/presentation/AdminExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/AdminExceptionHandler.java
@@ -2,7 +2,7 @@ package atwoz.atwoz.admin.presentation;
 
 import atwoz.atwoz.admin.application.exception.AdminNotFoundException;
 import atwoz.atwoz.admin.application.exception.DuplicateEmailException;
-import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
+import atwoz.atwoz.admin.domain.exception.IncorrectPasswordException;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -33,8 +33,8 @@ public class AdminExceptionHandler {
                 .body(BaseResponse.from(StatusType.UNAUTHORIZED));
     }
 
-    @ExceptionHandler(PasswordMismatchException.class)
-    public ResponseEntity<BaseResponse<Void>> handlePasswordMismatchException(PasswordMismatchException e) {
+    @ExceptionHandler(IncorrectPasswordException.class)
+    public ResponseEntity<BaseResponse<Void>> handlePasswordMismatchException(IncorrectPasswordException e) {
         log.warn("관리자 로그인에 실패했습니다. {}", e.getMessage());
 
         return ResponseEntity.status(401)

--- a/src/main/java/atwoz/atwoz/auth/presentation/filter/PathMatcherConfig.java
+++ b/src/main/java/atwoz/atwoz/auth/presentation/filter/PathMatcherConfig.java
@@ -11,7 +11,8 @@ public class PathMatcherConfig {
     private static final List<String> EXCLUDED_URIS = List.of(
             "/member/auth/login", "/member/auth/logout",
             "/admin/login", "/admin/signup",
-            "/v3/api-docs/**", "/config-ui.html", "/config-ui/**", "/config-resources/**", "/webjars/**"
+            "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**",
+            "/webjars/**"
     );
 
     @Bean

--- a/src/test/java/atwoz/atwoz/admin/application/AdminAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/application/AdminAuthServiceTest.java
@@ -61,10 +61,8 @@ class AdminAuthServiceTest {
             String rawPassword = "password123^^";
             AdminSignupRequest request = new AdminSignupRequest(email, rawPassword, "홍길동", "01012345678");
 
-            when(adminRepository.findByEmail(Email.from(email)))
-                    .thenReturn(Optional.empty());
-            when(passwordHasher.hash(rawPassword))
-                    .thenReturn("hashed-password123^^");
+            when(adminRepository.findByEmail(Email.from(email))).thenReturn(Optional.empty());
+            when(passwordHasher.hash(rawPassword)).thenReturn("hashed-password123^^");
             when(adminRepository.save(any(Admin.class)))
                     .thenAnswer(invocation -> {
                         Admin admin = invocation.getArgument(0, Admin.class);
@@ -92,12 +90,10 @@ class AdminAuthServiceTest {
             String email = "exists@example.com";
             AdminSignupRequest request = new AdminSignupRequest(email, "password123^^", "홍길동", "01012345678");
 
-            when(adminRepository.findByEmail(Email.from(email)))
-                    .thenReturn(Optional.of(mock(Admin.class)));
+            when(adminRepository.findByEmail(Email.from(email))).thenReturn(Optional.of(mock(Admin.class)));
 
             // when & then
-            assertThatThrownBy(() -> adminAuthService.signup(request))
-                    .isInstanceOf(DuplicateEmailException.class);
+            assertThatThrownBy(() -> adminAuthService.signup(request)).isInstanceOf(DuplicateEmailException.class);
 
             verify(adminRepository, never()).save(any(Admin.class));
             verify(passwordHasher, never()).hash(anyString());
@@ -111,12 +107,10 @@ class AdminAuthServiceTest {
             String invalidPassword = "short12^^";
             AdminSignupRequest request = new AdminSignupRequest(email, invalidPassword, "홍길동", "01012345678");
 
-            when(adminRepository.findByEmail(Email.from(email)))
-                    .thenReturn(Optional.empty());
+            when(adminRepository.findByEmail(Email.from(email))).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> adminAuthService.signup(request))
-                    .isInstanceOf(InvalidPasswordException.class);
+            assertThatThrownBy(() -> adminAuthService.signup(request)).isInstanceOf(InvalidPasswordException.class);
 
             verify(adminRepository).findByEmail(Email.from(email));
             verify(passwordHasher, never()).hash(anyString());
@@ -170,8 +164,7 @@ class AdminAuthServiceTest {
             when(adminRepository.findByEmail(Email.from(email))).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> adminAuthService.login(request))
-                    .isInstanceOf(AdminNotFoundException.class);
+            assertThatThrownBy(() -> adminAuthService.login(request)).isInstanceOf(AdminNotFoundException.class);
         }
     }
 }

--- a/src/test/java/atwoz/atwoz/admin/application/AdminAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/application/AdminAuthServiceTest.java
@@ -142,21 +142,21 @@ class AdminAuthServiceTest {
             when(admin.getId()).thenReturn(1L);
             when(adminRepository.findByEmail(Email.from(email))).thenReturn(Optional.of(admin));
 
-            String reissuedAccessToken = "accessToken";
-            String reissuedRefreshToken = "refreshToken";
+            String newAccessToken = "accessToken";
+            String newRefreshToken = "refreshToken";
             when(tokenProvider.createAccessToken(eq(1L), eq(Role.ADMIN), any(Instant.class)))
-                    .thenReturn(reissuedAccessToken);
+                    .thenReturn(newAccessToken);
             when(tokenProvider.createRefreshToken(eq(1L), eq(Role.ADMIN), any(Instant.class)))
-                    .thenReturn(reissuedRefreshToken);
+                    .thenReturn(newRefreshToken);
 
             // when
             AdminLoginResponse response = adminAuthService.login(request);
 
             // then
-            verify(tokenRepository).save(reissuedRefreshToken);
+            verify(tokenRepository).save(newRefreshToken);
             assertThat(response).isNotNull();
-            assertThat(response.accessToken()).isEqualTo(reissuedAccessToken);
-            assertThat(response.refreshToken()).isEqualTo(reissuedRefreshToken);
+            assertThat(response.accessToken()).isEqualTo(newAccessToken);
+            assertThat(response.refreshToken()).isEqualTo(newRefreshToken);
         }
 
         @Test

--- a/src/test/java/atwoz/atwoz/admin/domain/AdminTest.java
+++ b/src/test/java/atwoz/atwoz/admin/domain/AdminTest.java
@@ -9,33 +9,26 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AdminTest {
 
-    private final Email email = Email.from("example@me.com");
-    private final Password password = Password.fromHashed("hashed-password");
-    private final Name name = Name.from("홍길동");
-    private final PhoneNumber phoneNumber = PhoneNumber.from("01012345678");
-
     @Mock
     private PasswordHasher passwordHasher;
 
-    @Test
-    @DisplayName("유효한 값 타입들로 Admin을 생성합니다.")
-    void createAdminWithValidValueTypes() {
-        Admin admin = createAdmin();
-
-        assertThat(admin).isNotNull();
-    }
-
     @ParameterizedTest
     @ValueSource(strings = {"email", "password", "name", "phoneNumber"})
-    @DisplayName("Admin의 값 타입이 null이면 예외를 던집니다.")
+    @DisplayName("Admin의 값 타입이 null이면 NullPointerException이 발생합니다.")
     void createAdminWithNullValueTypeThrowsException(String fieldName) {
+        // given
+        Email email = Email.from("example@me.com");
+        Password password = Password.fromHashed("hashed-password");
+        Name name = Name.from("홍길동");
+        PhoneNumber phoneNumber = PhoneNumber.from("01012345678");
+
+        // when & then
         assertThatThrownBy(() ->
                 Admin.builder()
                         .email(fieldName.equals("email") ? null : email)
@@ -47,25 +40,22 @@ class AdminTest {
     }
 
     @Test
-    @DisplayName("비밀번호가 일치하지 않으면 PasswordMismatchException을 던집니다.")
+    @DisplayName("비밀번호가 일치하지 않으면 PasswordMismatchException이 발생합니다.")
     void throwsPasswordMismatchExceptionWhenPasswordMismatch() {
         // given
-        Admin admin = createAdmin();
-        String rawPassword = "raw-password";
+        Admin admin = Admin.builder()
+                .email(Email.from("example@me.com"))
+                .password(Password.fromHashed("hashed-password"))
+                .name(Name.from("홍길동"))
+                .phoneNumber(PhoneNumber.from("01012345678"))
+                .build();
 
-        when(passwordHasher.matches(rawPassword, password.getHashedValue())).thenReturn(false);
+        String rawPassword = "raw-password";
+        String hashedPassword = "hashed-password";
+        when(passwordHasher.matches(rawPassword, hashedPassword)).thenReturn(false);
 
         // when & then
         assertThatThrownBy(() -> admin.matchPassword(rawPassword, passwordHasher))
                 .isInstanceOf(IncorrectPasswordException.class);
-    }
-
-    private Admin createAdmin() {
-        return Admin.builder()
-                .email(email)
-                .password(password)
-                .name(name)
-                .phoneNumber(phoneNumber)
-                .build();
     }
 }

--- a/src/test/java/atwoz/atwoz/admin/domain/AdminTest.java
+++ b/src/test/java/atwoz/atwoz/admin/domain/AdminTest.java
@@ -1,6 +1,6 @@
 package atwoz.atwoz.admin.domain;
 
-import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
+import atwoz.atwoz.admin.domain.exception.IncorrectPasswordException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,7 +57,7 @@ class AdminTest {
 
         // when & then
         assertThatThrownBy(() -> admin.matchPassword(rawPassword, passwordHasher))
-                .isInstanceOf(PasswordMismatchException.class);
+                .isInstanceOf(IncorrectPasswordException.class);
     }
 
     private Admin createAdmin() {

--- a/src/test/java/atwoz/atwoz/admin/domain/AdminTest.java
+++ b/src/test/java/atwoz/atwoz/admin/domain/AdminTest.java
@@ -1,29 +1,33 @@
 package atwoz.atwoz.admin.domain;
 
+import atwoz.atwoz.admin.application.exception.PasswordMismatchException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class AdminTest {
 
-    private static final Email EMAIL = Email.from("example@me.com");
-    private static final Password PASSWORD = Password.fromHashed("hashed-password");
-    private static final Name NAME = Name.from("홍길동");
-    private static final PhoneNumber PHONE_NUMBER = PhoneNumber.from("01012345678");
+    private final Email email = Email.from("example@me.com");
+    private final Password password = Password.fromHashed("hashed-password");
+    private final Name name = Name.from("홍길동");
+    private final PhoneNumber phoneNumber = PhoneNumber.from("01012345678");
+
+    @Mock
+    private PasswordHasher passwordHasher;
 
     @Test
     @DisplayName("유효한 값 타입들로 Admin을 생성합니다.")
     void createAdminWithValidValueTypes() {
-        Admin admin = Admin.builder()
-                .email(EMAIL)
-                .password(PASSWORD)
-                .name(NAME)
-                .phoneNumber(PHONE_NUMBER)
-                .build();
+        Admin admin = createAdmin();
 
         assertThat(admin).isNotNull();
     }
@@ -34,11 +38,34 @@ class AdminTest {
     void createAdminWithNullValueTypeThrowsException(String fieldName) {
         assertThatThrownBy(() ->
                 Admin.builder()
-                        .email(fieldName.equals("email") ? null : EMAIL)
-                        .password(fieldName.equals("password") ? null : PASSWORD)
-                        .name(fieldName.equals("name") ? null : NAME)
-                        .phoneNumber(fieldName.equals("phoneNumber") ? null : PHONE_NUMBER)
+                        .email(fieldName.equals("email") ? null : email)
+                        .password(fieldName.equals("password") ? null : password)
+                        .name(fieldName.equals("name") ? null : name)
+                        .phoneNumber(fieldName.equals("phoneNumber") ? null : phoneNumber)
                         .build())
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 PasswordMismatchException을 던집니다.")
+    void throwsPasswordMismatchExceptionWhenPasswordMismatch() {
+        // given
+        Admin admin = createAdmin();
+        String rawPassword = "raw-password";
+
+        when(passwordHasher.matches(rawPassword, password.getHashedValue())).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> admin.matchPassword(rawPassword, passwordHasher))
+                .isInstanceOf(PasswordMismatchException.class);
+    }
+
+    private Admin createAdmin() {
+        return Admin.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .build();
     }
 }

--- a/src/test/java/atwoz/atwoz/admin/domain/EmailTest.java
+++ b/src/test/java/atwoz/atwoz/admin/domain/EmailTest.java
@@ -2,19 +2,18 @@ package atwoz.atwoz.admin.domain;
 
 import atwoz.atwoz.admin.domain.exception.InvalidEmailException;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class EmailTest {
 
-    @Test
-    @DisplayName("이메일 주소가 형식에 맞는 경우 유효합니다.")
-    void isValidWhenFormatIsValid() {
-        // given
-        String validEmail = "example@me.com";
-
+    @ParameterizedTest
+    @ValueSource(strings = {"example@me.com", "user.name@domain.co", "abc.def@ghi.jkl"})
+    @DisplayName("유효한 이메일 주소로 Email을 생성할 수 있습니다.")
+    void canCreateEmailWhenFormatIsValid(String validEmail) {
         // when
         Email email = Email.from(validEmail);
 
@@ -23,56 +22,10 @@ class EmailTest {
         assertThat(email.getAddress()).isEqualTo(validEmail);
     }
 
-    @Test
-    @DisplayName("이메일 주소에 로컬이 없는 경우 유효하지 않습니다.")
-    void isInValidWhenLocalPartIsAbsent() {
-        // given
-        String invalidEmail = "@me.com";
-
-        // when & then
-        assertThatThrownBy(() -> Email.from(invalidEmail))
-                .isInstanceOf(InvalidEmailException.class);
-    }
-
-    @Test
-    @DisplayName("이메일 주소에 @가 없는 경우 유효하지 않습니다.")
-    void isInValidWhenAtIsAbsent() {
-        // given
-        String invalidEmail = "exampleme.com";
-
-        // when & then
-        assertThatThrownBy(() -> Email.from(invalidEmail))
-                .isInstanceOf(InvalidEmailException.class);
-    }
-
-    @Test
-    @DisplayName("이메일 주소에 도메인이 없는 경우 유효하지 않습니다.")
-    void isInValidWhenDomainIsAbsent() {
-        // given
-        String invalidEmail = "example@";
-
-        // when & then
-        assertThatThrownBy(() -> Email.from(invalidEmail))
-                .isInstanceOf(InvalidEmailException.class);
-    }
-
-    @Test
-    @DisplayName("이메일 주소의 도메인이 유효하지 않은 경우 유효하지 않습니다.")
-    void isInValidWhenDomainIsInvalid() {
-        // given
-        String invalidEmail = "example@me";
-
-        // when & then
-        assertThatThrownBy(() -> Email.from(invalidEmail))
-                .isInstanceOf(InvalidEmailException.class);
-    }
-
-    @Test
-    @DisplayName("이메일 주소에 허용되지 않은 문자가 포함된 경우 유효하지 않습니다.")
-    void isInValidWhenEmailContainsForbiddenCharacters() {
-        // given
-        String invalidEmail = "홍길동@me.com";
-
+    @ParameterizedTest
+    @ValueSource(strings = {"@me.com", "example.com", "example@", "example@me", "홍길동@me.com"})
+    @DisplayName("잘못된 형식의 이메일 주소는 InvalidEmailException이 발생합니다.")
+    void throwsExceptionWhenFormatIsInvalid(String invalidEmail) {
         // when & then
         assertThatThrownBy(() -> Email.from(invalidEmail))
                 .isInstanceOf(InvalidEmailException.class);

--- a/src/test/java/atwoz/atwoz/admin/domain/NameTest.java
+++ b/src/test/java/atwoz/atwoz/admin/domain/NameTest.java
@@ -2,19 +2,18 @@ package atwoz.atwoz.admin.domain;
 
 import atwoz.atwoz.admin.domain.exception.InvalidNameException;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NameTest {
 
-    @Test
-    @DisplayName("이름이 한 글자이고 문자(한글, 영어)나 숫자인 경우 유효합니다.")
-    void isValidWhenNameIsOneCharacterOrNumber() {
-        // given
-        String validName = "김";
-
+    @ParameterizedTest
+    @ValueSource(strings = {"홍길동", "John", "김", "1234567890"})
+    @DisplayName("10자 이하의 문자나 숫자로 Name을 생성할 수 있습니다.")
+    void canCreateNameWhenFormatIsValid(String validName) {
         // when
         Name name = Name.from(validName);
 
@@ -23,70 +22,10 @@ class NameTest {
         assertThat(name.getValue()).isEqualTo(validName);
     }
 
-    @Test
-    @DisplayName("이름이 열 글자이고 문자(한글, 영어)나 숫자인 경우 유효합니다.")
-    void isValidWhenNameIsTenCharacterOrNumber() {
-        // given
-        String validName = "1234567890";
-
-        // when
-        Name name = Name.from(validName);
-
-        // then
-        assertThat(name).isNotNull();
-        assertThat(name.getValue()).isEqualTo(validName);
-    }
-
-    @Test
-    @DisplayName("이름이 공백인 경우 유효하지 않습니다.")
-    void isInValidWhenNameIsEmpty() {
-        // given
-        String invalidName = "";
-
-        // when & then
-        assertThatThrownBy(() -> Name.from(invalidName))
-                .isInstanceOf(InvalidNameException.class);
-    }
-
-    @Test
-    @DisplayName("이름이 null인 경우 유효하지 않습니다.")
-    void isInValidWhenNameIsNull() {
-        // given
-        String invalidName = null;
-
-        // when & then
-        assertThatThrownBy(() -> Name.from(invalidName))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("이름이 열 글자를 초과하는 경우 유효하지 않습니다.")
-    void isInValidWhenNameIsGreaterThanTenCharacters() {
-        // given
-        String invalidName = "12345678910";
-
-        // when & then
-        assertThatThrownBy(() -> Name.from(invalidName))
-                .isInstanceOf(InvalidNameException.class);
-    }
-
-    @Test
-    @DisplayName("이름에 허용되지 않는 문자가 포함된 경우 유효하지 않습니다.")
-    void isInValidWhenNameContainsInvalidCharacters() {
-        // given
-        String invalidName = "홍길동123^^";
-
-        // when & then
-        assertThatThrownBy(() -> Name.from(invalidName))
-                .isInstanceOf(InvalidNameException.class);
-    }
-
-    @Test
-    @DisplayName("이름에 공백이 포함된 경우 유효하지 않습니다.")
-    void isInvalidWhenNameContainsWhitespace() {
-        // given
-        String invalidName = "John Doe";
-
+    @ParameterizedTest
+    @ValueSource(strings = {"", "12345678910", "홍길동123^^", "John Doe"})
+    @DisplayName("잘못된 형식의 이름은 InvalidNameException이 발생합니다.")
+    void throwInvalidNameExceptionWhenFormatIsInvalid(String invalidName) {
         // when & then
         assertThatThrownBy(() -> Name.from(invalidName))
                 .isInstanceOf(InvalidNameException.class);

--- a/src/test/java/atwoz/atwoz/admin/domain/PasswordTest.java
+++ b/src/test/java/atwoz/atwoz/admin/domain/PasswordTest.java
@@ -2,6 +2,7 @@ package atwoz.atwoz.admin.domain;
 
 import atwoz.atwoz.admin.domain.exception.InvalidPasswordException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -18,118 +19,159 @@ class PasswordTest {
     @Mock
     private PasswordHasher passwordHasher;
 
-    @Test
-    @DisplayName("비밀번호가 10자이고, 문자, 숫자, 특수문자를 포함한 경우 유효합니다.")
-    void isValidWhenPasswordHasTenCharactersIncludingLettersNumbersAndSpecialCharacters() {
-        // given
-        String validPassword = "pw345678^^";
-        when(passwordHasher.hash(anyString()))
-                .thenAnswer(invocation -> {
-                    String raw = invocation.getArgument(0, String.class);
-                    return "hashed" + raw;
-                });
+    @Nested
+    @DisplayName("비밀번호 유효성 검증")
+    class PasswordValidation {
 
-        // when
-        Password password = Password.fromRaw(validPassword, passwordHasher);
+        @Test
+        @DisplayName("비밀번호가 10자이고, 문자, 숫자, 특수문자를 포함한 경우 유효합니다.")
+        void isValidWhenPasswordHasTenCharactersIncludingLettersNumbersAndSpecialCharacters() {
+            // given
+            String validPassword = "pw345678^^";
+            when(passwordHasher.hash(anyString()))
+                    .thenAnswer(invocation -> {
+                        String raw = invocation.getArgument(0, String.class);
+                        return "hashed" + raw;
+                    });
 
-        // then
-        assertThat(password).isNotNull();
-        assertThat(password.getHashedValue()).isEqualTo("hashed" + validPassword);
+            // when
+            Password password = Password.fromRaw(validPassword, passwordHasher);
+
+            // then
+            assertThat(password).isNotNull();
+            assertThat(password.getHashedValue()).isEqualTo("hashed" + validPassword);
+        }
+
+        @Test
+        @DisplayName("비밀번호가 20자이고, 문자, 숫자, 특수문자를 포함한 경우 유효합니다.")
+        void isValidWhenPasswordHasTwentyCharactersIncludingLettersNumbersAndSpecialCharacters() {
+            // given
+            String validPassword = "password9012345678^^";
+            when(passwordHasher.hash(anyString()))
+                    .thenAnswer(invocation -> {
+                        String raw = invocation.getArgument(0, String.class);
+                        return "hashed" + raw;
+                    });
+
+            // when
+            Password password = Password.fromRaw(validPassword, passwordHasher);
+
+            // then
+            assertThat(password).isNotNull();
+            assertThat(password.getHashedValue()).isEqualTo("hashed" + validPassword);
+        }
+
+        @Test
+        @DisplayName("비밀번호가 10자 미만인 경우 유효하지 않습니다.")
+        void isInvalidWhenPasswordIsLessThan10Characters() {
+            // given
+            String invalidPassword = "pw123^^";
+
+            // when & then
+            assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
+                    .isInstanceOf(InvalidPasswordException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호가 20자를 초과하는 경우 유효하지 않습니다.")
+        void isInvalidWhenPasswordIsGreaterThan20Characters() {
+            // given
+            String invalidPassword = "abcdefghijklmnopqrstuvwxyz1234567890^^";
+
+            // when & then
+            assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
+                    .isInstanceOf(InvalidPasswordException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호가 null인 경우 유효하지 않습니다.")
+        void isInvalidWhenPasswordIsNull() {
+            // given
+            String invalidPassword = null;
+
+            // when & then
+            assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호에 문자가 포함되지 않은 경우 유효하지 않습니다.")
+        void isInvalidWhenPasswordDoesNotContainCharacters() {
+            // given
+            String invalidPassword = "1234567890^^";
+
+            // when & then
+            assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
+                    .isInstanceOf(InvalidPasswordException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호에 숫자가 포함되지 않은 경우 유효하지 않습니다.")
+        void isInvalidWhenPasswordDoesNotContainNumbers() {
+            // given
+            String invalidPassword = "password^^";
+
+            // when & then
+            assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
+                    .isInstanceOf(InvalidPasswordException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호에 특수문자가 포함되지 않은 경우 유효하지 않습니다.")
+        void isInvalidWhenPasswordDoesNotContainSpecialCharacters() {
+            // given
+            String invalidPassword = "password1234";
+
+            // when & then
+            assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
+                    .isInstanceOf(InvalidPasswordException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호에 영어 대소문자 이외의 문자가 포함된 경우 유효하지 않습니다.")
+        void isInvalidWhenPasswordContainsNonAlphabetCharacters() {
+            // given
+            String invalidPassword = "비밀번호abcd1234^^";
+
+            // when & then
+            assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
+                    .isInstanceOf(InvalidPasswordException.class);
+        }
     }
 
-    @Test
-    @DisplayName("비밀번호가 20자이고, 문자, 숫자, 특수문자를 포함한 경우 유효합니다.")
-    void isValidWhenPasswordHasTwentyCharactersIncludingLettersNumbersAndSpecialCharacters() {
-        // given
-        String validPassword = "password9012345678^^";
-        when(passwordHasher.hash(anyString()))
-                .thenAnswer(invocation -> {
-                    String raw = invocation.getArgument(0, String.class);
-                    return "hashed" + raw;
-                });
+    @Nested
+    @DisplayName("비밀번호 매칭")
+    class PasswordMatch {
 
-        // when
-        Password password = Password.fromRaw(validPassword, passwordHasher);
+        private static final String RAW_PASSWORD = "raw";
+        private static final String HASHED_PASSWORD = "hashed";
 
-        // then
-        assertThat(password).isNotNull();
-        assertThat(password.getHashedValue()).isEqualTo("hashed" + validPassword);
-    }
+        @Test
+        @DisplayName("비밀번호가 일치하는 경우 true를 반환합니다.")
+        void shouldReturnTrueWhenPasswordMatches() {
+            // given
+            Password hashedPassword = Password.fromHashed(HASHED_PASSWORD);
+            when(passwordHasher.matches(RAW_PASSWORD, HASHED_PASSWORD)).thenReturn(true);
 
-    @Test
-    @DisplayName("비밀번호가 10자 미만인 경우 유효하지 않습니다.")
-    void isInvalidWhenPasswordIsLessThan10Characters() {
-        // given
-        String invalidPassword = "pw123^^";
+            // when
+            boolean result = hashedPassword.matches(RAW_PASSWORD, passwordHasher);
 
-        // when & then
-        assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
-                .isInstanceOf(InvalidPasswordException.class);
-    }
+            // then
+            assertThat(result).isTrue();
+        }
 
-    @Test
-    @DisplayName("비밀번호가 20자를 초과하는 경우 유효하지 않습니다.")
-    void isInvalidWhenPasswordIsGreaterThan20Characters() {
-        // given
-        String invalidPassword = "abcdefghijklmnopqrstuvwxyz1234567890^^";
+        @Test
+        @DisplayName("비밀번호가 일치하지 않는 경우 false를 반환합니다.")
+        void shouldReturnFalseWhenPasswordDoesntMatch() {
+            // given
+            Password hashedPassword = Password.fromHashed(HASHED_PASSWORD);
+            when(passwordHasher.matches(RAW_PASSWORD, HASHED_PASSWORD)).thenReturn(false);
 
-        // when & then
-        assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
-                .isInstanceOf(InvalidPasswordException.class);
-    }
+            // when
+            boolean result = hashedPassword.matches(RAW_PASSWORD, passwordHasher);
 
-    @Test
-    @DisplayName("비밀번호가 null인 경우 유효하지 않습니다.")
-    void isInvalidWhenPasswordIsNull() {
-        // given
-        String invalidPassword = null;
-
-        // when & then
-        assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("비밀번호에 문자가 포함되지 않은 경우 유효하지 않습니다.")
-    void isInvalidWhenPasswordDoesNotContainCharacters() {
-        // given
-        String invalidPassword = "1234567890^^";
-
-        // when & then
-        assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
-                .isInstanceOf(InvalidPasswordException.class);
-    }
-
-    @Test
-    @DisplayName("비밀번호에 숫자가 포함되지 않은 경우 유효하지 않습니다.")
-    void isInvalidWhenPasswordDoesNotContainNumbers() {
-        // given
-        String invalidPassword = "password^^";
-
-        // when & then
-        assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
-                .isInstanceOf(InvalidPasswordException.class);
-    }
-
-    @Test
-    @DisplayName("비밀번호에 특수문자가 포함되지 않은 경우 유효하지 않습니다.")
-    void isInvalidWhenPasswordDoesNotContainSpecialCharacters() {
-        // given
-        String invalidPassword = "password1234";
-
-        // when & then
-        assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
-                .isInstanceOf(InvalidPasswordException.class);
-    }
-
-    @Test
-    @DisplayName("비밀번호에 영어 대소문자 이외의 문자가 포함된 경우 유효하지 않습니다.")
-    void isInvalidWhenPasswordContainsNonAlphabetCharacters() {
-        // given
-        String invalidPassword = "비밀번호abcd1234^^";
-
-        // when & then
-        assertThatThrownBy(() -> Password.fromRaw(invalidPassword, passwordHasher))
-                .isInstanceOf(InvalidPasswordException.class);
+            // then
+            assertThat(result).isFalse();
+        }
     }
 }

--- a/src/test/java/atwoz/atwoz/admin/domain/PhoneNumberTest.java
+++ b/src/test/java/atwoz/atwoz/admin/domain/PhoneNumberTest.java
@@ -2,19 +2,18 @@ package atwoz.atwoz.admin.domain;
 
 import atwoz.atwoz.admin.domain.exception.InvalidPhoneNumberException;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PhoneNumberTest {
 
-    @Test
-    @DisplayName("전화번호가 형식에 맞는 경우 유효합니다.")
-    void isValidWhenFormatIsCorrect() {
-        // given
-        String validPhoneNumber = "01012345678";
-
+    @ParameterizedTest
+    @ValueSource(strings = {"01012345678", "01099999999"})
+    @DisplayName("전화번호가 01012345678 형식에 맞는 경우 유효합니다.")
+    void canCreatePhoneNumberWhenFormatIsValid(String validPhoneNumber) {
         // when
         PhoneNumber phoneNumber = PhoneNumber.from(validPhoneNumber);
 
@@ -23,56 +22,10 @@ class PhoneNumberTest {
         assertThat(phoneNumber.getValue()).isEqualTo(validPhoneNumber);
     }
 
-    @Test
-    @DisplayName("전화번호가 010으로 시작하지 않는 경우 유효하지 않습니다.")
-    void isInvalidWhenPhoneNumberDoesNotStartWith010() {
-        // given
-        String invalidPhoneNumber = "01234567890";
-
-        // when & then
-        assertThatThrownBy(() -> PhoneNumber.from(invalidPhoneNumber))
-                .isInstanceOf(InvalidPhoneNumberException.class);
-    }
-
-    @Test
-    @DisplayName("전화번호가 11자리보다 큰 경우 유효하지 않습니다.")
-    void isInvalidWhenPhoneNumberExceedsElevenDigits() {
-        // given
-        String invalidPhoneNumber = "010123456789";
-
-        // when & then
-        assertThatThrownBy(() -> PhoneNumber.from(invalidPhoneNumber))
-                .isInstanceOf(InvalidPhoneNumberException.class);
-    }
-
-    @Test
-    @DisplayName("전화번호가 null인 경우 유효하지 않습니다.")
-    void isInvalidWhenPhoneNumberIsNull() {
-        // given
-        String invalidPhoneNumber = null;
-
-        // when & then
-        assertThatThrownBy(() -> PhoneNumber.from(invalidPhoneNumber))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("전화번호가 빈 문자열인 경우 유효하지 않습니다.")
-    void isInvalidWhenPhoneNumberIsEmpty() {
-        // given
-        String invalidPhoneNumber = "";
-
-        // when & then
-        assertThatThrownBy(() -> PhoneNumber.from(invalidPhoneNumber))
-                .isInstanceOf(InvalidPhoneNumberException.class);
-    }
-
-    @Test
-    @DisplayName("전화번호에 숫자가 아닌 값이 포함된 경우 유효하지 않습니다.")
-    void isInvalidWhenPhoneNumberContainsNonNumericCharacters() {
-        // given
-        String invalidPhoneNumber = "010-1234-5678";
-
+    @ParameterizedTest
+    @ValueSource(strings = {"01234567890", "010123456789", "", "010-1234-5678"})
+    @DisplayName("전화번호 형식이 유효하지 않은 경우 InvalidPhoneNumberException이 발생합니다.")
+    void isInvalidWhenFormatIsIncorrect(String invalidPhoneNumber) {
         // when & then
         assertThatThrownBy(() -> PhoneNumber.from(invalidPhoneNumber))
                 .isInstanceOf(InvalidPhoneNumberException.class);


### PR DESCRIPTION
### 관련 이슈
- closes #44 

<br>

### 작업 내용
- 관리자 로그아웃 기능 구현
- 기존 애플리케이션 서비스에 있던 비밀번호 검증 도메인 로직을 비밀번호가 책임을 갖도록 리팩토링
- 테스트 코드 리팩토링

<br>

### 노트
- 리뷰 반영하고 머지하면 프론트 분들이랑 테스트 진행해보겠습니다!
- 테스트 코드는 유지보수성을 높이는 형태로 리팩토링 했습니다.
  - parameterized 테스트로 바꿀 수 있는 부분들은 바꿈
  - 굳이 테스트하지 않아도 될만한 케이스들은 제거(도메인 로직과 큰 상관없는 null 체크)
  - 과한 반복 줄이기 제거(상수 등) -> 공통 부분을 억지로 뽑아내려 하다보니 테스트간 의존성이 높아져 다른 곳의 변경에 의도치 않게 실패하는 경우가 생겨서 수정
