### PR TITLE
심사 상세 조회에 인터뷰 추가

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/command/application/screening/ScreeningService.java
+++ b/src/main/java/atwoz/atwoz/admin/command/application/screening/ScreeningService.java
@@ -2,9 +2,11 @@ package atwoz.atwoz.admin.command.application.screening;
 
 import atwoz.atwoz.admin.command.domain.screening.Screening;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningCommandRepository;
+import atwoz.atwoz.admin.presentation.screening.ScreeningApproveRequest;
 import atwoz.atwoz.admin.presentation.screening.ScreeningRejectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,14 +29,24 @@ public class ScreeningService {
     }
 
     @Transactional
-    public void approve(long screeningId, long adminId) {
+    public void approve(long screeningId, ScreeningApproveRequest request, long adminId) {
         Screening screening = findById(screeningId);
+
+        if (screening.hasVersionConflict(request.version())) {
+            throw new OptimisticLockingFailureException("심사를 승인할 수 없습니다.");
+        }
+
         screening.approve(adminId);
     }
 
     @Transactional
     public void reject(long screeningId, long adminId, ScreeningRejectRequest request) {
         Screening screening = findById(screeningId);
+
+        if (screening.hasVersionConflict(request.version())) {
+            throw new OptimisticLockingFailureException("심사를 반려할 수 없습니다.");
+        }
+
         screening.reject(adminId, toRejectionReasonType(request.rejectionReason()));
     }
 

--- a/src/main/java/atwoz/atwoz/admin/command/domain/screening/Screening.java
+++ b/src/main/java/atwoz/atwoz/admin/command/domain/screening/Screening.java
@@ -44,6 +44,10 @@ public class Screening extends BaseEntity {
         this.status = status;
     }
 
+    public boolean hasVersionConflict(long version) {
+        return this.version == version;
+    }
+
     public void approve(long adminId) {
         setAdminId(adminId);
         changeScreeningStatus(ScreeningStatus.APPROVED);

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningApproveRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningApproveRequest.java
@@ -1,6 +1,4 @@
 package atwoz.atwoz.admin.presentation.screening;
 
-public record ScreeningApproveRequest(
-
-) {
+public record ScreeningApproveRequest(long version) {
 }

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningApproveRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningApproveRequest.java
@@ -1,0 +1,6 @@
+package atwoz.atwoz.admin.presentation.screening;
+
+public record ScreeningApproveRequest(
+
+) {
+}

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningController.java
@@ -39,9 +39,10 @@ public class ScreeningController {
     @PostMapping("/{screeningId}/approve")
     public ResponseEntity<BaseResponse<Void>> approve(
             @PathVariable long screeningId,
+            @RequestBody ScreeningApproveRequest request,
             @AuthPrincipal AuthContext authContext
     ) {
-        screeningService.approve(screeningId, authContext.getId());
+        screeningService.approve(screeningId, request, authContext.getId());
         return ResponseEntity.ok(BaseResponse.from(OK));
     }
 

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningRejectRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningRejectRequest.java
@@ -10,6 +10,8 @@ public record ScreeningRejectRequest(
                 example = "STOLEN_IMAGE"
         )
         @NotBlank(message = "반려 사유를 선택해주세요.")
-        String rejectionReason
+        String rejectionReason,
+
+        long version
 ) {
 }

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailInterviewView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailInterviewView.java
@@ -1,0 +1,12 @@
+package atwoz.atwoz.admin.query;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ScreeningDetailInterviewView(
+        String question,
+        String answer
+) {
+    @QueryProjection
+    public ScreeningDetailInterviewView {
+    }
+}

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailProfileImageView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailProfileImageView.java
@@ -2,12 +2,12 @@ package atwoz.atwoz.admin.query;
 
 import com.querydsl.core.annotations.QueryProjection;
 
-public record ProfileImageView(
+public record ScreeningDetailProfileImageView(
         String imageUrl,
         int order,
         boolean isPrimary
 ) {
     @QueryProjection
-    public ProfileImageView {
+    public ScreeningDetailProfileImageView {
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailProfileView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailProfileView.java
@@ -1,0 +1,17 @@
+package atwoz.atwoz.admin.query;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ScreeningDetailProfileView(
+        long memberId,
+        String screeningStatus,
+        String rejectionReason,
+        String nickname,
+        int age,
+        String gender,
+        String joinedDate
+) {
+    @QueryProjection
+    public ScreeningDetailProfileView {
+    }
+}

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailQueryRepository.java
@@ -4,11 +4,14 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import static atwoz.atwoz.admin.command.domain.screening.QScreening.screening;
+import static atwoz.atwoz.interview.command.domain.answer.QInterviewAnswer.interviewAnswer;
+import static atwoz.atwoz.interview.command.domain.question.QInterviewQuestion.interviewQuestion;
 import static atwoz.atwoz.member.command.domain.member.QMember.member;
 import static atwoz.atwoz.member.command.domain.profileImage.QProfileImage.profileImage;
-import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.list;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,30 +20,57 @@ public class ScreeningDetailQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     public ScreeningDetailView findById(long screeningId) {
-        return queryFactory
-                .from(member)
-                .join(screening).on(screening.memberId.eq(member.id))
-                .leftJoin(profileImage).on(profileImage.memberId.eq(member.id))
+        long version = Optional.ofNullable(
+                queryFactory
+                        .select(screening.version)
+                        .from(screening)
+                        .where(screening.id.eq(screeningId))
+                        .fetchOne()
+        ).orElse(-1L);
+
+        ScreeningDetailProfileView profile = queryFactory
+                .select(new QScreeningDetailProfileView(
+                        member.id,
+                        screening.status.stringValue(),
+                        screening.rejectionReason.stringValue(),
+                        member.profile.nickname.value,
+                        member.profile.age,
+                        member.profile.gender.stringValue(),
+                        member.createdAt.stringValue()
+                ))
+                .from(screening)
+                .join(member).on(screening.memberId.eq(member.id))
                 .where(screening.id.eq(screeningId))
-                .transform(
-                        groupBy(screening.id).as(
-                                new QScreeningDetailView(
-                                        screening.id,
-                                        member.id,
-                                        screening.status.stringValue(),
-                                        screening.rejectionReason.stringValue(),
-                                        member.profile.nickname.value,
-                                        member.profile.age,
-                                        member.profile.gender.stringValue(),
-                                        member.createdAt.stringValue(),
-                                        list(new QProfileImageView(
-                                                profileImage.imageUrl.value,
-                                                profileImage.order,
-                                                profileImage.isPrimary
-                                        ))
-                                )
-                        )
-                )
-                .get(screeningId);
+                .fetchOne();
+
+        List<ScreeningDetailProfileImageView> profileImages = queryFactory
+                .select(new QScreeningDetailProfileImageView(
+                        profileImage.imageUrl.value,
+                        profileImage.order,
+                        profileImage.isPrimary
+                ))
+                .from(member)
+                .join(profileImage).on(profileImage.memberId.eq(member.id))
+                .where(member.id.eq(profile.memberId()))
+                .fetch();
+
+        List<ScreeningDetailInterviewView> interviews = queryFactory
+                .select(new QScreeningDetailInterviewView(
+                        interviewQuestion.content,
+                        interviewAnswer.content
+                ))
+                .from(member)
+                .join(interviewAnswer).on(member.id.eq(interviewAnswer.memberId))
+                .join(interviewQuestion).on(interviewAnswer.questionId.eq(interviewQuestion.id))
+                .where(interviewQuestion.isPublic.eq(true), interviewAnswer.memberId.eq(profile.memberId()))
+                .fetch();
+
+        return new ScreeningDetailView(
+                screeningId,
+                version,
+                profile,
+                profileImages,
+                interviews
+        );
     }
 }

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningDetailView.java
@@ -1,22 +1,12 @@
 package atwoz.atwoz.admin.query;
 
-import com.querydsl.core.annotations.QueryProjection;
-
 import java.util.List;
 
 public record ScreeningDetailView(
         long screeningId,
-        long memberId,
-        String screeningStatus,
-        String rejectionReason,
-        String nickname,
-        int age,
-        String gender,
-        String joinedDate,
-        List<ProfileImageView> profileImages
-        // TODO: interviews
+        long version,
+        ScreeningDetailProfileView profile,
+        List<ScreeningDetailProfileImageView> profileImages,
+        List<ScreeningDetailInterviewView> interviews
 ) {
-    @QueryProjection
-    public ScreeningDetailView {
-    }
 }

--- a/src/main/java/atwoz/atwoz/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/common/exception/GlobalExceptionHandler.java
@@ -2,9 +2,9 @@ package atwoz.atwoz.common.exception;
 
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
-import jakarta.persistence.OptimisticLockException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,9 +26,9 @@ public class GlobalExceptionHandler {
                 .body(BaseResponse.of(StatusType.BAD_REQUEST, errors));
     }
 
-    @ExceptionHandler(OptimisticLockException.class)
-    public ResponseEntity<BaseResponse<List<String>>> handleOptimisticLockException(OptimisticLockException e) {
-        log.warn("Optimistic lock exception", e);
+    @ExceptionHandler(OptimisticLockingFailureException.class)
+    public ResponseEntity<BaseResponse<List<String>>> handleOptimisticLockingFailureException(OptimisticLockingFailureException e) {
+        log.warn("Optimistic locking failure exception", e);
 
         return ResponseEntity.status(409)
                 .body(BaseResponse.from(StatusType.CONFLICT));

--- a/src/main/java/atwoz/atwoz/interview/command/domain/answer/InterviewAnswer.java
+++ b/src/main/java/atwoz/atwoz/interview/command/domain/answer/InterviewAnswer.java
@@ -1,11 +1,12 @@
 package atwoz.atwoz.interview.command.domain.answer;
 
 import atwoz.atwoz.common.entity.BaseEntity;
-import atwoz.atwoz.interview.command.domain.answer.event.FirstInterviewSubmittedEvent;
 import atwoz.atwoz.common.event.Events;
+import atwoz.atwoz.interview.command.domain.answer.event.FirstInterviewSubmittedEvent;
 import atwoz.atwoz.interview.command.domain.answer.exception.InvalidInterviewAnswerContentException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
@@ -21,6 +22,7 @@ public class InterviewAnswer extends BaseEntity {
 
     private Long memberId;
 
+    @Getter
     private String content;
 
     public static InterviewAnswer of(Long questionId, Long memberId, String content) {

--- a/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
@@ -3,8 +3,8 @@ package atwoz.atwoz.admin.command.application.screening;
 import atwoz.atwoz.admin.command.domain.screening.RejectionReasonType;
 import atwoz.atwoz.admin.command.domain.screening.Screening;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningCommandRepository;
+import atwoz.atwoz.admin.presentation.screening.ScreeningApproveRequest;
 import atwoz.atwoz.admin.presentation.screening.ScreeningRejectRequest;
-import atwoz.atwoz.admin.query.ScreeningDetailQueryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,9 +21,6 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ScreeningServiceTest {
-
-    @Mock
-    private ScreeningDetailQueryRepository screeningDetailQueryRepository;
 
     @Mock
     private ScreeningCommandRepository screeningCommandRepository;
@@ -81,7 +78,7 @@ class ScreeningServiceTest {
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
 
             // when
-            screeningService.approve(screeningId, adminId);
+            screeningService.approve(screeningId, new ScreeningApproveRequest(1L), adminId);
 
             // then
             verify(screening).approve(adminId);
@@ -95,7 +92,7 @@ class ScreeningServiceTest {
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> screeningService.approve(screeningId, 999L))
+            assertThatThrownBy(() -> screeningService.approve(screeningId, new ScreeningApproveRequest(1L), 999L))
                     .isInstanceOf(ScreeningNotFoundException.class);
         }
     }
@@ -115,7 +112,7 @@ class ScreeningServiceTest {
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
 
             String rejectionReason = "STOLEN_IMAGE";
-            ScreeningRejectRequest request = new ScreeningRejectRequest(rejectionReason);
+            ScreeningRejectRequest request = new ScreeningRejectRequest(rejectionReason, 1L);
 
             // when
             screeningService.reject(screeningId, adminId, request);
@@ -131,7 +128,7 @@ class ScreeningServiceTest {
             long screeningId = 1L;
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.empty());
 
-            ScreeningRejectRequest request = new ScreeningRejectRequest("STOLEN_IMAGE");
+            ScreeningRejectRequest request = new ScreeningRejectRequest("STOLEN_IMAGE", 1L);
 
             // when & then
             assertThatThrownBy(() -> screeningService.reject(screeningId, 999L, request))
@@ -146,7 +143,7 @@ class ScreeningServiceTest {
             Screening screening = mock(Screening.class);
             when(screeningCommandRepository.findById(screeningId)).thenReturn(Optional.of(screening));
 
-            ScreeningRejectRequest request = new ScreeningRejectRequest("NON_EXISTING_REASON");
+            ScreeningRejectRequest request = new ScreeningRejectRequest("NON_EXISTING_REASON", 1L);
 
             // when & then
             assertThatThrownBy(() -> screeningService.reject(screeningId, 999L, request))

--- a/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/command/application/screening/ScreeningServiceTest.java
@@ -4,6 +4,7 @@ import atwoz.atwoz.admin.command.domain.screening.RejectionReasonType;
 import atwoz.atwoz.admin.command.domain.screening.Screening;
 import atwoz.atwoz.admin.command.domain.screening.ScreeningCommandRepository;
 import atwoz.atwoz.admin.presentation.screening.ScreeningRejectRequest;
+import atwoz.atwoz.admin.query.ScreeningDetailQueryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,9 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ScreeningServiceTest {
+
+    @Mock
+    private ScreeningDetailQueryRepository screeningDetailQueryRepository;
 
     @Mock
     private ScreeningCommandRepository screeningCommandRepository;


### PR DESCRIPTION
### 관련 이슈
- closes #55 

<br>

### 작업 내용
- 심사 상세 조회에 인터뷰 부분을 추가했습니다.
- 추가로, 낙관적 락이 여러 트랜잭션 범위에서 적용되지 않던 문제를 해결했습니다.

<br>

### 노트
#### `ScreeningDetailView` 조회 쿼리를 분리한 이유
- 기존 쿼리에 인터뷰 로직까지 추가하려다보니 쿼리가 매우 복잡해졌으며, cartesian product로 인해 중복 결과가 발생했습니다.
- 그리고 관리자 페이지는 쿼리의 성능보다는 가독성, 유지보수성이 중요하다고 판단했고, 단일 쿼리로 작성한다해서 무조건 빠르다는 보장도 없으므로 여러 쿼리를 조합하는 방식으로 변경했습니다.

#### 낙관적 락 관련 문제
- 기존 낙관적 락은 data jpa에서 자동으로 관리하는 version 필드를 통해 '동시에' 수정을 시도할 시 예외를 던졌습니다.
- 하지만 저희가 원하던 경우에 대해서는 예외를 뱉지 않았습니다.
- 따라서 낙관적 락을 이용한 트랜잭션 충돌 방지를 여러 트랜잭션으로 확장함으로써 문제를 해결했습니다.