### PR TITLE
관리자 로그아웃 401 응답 내려가는 버그 수정

### DIFF
--- a/src/main/java/atwoz/atwoz/auth/presentation/filter/PathMatcherConfig.java
+++ b/src/main/java/atwoz/atwoz/auth/presentation/filter/PathMatcherConfig.java
@@ -9,8 +9,8 @@ import java.util.List;
 public class PathMatcherConfig {
 
     private static final List<String> EXCLUDED_URIS = List.of(
-            "/member/auth/login", "/member/auth/logout",
-            "/admin/login", "/admin/signup",
+            "/member/login", "/member/logout",
+            "/admin/login", "/admin/signup", "/admin/logout",
             "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**",
             "/webjars/**"
     );

--- a/src/main/java/atwoz/atwoz/member/presentation/MemberAuthController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/MemberAuthController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/member/auth")
+@RequestMapping("/member")
 public class MemberAuthController {
 
     private final RefreshTokenCookieProperties refreshTokenCookieProperties;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,9 +42,9 @@ server:
 jwt:
   secret: ${JWT_SECRET:this-is-secret-key-value-at-least-128-bytes}
   access-token:
-    expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:30}  # 30분(1800)
+    expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:1800}  # 30분
   refresh-token:
-    expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:120}  # 2주(1209600)
+    expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600}  # 2주
 
 auth:
   refresh-token-cookie:


### PR DESCRIPTION
### 관련 이슈
- closes #60 

<br>

### 작업 내용
- 로그아웃 엔드포인트(`/admin/logout`)가 `TokenFilter`에서 제외되지 않아 로그아웃이 정상적으로 이루어지지 않던 오류 수정
- member 로그인, 로그아웃 엔드포인트 수정
- 테스트를 위해 수정했던 토큰 만료시간 원상 복구

<br>

### 노트
- 현재 구현에서 로그아웃은 refresh token이 있든 없든, 만료되었든 되지 않았든 모든 경우 200을 내려줍니다.
- 로그아웃은 단순 redis에 있는 토큰을 지우는 행위이므로, refresh token이 redis에 있으면 지워지고 없으면 지워지지 않기 때문에 위처럼 간단하게 구현했습니다.
