### PR TITLE
fix : MemberAuthSupport.class 를 통해 클래스 분리

### DIFF
--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthSupport.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthSupport.java
@@ -1,0 +1,25 @@
+package atwoz.atwoz.member.command.application.member;
+
+import atwoz.atwoz.member.command.application.member.exception.MemberLoginConflictException;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAuthSupport {
+    private final MemberCommandRepository memberCommandRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected Member create(String phoneNumber) {
+        try {
+            return memberCommandRepository.save(Member.fromPhoneNumber(phoneNumber));
+        } catch (DataIntegrityViolationException e) {
+            throw new MemberLoginConflictException(phoneNumber);
+        }
+    }
+}


### PR DESCRIPTION
### 관련 이슈
- closes #80 

<br>

### 작업 내용
- `MemberAuthSupport.class` 를 따로 생성하여, 각각의 트랜잭션이 AOP 프록시 객체를 통해 실행될 수 있도록 하였습니다.

<br>

### 참고 자료
-

<br>

### 노트
- 
