### PR TITLE
심사 승인/거절 심사 id 기반으로 동작하도록 수정

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/command/application/admin/AdminAuthService.java
+++ b/src/main/java/atwoz/atwoz/admin/command/application/admin/AdminAuthService.java
@@ -63,11 +63,11 @@ public class AdminAuthService {
                 .orElseThrow(AdminNotFoundException::new);
     }
 
-    private String createAccessToken(Long id, Instant issuedAt) {
+    private String createAccessToken(long id, Instant issuedAt) {
         return tokenProvider.createAccessToken(id, Role.ADMIN, issuedAt);
     }
 
-    private String createRefreshToken(Long id, Instant issuedAt) {
+    private String createRefreshToken(long id, Instant issuedAt) {
         return tokenProvider.createRefreshToken(id, Role.ADMIN, issuedAt);
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/command/application/screening/ScreeningNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/admin/command/application/screening/ScreeningNotFoundException.java
@@ -1,4 +1,4 @@
-package atwoz.atwoz.admin.command.domain.screening;
+package atwoz.atwoz.admin.command.application.screening;
 
 public class ScreeningNotFoundException extends RuntimeException {
     public ScreeningNotFoundException() {

--- a/src/main/java/atwoz/atwoz/admin/command/application/screening/ScreeningService.java
+++ b/src/main/java/atwoz/atwoz/admin/command/application/screening/ScreeningService.java
@@ -2,7 +2,6 @@ package atwoz.atwoz.admin.command.application.screening;
 
 import atwoz.atwoz.admin.command.domain.screening.Screening;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningCommandRepository;
-import atwoz.atwoz.admin.command.domain.screening.ScreeningNotFoundException;
 import atwoz.atwoz.admin.presentation.screening.ScreeningRejectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/atwoz/atwoz/admin/command/application/screening/ScreeningService.java
+++ b/src/main/java/atwoz/atwoz/admin/command/application/screening/ScreeningService.java
@@ -3,12 +3,13 @@ package atwoz.atwoz.admin.command.application.screening;
 import atwoz.atwoz.admin.command.domain.screening.Screening;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningCommandRepository;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningNotFoundException;
-import atwoz.atwoz.admin.presentation.screening.dto.ScreeningApproveRequest;
-import atwoz.atwoz.admin.presentation.screening.dto.ScreeningRejectRequest;
+import atwoz.atwoz.admin.presentation.screening.ScreeningRejectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static atwoz.atwoz.admin.command.application.screening.ScreeningMapper.toRejectionReasonType;
 
 @Slf4j
 @Service
@@ -18,28 +19,28 @@ public class ScreeningService {
     private final ScreeningCommandRepository screeningCommandRepository;
 
     @Transactional
-    public void create(Long memberId) {
+    public void create(long memberId) {
         if (screeningCommandRepository.existsByMemberId(memberId)) {
-            log.warn("멤버(id: {})에 대해 중복된 MemberScreening을 생성할 수 없습니다.", memberId);
+            log.warn("멤버(id: {})에 대해 중복된 Screening을 생성할 수 없습니다.", memberId);
             return;
         }
         screeningCommandRepository.save(Screening.from(memberId));
     }
 
     @Transactional
-    public void approve(ScreeningApproveRequest request, Long adminId) {
-        Screening screening = findScreening(request.memberId());
+    public void approve(long screeningId, long adminId) {
+        Screening screening = findById(screeningId);
         screening.approve(adminId);
     }
 
     @Transactional
-    public void reject(ScreeningRejectRequest request, Long adminId) {
-        Screening screening = findScreening(request.memberId());
-        screening.reject(adminId, ScreeningMapper.toRejectionReasonType(request.rejectionReason()));
+    public void reject(long screeningId, long adminId, ScreeningRejectRequest request) {
+        Screening screening = findById(screeningId);
+        screening.reject(adminId, toRejectionReasonType(request.rejectionReason()));
     }
 
-    private Screening findScreening(Long memberId) {
-        return screeningCommandRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new ScreeningNotFoundException(memberId));
+    private Screening findById(long id) {
+        return screeningCommandRepository.findById(id)
+                .orElseThrow(ScreeningNotFoundException::new);
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/command/domain/screening/Screening.java
+++ b/src/main/java/atwoz/atwoz/admin/command/domain/screening/Screening.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
 import static jakarta.persistence.EnumType.STRING;
 
@@ -34,31 +33,31 @@ public class Screening extends BaseEntity {
     @Version
     private Long version;
 
-    public static Screening from(Long memberId) {
+    public static Screening from(long memberId) {
         return new Screening(memberId, null, null, ScreeningStatus.PENDING);
     }
 
-    private Screening(Long memberId, Long adminId, RejectionReasonType rejectionReason, ScreeningStatus status) {
+    private Screening(long memberId, Long adminId, RejectionReasonType rejectionReason, ScreeningStatus status) {
         this.memberId = memberId;
         this.adminId = adminId;
         this.rejectionReason = rejectionReason;
         this.status = status;
     }
 
-    public void approve(Long adminId) {
+    public void approve(long adminId) {
         setAdminId(adminId);
         changeScreeningStatus(ScreeningStatus.APPROVED);
         setRejectionReason(null);
     }
 
-    public void reject(Long adminId, RejectionReasonType rejectionReason) {
+    public void reject(long adminId, RejectionReasonType rejectionReason) {
         validateNotApproved();
         setAdminId(adminId);
         changeScreeningStatus(ScreeningStatus.REJECTED);
         setRejectionReason(rejectionReason);
     }
 
-    private void setAdminId(@NonNull Long adminId) {
+    private void setAdminId(long adminId) {
         this.adminId = adminId;
     }
 

--- a/src/main/java/atwoz/atwoz/admin/command/domain/screening/ScreeningCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/admin/command/domain/screening/ScreeningCommandRepository.java
@@ -2,11 +2,7 @@ package atwoz.atwoz.admin.command.domain.screening;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ScreeningCommandRepository extends JpaRepository<Screening, Long> {
 
-    boolean existsByMemberId(Long memberId);
-
-    Optional<Screening> findByMemberId(Long memberId);
+    boolean existsByMemberId(long memberId);
 }

--- a/src/main/java/atwoz/atwoz/admin/command/domain/screening/ScreeningNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/admin/command/domain/screening/ScreeningNotFoundException.java
@@ -1,7 +1,7 @@
 package atwoz.atwoz.admin.command.domain.screening;
 
 public class ScreeningNotFoundException extends RuntimeException {
-    public ScreeningNotFoundException(Long memberId) {
-        super("멤버(id: " + memberId + ")에 대한 심사를 찾을 수 없습니다.");
+    public ScreeningNotFoundException() {
+        super("심사를 찾을 수 없습니다.");
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningController.java
@@ -1,8 +1,6 @@
 package atwoz.atwoz.admin.presentation.screening;
 
 import atwoz.atwoz.admin.command.application.screening.ScreeningService;
-import atwoz.atwoz.admin.presentation.screening.dto.ScreeningApproveRequest;
-import atwoz.atwoz.admin.presentation.screening.dto.ScreeningRejectRequest;
 import atwoz.atwoz.admin.query.*;
 import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
@@ -25,24 +23,6 @@ public class ScreeningController {
     private final ScreeningQueryRepository screeningQueryRepository;
     private final ScreeningDetailQueryRepository screeningDetailQueryRepository;
 
-    @PostMapping("/approve")
-    public ResponseEntity<BaseResponse<Void>> approve(
-            @Valid @RequestBody ScreeningApproveRequest request,
-            @AuthPrincipal AuthContext authContext
-    ) {
-        screeningService.approve(request, authContext.getId());
-        return ResponseEntity.ok(BaseResponse.from(OK));
-    }
-
-    @PostMapping("/reject")
-    public ResponseEntity<BaseResponse<Void>> reject(
-            @Valid @RequestBody ScreeningRejectRequest request,
-            @AuthPrincipal AuthContext authContext
-    ) {
-        screeningService.reject(request, authContext.getId());
-        return ResponseEntity.ok(BaseResponse.from(OK));
-    }
-
     @GetMapping
     public ResponseEntity<BaseResponse<Page<ScreeningView>>> getScreenings(
             @Valid @ModelAttribute ScreeningSearchCondition condition,
@@ -52,7 +32,26 @@ public class ScreeningController {
     }
 
     @GetMapping("/{screeningId}")
-    public ResponseEntity<BaseResponse<ScreeningDetailView>> getScreeningDetail(@PathVariable Long screeningId) {
+    public ResponseEntity<BaseResponse<ScreeningDetailView>> getScreeningDetail(@PathVariable long screeningId) {
         return ResponseEntity.ok(BaseResponse.of(OK, screeningDetailQueryRepository.findById(screeningId)));
+    }
+
+    @PostMapping("/{screeningId}/approve")
+    public ResponseEntity<BaseResponse<Void>> approve(
+            @PathVariable long screeningId,
+            @AuthPrincipal AuthContext authContext
+    ) {
+        screeningService.approve(screeningId, authContext.getId());
+        return ResponseEntity.ok(BaseResponse.from(OK));
+    }
+
+    @PostMapping("/{screeningId}/reject")
+    public ResponseEntity<BaseResponse<Void>> reject(
+            @PathVariable long screeningId,
+            @Valid @RequestBody ScreeningRejectRequest request,
+            @AuthPrincipal AuthContext authContext
+    ) {
+        screeningService.reject(screeningId, authContext.getId(), request);
+        return ResponseEntity.ok(BaseResponse.from(OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningExceptionHandler.java
@@ -1,8 +1,8 @@
 package atwoz.atwoz.admin.presentation.screening;
 
 import atwoz.atwoz.admin.command.application.screening.InvalidRejectionReasonException;
+import atwoz.atwoz.admin.command.application.screening.ScreeningNotFoundException;
 import atwoz.atwoz.admin.command.domain.screening.CannotRejectApprovedScreeningException;
-import atwoz.atwoz.admin.command.domain.screening.ScreeningNotFoundException;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningRejectRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningRejectRequest.java
@@ -1,13 +1,9 @@
-package atwoz.atwoz.admin.presentation.screening.dto;
+package atwoz.atwoz.admin.presentation.screening;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record ScreeningRejectRequest(
-        @NotNull(message = "멤버 id는 null일 수 없습니다.")
-        Long memberId,
-
         @Schema(
                 description = "반려 사유",
                 allowableValues = {"STOLEN_IMAGE", "INAPPROPRIATE_IMAGE", "EXPLICIT_CONTENT", "OFFENSIVE_LANGUAGE", "CONTACT_IN_PROFILE"},

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/dto/ScreeningApproveRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/dto/ScreeningApproveRequest.java
@@ -1,9 +1,0 @@
-package atwoz.atwoz.admin.presentation.screening.dto;
-
-import jakarta.validation.constraints.NotNull;
-
-public record ScreeningApproveRequest(
-        @NotNull(message = "멤버 id는 null일 수 없습니다.")
-        Long memberId
-) {
-}

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailQueryRepository.java
@@ -16,7 +16,7 @@ public class ScreeningDetailQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public ScreeningDetailView findById(Long screeningId) {
+    public ScreeningDetailView findById(long screeningId) {
         return queryFactory
                 .from(member)
                 .join(screening).on(screening.memberId.eq(member.id))

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailView.java
@@ -7,14 +7,14 @@ import java.util.List;
 public record ScreeningDetailView(
         long screeningId,
         long memberId,
-    String screeningStatus,
-    String rejectionReason,
-    String nickname,
+        String screeningStatus,
+        String rejectionReason,
+        String nickname,
         int age,
-    String gender,
-    String joinedDate,
+        String gender,
+        String joinedDate,
         List<ProfileImageView> profileImages
-    // TODO: interviews
+        // TODO: interviews
 ) {
     @QueryProjection
     public ScreeningDetailView {

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningView.java
@@ -3,7 +3,7 @@ package atwoz.atwoz.admin.query;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record ScreeningView(
-        Long screeningId,
+        long screeningId,
         String nickname,
         String gender,
         String joinedDate,

--- a/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
@@ -3,7 +3,6 @@ package atwoz.atwoz.admin.command.application.screening;
 import atwoz.atwoz.admin.command.domain.screening.RejectionReasonType;
 import atwoz.atwoz.admin.command.domain.screening.Screening;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningCommandRepository;
-import atwoz.atwoz.admin.command.domain.screening.ScreeningNotFoundException;
 import atwoz.atwoz.admin.presentation.screening.ScreeningRejectRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
@@ -4,8 +4,7 @@ import atwoz.atwoz.admin.command.domain.screening.RejectionReasonType;
 import atwoz.atwoz.admin.command.domain.screening.Screening;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningCommandRepository;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningNotFoundException;
-import atwoz.atwoz.admin.presentation.screening.dto.ScreeningApproveRequest;
-import atwoz.atwoz.admin.presentation.screening.dto.ScreeningRejectRequest;
+import atwoz.atwoz.admin.presentation.screening.ScreeningRejectRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,10 +33,10 @@ class ScreeningServiceTest {
     class Create {
 
         @Test
-        @DisplayName("멤버 심사가 아직 존재하지 않는다면 MemberScreening을 생성하고 저장합니다.")
+        @DisplayName("멤버 심사가 아직 존재하지 않는다면 Screening을 생성하고 저장합니다.")
         void createNewMemberScreeningWhenNotExists() {
             // given
-            Long memberId = 100L;
+            long memberId = 100L;
             when(screeningCommandRepository.existsByMemberId(memberId)).thenReturn(false);
 
             // when
@@ -49,10 +48,10 @@ class ScreeningServiceTest {
         }
 
         @Test
-        @DisplayName("이미 동일 멤버의 MemberScreening이 존재한다면 저장하지 않고 경고 로그를 남기고 종료합니다.")
+        @DisplayName("이미 동일 멤버의 Screening이 존재한다면 저장하지 않고 경고 로그를 남기고 종료합니다.")
         void skipCreationWhenAlreadyExists() {
             // given
-            Long memberId = 200L;
+            long memberId = 100L;
             when(screeningCommandRepository.existsByMemberId(memberId)).thenReturn(true);
 
             // when
@@ -69,36 +68,32 @@ class ScreeningServiceTest {
     class Approve {
 
         @Test
-        @DisplayName("존재하는 MemberScreening이면 approve(adminId)를 호출합니다.")
+        @DisplayName("존재하는 Screening이면 approve(adminId)를 호출합니다.")
         void approveWhenScreeningExists() {
             // given
-            Long memberId = 300L;
-            Long adminId = 999L;
-            ScreeningApproveRequest request = new ScreeningApproveRequest(memberId);
+            long screeningId = 1L;
+            long adminId = 999L;
 
             Screening screening = mock(Screening.class);
-            when(screeningCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(screening));
+            when(screening.getId()).thenReturn(screeningId);
+            when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
 
             // when
-            screeningService.approve(request, adminId);
+            screeningService.approve(screeningId, adminId);
 
             // then
-            verify(screeningCommandRepository).findByMemberId(memberId);
             verify(screening).approve(adminId);
         }
 
         @Test
-        @DisplayName("존재하지 않는 MemberScreening이면 MemberScreeningNotFoundException을 던집니다.")
+        @DisplayName("존재하지 않는 Screening이면 ScreeningNotFoundException을 던집니다.")
         void throwExceptionWhenScreeningDoesNotExist() {
             // given
-            Long memberId = 400L;
-            Long adminId = 999L;
-            ScreeningApproveRequest request = new ScreeningApproveRequest(memberId);
-
-            when(screeningCommandRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+            long screeningId = 1L;
+            when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> screeningService.approve(request, adminId))
+            assertThatThrownBy(() -> screeningService.approve(screeningId, 999L))
                     .isInstanceOf(ScreeningNotFoundException.class);
         }
     }
@@ -108,37 +103,41 @@ class ScreeningServiceTest {
     class Reject {
 
         @Test
-        @DisplayName("존재하는 MemberScreening이면 reject(adminId, reasonType)을 호출합니다.")
+        @DisplayName("존재하는 Screening이면 reject(adminId, rejectionReason)을 호출합니다.")
         void rejectWhenScreeningExists() {
             // given
-            Long memberId = 500L;
-            Long adminId = 999L;
-            String rejectionReason = "STOLEN_IMAGE";
-            ScreeningRejectRequest request = new ScreeningRejectRequest(memberId, rejectionReason);
+            long screeningId = 1L;
+            long adminId = 999L;
 
             Screening screening = mock(Screening.class);
-            when(screeningCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(screening));
+            when(screening.getId()).thenReturn(screeningId);
+            when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
+
+            String rejectionReason = "STOLEN_IMAGE";
+            ScreeningRejectRequest request = new ScreeningRejectRequest(rejectionReason);
 
             // when
-            screeningService.reject(request, adminId);
+            screeningService.reject(screeningId, adminId, request);
 
             // then
-            verify(screeningCommandRepository).findByMemberId(memberId);
             verify(screening).reject(adminId, RejectionReasonType.STOLEN_IMAGE);
         }
 
         @Test
-        @DisplayName("존재하지 않는 MemberScreening이면 MemberScreeningNotFoundException을 던집니다.")
+        @DisplayName("존재하지 않는 Screening이면 ScreeningNotFoundException을 던집니다.")
         void throwExceptionWhenRejectingNonExistentScreening() {
             // given
-            Long memberId = 600L;
-            Long adminId = 999L;
-            ScreeningRejectRequest request = new ScreeningRejectRequest(memberId, "STOLEN_IMAGE");
+            long screeningId = 1L;
+            long adminId = 999L;
 
-            when(screeningCommandRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+            Screening screening = mock(Screening.class);
+            when(screening.getId()).thenReturn(screeningId);
+            when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.empty());
+
+            ScreeningRejectRequest request = new ScreeningRejectRequest("STOLEN_IMAGE");
 
             // when & then
-            assertThatThrownBy(() -> screeningService.reject(request, adminId))
+            assertThatThrownBy(() -> screeningService.reject(screeningId, adminId, request))
                     .isInstanceOf(ScreeningNotFoundException.class);
         }
 
@@ -146,15 +145,17 @@ class ScreeningServiceTest {
         @DisplayName("존재하지 않는 반려 사유인 경우 InvalidRejectionReasonException을 던집니다.")
         void throwExceptionWhenRejectionReasonNonExists() {
             // given
-            Long memberId = 600L;
-            Long adminId = 999L;
-            ScreeningRejectRequest request = new ScreeningRejectRequest(memberId, "NON_EXISTING_REASON");
+            long screeningId = 1L;
+            long adminId = 999L;
 
             Screening screening = mock(Screening.class);
-            when(screeningCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(screening));
+            when(screening.getId()).thenReturn(screeningId);
+            when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
+
+            ScreeningRejectRequest request = new ScreeningRejectRequest("NON_EXISTING_REASON");
 
             // when & then
-            assertThatThrownBy(() -> screeningService.reject(request, adminId))
+            assertThatThrownBy(() -> screeningService.reject(screeningId, adminId, request))
                     .isInstanceOf(InvalidRejectionReasonException.class);
         }
     }

--- a/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
@@ -75,7 +75,6 @@ class ScreeningServiceTest {
             long adminId = 999L;
 
             Screening screening = mock(Screening.class);
-            when(screening.getId()).thenReturn(screeningId);
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
 
             // when
@@ -110,7 +109,6 @@ class ScreeningServiceTest {
             long adminId = 999L;
 
             Screening screening = mock(Screening.class);
-            when(screening.getId()).thenReturn(screeningId);
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
 
             String rejectionReason = "STOLEN_IMAGE";
@@ -128,16 +126,12 @@ class ScreeningServiceTest {
         void throwExceptionWhenRejectingNonExistentScreening() {
             // given
             long screeningId = 1L;
-            long adminId = 999L;
-
-            Screening screening = mock(Screening.class);
-            when(screening.getId()).thenReturn(screeningId);
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.empty());
 
             ScreeningRejectRequest request = new ScreeningRejectRequest("STOLEN_IMAGE");
 
             // when & then
-            assertThatThrownBy(() -> screeningService.reject(screeningId, adminId, request))
+            assertThatThrownBy(() -> screeningService.reject(screeningId, 999L, request))
                     .isInstanceOf(ScreeningNotFoundException.class);
         }
 
@@ -146,16 +140,13 @@ class ScreeningServiceTest {
         void throwExceptionWhenRejectionReasonNonExists() {
             // given
             long screeningId = 1L;
-            long adminId = 999L;
-
             Screening screening = mock(Screening.class);
-            when(screening.getId()).thenReturn(screeningId);
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
 
             ScreeningRejectRequest request = new ScreeningRejectRequest("NON_EXISTING_REASON");
 
             // when & then
-            assertThatThrownBy(() -> screeningService.reject(screeningId, adminId, request))
+            assertThatThrownBy(() -> screeningService.reject(screeningId, 999L, request))
                     .isInstanceOf(InvalidRejectionReasonException.class);
         }
     }

--- a/src/test/java/atwoz/atwoz/admin/command/domain/screening/ScreeningTest.java
+++ b/src/test/java/atwoz/atwoz/admin/command/domain/screening/ScreeningTest.java
@@ -14,7 +14,7 @@ class ScreeningTest {
     class FromMethodTest {
 
         @Test
-        @DisplayName("주어진 memberId로 from()을 호출하면, PENDING 상태의 MemberScreening을 생성합니다.")
+        @DisplayName("주어진 memberId로 from()을 호출하면, PENDING 상태의 Screening을 생성합니다.")
         void createPendingScreening() {
             // given
             Long memberId = 1L;
@@ -35,7 +35,7 @@ class ScreeningTest {
     class ApproveMethodTest {
 
         @Test
-        @DisplayName("PENDING 상태인 MemberScreening을 approve하면, APPROVED 상태가 되며 거절 사유는 null이 됩니다.")
+        @DisplayName("PENDING 상태인 Screening을 approve하면, APPROVED 상태가 되며 거절 사유는 null이 됩니다.")
         void approvePendingScreening() {
             // given
             Screening screening = Screening.from(10L);
@@ -50,7 +50,7 @@ class ScreeningTest {
         }
 
         @Test
-        @DisplayName("REJECTED 상태인 MemberScreening을 approve하면, 다시 APPROVED 상태가 되며 거절 사유는 null이 됩니다.")
+        @DisplayName("REJECTED 상태인 Screening을 approve하면, 다시 APPROVED 상태가 되며 거절 사유는 null이 됩니다.")
         void approveRejectedScreening() {
             // given
             Screening screening = Screening.from(10L);
@@ -66,7 +66,7 @@ class ScreeningTest {
         }
 
         @Test
-        @DisplayName("APPROVED 상태인 MemberScreening을 다시 approve하면, 상태 변화 없이 adminId만 갱신되고 거절 사유는 여전히 null입니다.")
+        @DisplayName("APPROVED 상태인 Screening을 다시 approve하면, 상태 변화 없이 adminId만 갱신되고 거절 사유는 여전히 null입니다.")
         void approveApprovedScreening() {
             // given
             Screening screening = Screening.from(10L);
@@ -87,7 +87,7 @@ class ScreeningTest {
     class RejectMethodTest {
 
         @Test
-        @DisplayName("PENDING 상태인 MemberScreening을 reject하면, REJECTED 상태가 되며 거절 사유가 설정됩니다.")
+        @DisplayName("PENDING 상태인 Screening을 reject하면, REJECTED 상태가 되며 거절 사유가 설정됩니다.")
         void rejectPendingScreening() {
             // given
             Screening screening = Screening.from(2L);
@@ -102,7 +102,7 @@ class ScreeningTest {
         }
 
         @Test
-        @DisplayName("REJECTED 상태인 MemberScreening을 다시 reject하면, 재거절이 가능하며 거절 사유가 덮어씌워집니다.")
+        @DisplayName("REJECTED 상태인 Screening을 다시 reject하면, 재거절이 가능하며 거절 사유가 덮어씌워집니다.")
         void rejectRejectedScreening() {
             // given
             Screening screening = Screening.from(2L);
@@ -118,7 +118,7 @@ class ScreeningTest {
         }
 
         @Test
-        @DisplayName("APPROVED 상태인 MemberScreening을 reject하려고 하면 예외가 발생합니다.")
+        @DisplayName("APPROVED 상태인 Screening을 reject하려고 하면 예외가 발생합니다.")
         void rejectApprovedScreeningThrowsException() {
             // given
             Screening screening = Screening.from(2L);


### PR DESCRIPTION
### 관련 이슈
- #54 

<br>

### 작업 내용
- 승인/반려를 기존 member id 에서 screening id 기반으로 작동하도록 수정했습니다.
- primitive 타입 사용할 수 있는 부분은 사용하도록 변경했습니다.