### PR TITLE
매치 요청 

### DIFF
--- a/src/main/java/atwoz/atwoz/common/exception/CannotGetLockException.java
+++ b/src/main/java/atwoz/atwoz/common/exception/CannotGetLockException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.common.exception;
+
+public class CannotGetLockException extends RuntimeException {
+    public CannotGetLockException() {
+        super("잠금을 획득하지 못하였습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/common/exception/GlobalExceptionHandler.java
@@ -34,6 +34,14 @@ public class GlobalExceptionHandler {
                 .body(BaseResponse.from(StatusType.CONFLICT));
     }
 
+    @ExceptionHandler(CannotGetLockException.class)
+    public ResponseEntity<BaseResponse<Void>> handleCannotGetLockException(CannotGetLockException e) {
+        log.warn("Can not Get NamedLock Exception", e);
+
+        return ResponseEntity.status(409)
+                .body(BaseResponse.from(StatusType.CONFLICT));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse<Void>> handleGlobalException(Exception exception, HttpServletRequest request) {
         String requestInfo = "Request URI: " + request.getRequestURI() + ", Method: " + request.getMethod();

--- a/src/main/java/atwoz/atwoz/common/repository/LockRepository.java
+++ b/src/main/java/atwoz/atwoz/common/repository/LockRepository.java
@@ -1,4 +1,4 @@
-package atwoz.atwoz.match.command.infra.match;
+package atwoz.atwoz.common.repository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -6,14 +6,12 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class MatchJdbcRepository {
-
+public class LockRepository {
     private final JdbcTemplate jdbcTemplate;
-    private final static int LOCK_HOLD_TIME = 10;
 
-    public void getLock(String key) {
+    public void getLock(String key, int lockWaitingTime) {
         String sql = "SELECT GET_LOCK(?, ?)";
-        jdbcTemplate.queryForObject(sql, Boolean.class, key, LOCK_HOLD_TIME);
+        jdbcTemplate.queryForObject(sql, Boolean.class, lockWaitingTime);
     }
 
     public void releaseLock(String key) {

--- a/src/main/java/atwoz/atwoz/common/repository/LockRepository.java
+++ b/src/main/java/atwoz/atwoz/common/repository/LockRepository.java
@@ -11,7 +11,7 @@ public class LockRepository {
 
     public void getLock(String key, int lockWaitingTime) {
         String sql = "SELECT GET_LOCK(?, ?)";
-        jdbcTemplate.queryForObject(sql, Boolean.class, lockWaitingTime);
+        jdbcTemplate.queryForObject(sql, Boolean.class, key, lockWaitingTime);
     }
 
     public void releaseLock(String key) {

--- a/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
@@ -1,0 +1,38 @@
+package atwoz.atwoz.match.command.application.match;
+
+import atwoz.atwoz.match.command.application.match.exception.ExistsMatchException;
+import atwoz.atwoz.match.command.domain.match.Match;
+import atwoz.atwoz.match.command.domain.match.MatchRepository;
+import atwoz.atwoz.match.command.domain.match.vo.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchService {
+    private final MatchRepository matchRepository;
+
+    @Transactional
+    public void request(Long requesterId, Long responderId, String requestMessage) {
+        String key = generateKey(requesterId, responderId);
+
+        matchRepository.withNamedLock(key, () -> {
+            if (existsMutualMatch(requesterId, responderId)) {
+                throw new ExistsMatchException();
+            }
+
+            Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
+            matchRepository.save(match);
+        });
+    }
+
+
+    private boolean existsMutualMatch(Long requesterId, Long responderId) {
+        return matchRepository.existsActiveMatchBetween(requesterId, responderId);
+    }
+
+    private String generateKey(Long requesterId, Long responderId) {
+        return Math.max(requesterId, responderId) + "" + Math.min(requesterId, responderId);
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/application/match/exception/ExistsMatchException.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/exception/ExistsMatchException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.match.command.application.match.exception;
+
+public class ExistsMatchException extends RuntimeException {
+    public ExistsMatchException() {
+        super("이미 상대방과의 매치가 존재합니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
@@ -45,6 +45,7 @@ public class Match {
     public static Match request(long requesterId, long responderId, @NonNull Message requestMessage) {
         /**
          * TODO : 매칭을 요청하는 경우, 하트 소비 이벤트 발행!
+         * TODO : 상대방에게 알림을 발생시키기 위한 이벤트 발행!
          */
         return Match.builder()
                 .requesterId(requesterId)

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.match.command.domain.match;
 
 import atwoz.atwoz.common.event.Events;
+import atwoz.atwoz.match.command.domain.match.event.MatchRequestCompletedEvent;
 import atwoz.atwoz.match.command.domain.match.event.MatchRequestedEvent;
 import atwoz.atwoz.match.command.domain.match.exception.InvalidMatchStatusChangeException;
 import atwoz.atwoz.match.command.domain.match.vo.Message;
@@ -63,6 +64,7 @@ public class Match {
 
     public static Match request(long requesterId, long responderId, @NonNull Message requestMessage) {
         Events.raise(MatchRequestedEvent.of(requesterId, responderId));
+        Events.raise(MatchRequestCompletedEvent.of(requesterId, responderId));
 
         return Match.builder()
                 .requesterId(requesterId)

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
@@ -41,6 +41,7 @@ public class Match {
     })
     private Message responseMessage;
 
+    @Getter
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)")
     private MatchStatus status;
@@ -61,10 +62,6 @@ public class Match {
     }
 
     public static Match request(long requesterId, long responderId, @NonNull Message requestMessage) {
-        /**
-         * TODO : 매칭을 요청하는 경우, 하트 소비 이벤트 발행!
-         * TODO : 상대방에게 알림을 발생시키기 위한 이벤트 발행!
-         */
         Events.raise(MatchRequestedEvent.of(requesterId, responderId));
 
         return Match.builder()

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/MatchRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/MatchRepository.java
@@ -3,7 +3,7 @@ package atwoz.atwoz.match.command.domain.match;
 public interface MatchRepository {
     void save(Match match);
 
-    boolean existsActiveMatchBetween(Long idOne, Long idTwo);
+    boolean existsActiveMatchBetween(Long memberId, Long anotherMemberId);
 
     void withNamedLock(String key, Runnable action);
 }

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/MatchRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/MatchRepository.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.match.command.domain.match;
+
+public interface MatchRepository {
+    void save(Match match);
+
+    boolean existsActiveMatchBetween(Long idOne, Long idTwo);
+
+    void withNamedLock(String key, Runnable action);
+}

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/MatchStatus.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/MatchStatus.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum MatchStatus {
     WAITING("응답 대기중"),
     MATCHED("매칭 완료."),
+    EXPIRED("만료됨"),
     REJECTED("거절");
 
     private final String description;

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRequestCompletedEvent.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRequestCompletedEvent.java
@@ -1,0 +1,17 @@
+package atwoz.atwoz.match.command.domain.match.event;
+
+import atwoz.atwoz.common.event.Event;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchRequestCompletedEvent extends Event {
+    private final Long requesterId;
+    private final Long responderId;
+
+    public static MatchRequestCompletedEvent of(Long requesterId, Long responderId) {
+        return new MatchRequestCompletedEvent(requesterId, responderId);
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRequestedEvent.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRequestedEvent.java
@@ -1,0 +1,17 @@
+package atwoz.atwoz.match.command.domain.match.event;
+
+import atwoz.atwoz.common.event.Event;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchRequestedEvent extends Event {
+    private final Long requesterId;
+    private final Long responderId;
+
+    public static MatchRequestedEvent of(Long requesterId, Long responderId) {
+        return new MatchRequestedEvent(requesterId, responderId);
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/exception/InvalidMatchStatusChangeException.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/exception/InvalidMatchStatusChangeException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.match.command.domain.match.exception;
+
+public class InvalidMatchStatusChangeException extends RuntimeException {
+    public InvalidMatchStatusChangeException() {
+        super("대기 상태일때 매치 상태를 변경할 수 있습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJdbcRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJdbcRepository.java
@@ -1,0 +1,23 @@
+package atwoz.atwoz.match.command.infra.match;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final static int LOCK_HOLD_TIME = 10;
+
+    public void getLock(String key) {
+        String sql = "SELECT GET_LOCK(?, ?)";
+        jdbcTemplate.queryForObject(sql, Boolean.class, key, LOCK_HOLD_TIME);
+    }
+
+    public void releaseLock(String key) {
+        String sql = "SELECT RELEASE_LOCK(?)";
+        jdbcTemplate.queryForObject(sql, Boolean.class, key);
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
@@ -10,9 +10,9 @@ public interface MatchJpaRepository extends JpaRepository<Match, Long> {
             SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false 
             END
             FROM Match m
-            WHERE ((m.requesterId = :idOne AND m.responderId = :idTwo)
-            OR (m.requesterId = :idTwo AND m.responderId = :idOne))
+            WHERE ((m.requesterId = :memberId AND m.responderId = :anotherMemberId)
+            OR (m.requesterId = :anotherMemberId AND m.responderId = :memberId))
             AND m.status <> 'EXPIRED'
             """)
-    boolean existsActiveMatchBetween(Long idOne, Long idTwo);
+    boolean existsActiveMatchBetween(Long memberId, Long anotherMemberId);
 }

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
@@ -1,0 +1,19 @@
+package atwoz.atwoz.match.command.infra.match;
+
+import atwoz.atwoz.match.command.domain.match.Match;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MatchJpaRepository extends JpaRepository<Match, Long> {
+
+    @Query(value = """
+            SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END
+            FROM Match m
+            WHERE (m.requesterId = :idOne AND m.responderId = :idTwo)
+            OR (m.requesterId = :idTwo AND m.responderId = :idOne)
+            AND m.status <> 'EXPIRED'
+            """)
+    boolean existsActiveMatchBetween(Long idOne, Long idTwo);
+
+
+}

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
@@ -7,13 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 public interface MatchJpaRepository extends JpaRepository<Match, Long> {
 
     @Query(value = """
-            SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END
+            SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false 
+            END
             FROM Match m
-            WHERE (m.requesterId = :idOne AND m.responderId = :idTwo)
-            OR (m.requesterId = :idTwo AND m.responderId = :idOne)
+            WHERE ((m.requesterId = :idOne AND m.responderId = :idTwo)
+            OR (m.requesterId = :idTwo AND m.responderId = :idOne))
             AND m.status <> 'EXPIRED'
             """)
     boolean existsActiveMatchBetween(Long idOne, Long idTwo);
-
-
 }

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.match.command.infra.match;
 
+import atwoz.atwoz.common.repository.LockRepository;
 import atwoz.atwoz.match.command.domain.match.Match;
 import atwoz.atwoz.match.command.domain.match.MatchRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MatchRepositoryImpl implements MatchRepository {
     private final MatchJpaRepository matchJpaRepository;
-    private final MatchJdbcRepository matchJdbcRepository;
+    private final LockRepository lockRepository;
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -27,10 +28,10 @@ public class MatchRepositoryImpl implements MatchRepository {
     @Override
     public void withNamedLock(String key, Runnable action) {
         try {
-            matchJdbcRepository.getLock(key);
+            lockRepository.getLock(key, 10);
             action.run();
         } finally {
-            matchJdbcRepository.releaseLock(key);
+            lockRepository.releaseLock(key);
         }
     }
 }

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
@@ -21,8 +21,8 @@ public class MatchRepositoryImpl implements MatchRepository {
     }
 
     @Override
-    public boolean existsActiveMatchBetween(Long idOne, Long idTwo) {
-        return matchJpaRepository.existsActiveMatchBetween(idOne, idTwo);
+    public boolean existsActiveMatchBetween(Long memberId, Long anotherMemberId) {
+        return matchJpaRepository.existsActiveMatchBetween(memberId, anotherMemberId);
     }
 
     @Override

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
@@ -1,9 +1,11 @@
 package atwoz.atwoz.match.command.infra.match;
 
+import atwoz.atwoz.common.exception.CannotGetLockException;
 import atwoz.atwoz.common.repository.LockRepository;
 import atwoz.atwoz.match.command.domain.match.Match;
 import atwoz.atwoz.match.command.domain.match.MatchRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +32,8 @@ public class MatchRepositoryImpl implements MatchRepository {
         try {
             lockRepository.getLock(key, 10);
             action.run();
+        } catch (DataAccessException e) {
+            throw new CannotGetLockException();
         } finally {
             lockRepository.releaseLock(key);
         }

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
@@ -1,0 +1,36 @@
+package atwoz.atwoz.match.command.infra.match;
+
+import atwoz.atwoz.match.command.domain.match.Match;
+import atwoz.atwoz.match.command.domain.match.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchRepositoryImpl implements MatchRepository {
+    private final MatchJpaRepository matchJpaRepository;
+    private final MatchJdbcRepository matchJdbcRepository;
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void save(Match match) {
+        matchJpaRepository.save(match);
+    }
+
+    @Override
+    public boolean existsActiveMatchBetween(Long idOne, Long idTwo) {
+        return matchJpaRepository.existsActiveMatchBetween(idOne, idTwo);
+    }
+
+    @Override
+    public void withNamedLock(String key, Runnable action) {
+        try {
+            matchJdbcRepository.getLock(key);
+            action.run();
+        } finally {
+            matchJdbcRepository.releaseLock(key);
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
@@ -1,0 +1,24 @@
+package atwoz.atwoz.match.presentation;
+
+import atwoz.atwoz.auth.presentation.AuthContext;
+import atwoz.atwoz.auth.presentation.AuthPrincipal;
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.match.command.application.match.MatchService;
+import atwoz.atwoz.match.presentation.dto.MatchRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/match")
+@RequiredArgsConstructor
+public class MatchController {
+    private final MatchService matchService;
+
+    @PostMapping("/request/{id}")
+    public ResponseEntity<BaseResponse<Void>> requestMatch(@PathVariable("id") long responderId, @RequestBody MatchRequestDto matchRequestDto, @AuthPrincipal AuthContext authContext) {
+        matchService.request(authContext.getId(), responderId, matchRequestDto.requestMessage());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
@@ -16,9 +16,9 @@ import org.springframework.web.bind.annotation.*;
 public class MatchController {
     private final MatchService matchService;
 
-    @PostMapping("/request/{id}")
-    public ResponseEntity<BaseResponse<Void>> requestMatch(@PathVariable("id") long responderId, @RequestBody MatchRequestDto matchRequestDto, @AuthPrincipal AuthContext authContext) {
-        matchService.request(authContext.getId(), responderId, matchRequestDto.requestMessage());
+    @PostMapping("/request")
+    public ResponseEntity<BaseResponse<Void>> requestMatch(@RequestBody MatchRequestDto matchRequestDto, @AuthPrincipal AuthContext authContext) {
+        matchService.request(authContext.getId(), matchRequestDto);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/match/presentation/MatchExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/MatchExceptionHandler.java
@@ -1,0 +1,25 @@
+package atwoz.atwoz.match.presentation;
+
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.match.command.application.match.exception.ExistsMatchException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice
+public class MatchExceptionHandler {
+
+    @ExceptionHandler(ExistsMatchException.class)
+    public ResponseEntity<BaseResponse<Void>> handleExistsMatchException(ExistsMatchException e) {
+        log.warn("매치 요청에 실패하였습니다. {}", e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.from(StatusType.BAD_REQUEST));
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/presentation/dto/MatchRequestDto.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/dto/MatchRequestDto.java
@@ -1,0 +1,8 @@
+package atwoz.atwoz.match.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MatchRequestDto(
+        @NotNull(message = "메세지를 입력해주세요.") String requestMessage
+) {
+}

--- a/src/main/java/atwoz/atwoz/match/presentation/dto/MatchRequestDto.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/dto/MatchRequestDto.java
@@ -1,8 +1,10 @@
 package atwoz.atwoz.match.presentation.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record MatchRequestDto(
-        @NotNull(message = "메세지를 입력해주세요.") String requestMessage
+        @NotNull(message = "응답자 아이디를 입력해주세요.") Long responderId,
+        @NotBlank(message = "메세지를 입력해주세요.") String requestMessage
 ) {
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/profileimage/ProfileImageController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/profileimage/ProfileImageController.java
@@ -5,6 +5,7 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.member.command.application.profileImage.ProfileImageService;
+import atwoz.atwoz.member.command.application.profileImage.dto.ProfileImageUploadResponse;
 import atwoz.atwoz.member.presentation.profileimage.dto.ProfileImageUploadRequestWrapper;
 import atwoz.atwoz.member.query.profileimage.ProfileImageQueryRepository;
 import atwoz.atwoz.member.query.profileimage.view.ProfileImageView;
@@ -25,9 +26,8 @@ public class ProfileImageController {
     private final ProfileImageQueryRepository profileImageQueryRepository;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<BaseResponse<Void>> updateProfileImage(@ModelAttribute @Valid ProfileImageUploadRequestWrapper request, @AuthPrincipal AuthContext authContext) {
-        profileImageService.save(authContext.getId(), request.getRequests());
-        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    public ResponseEntity<BaseResponse<List<ProfileImageUploadResponse>>> updateProfileImage(@ModelAttribute @Valid ProfileImageUploadRequestWrapper request, @AuthPrincipal AuthContext authContext) {
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, profileImageService.save(authContext.getId(), request.getRequests())));
     }
 
     @DeleteMapping("/{id}")

--- a/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
@@ -2,6 +2,7 @@ package atwoz.atwoz.match.command.application.match;
 
 import atwoz.atwoz.match.command.application.match.exception.ExistsMatchException;
 import atwoz.atwoz.match.command.domain.match.MatchRepository;
+import atwoz.atwoz.match.presentation.dto.MatchRequestDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ public class MatchServiceTest {
         Long requesterId = 1L;
         Long responderId = 2L;
         String requestMessage = "매칭을 요청합니다!";
+        MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
 
         Mockito.doAnswer(invocation -> {
             Runnable runnable = invocation.getArgument(1);
@@ -34,11 +36,11 @@ public class MatchServiceTest {
             return null;
         }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
 
-        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, responderId))
+        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
                 .thenReturn(true);
 
         // When & Then
-        Assertions.assertThatThrownBy(() -> matchService.request(requesterId, responderId, requestMessage))
+        Assertions.assertThatThrownBy(() -> matchService.request(requesterId, requestDto))
                 .isInstanceOf(ExistsMatchException.class);
     }
 
@@ -50,6 +52,7 @@ public class MatchServiceTest {
         Long requesterId = 1L;
         Long responderId = 2L;
         String requestMessage = "매칭을 요청합니다!";
+        MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
 
         Mockito.doAnswer(invocation -> {
             Runnable runnable = invocation.getArgument(1);
@@ -57,11 +60,11 @@ public class MatchServiceTest {
             return null;
         }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
 
-        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, responderId))
+        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
                 .thenReturn(false);
 
         // When
-        matchService.request(requesterId, responderId, requestMessage);
+        matchService.request(requesterId, requestDto);
 
         // Then
         Mockito.verify(matchRepository).save(

--- a/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
@@ -1,0 +1,73 @@
+package atwoz.atwoz.match.command.application.match;
+
+import atwoz.atwoz.match.command.application.match.exception.ExistsMatchException;
+import atwoz.atwoz.match.command.domain.match.MatchRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MatchServiceTest {
+
+    @Mock
+    private MatchRepository matchRepository;
+
+    @InjectMocks
+    private MatchService matchService;
+
+    @Test
+    @DisplayName("이미 두 유저간의 진행중인 매치가 존재하는 경우, 예외 발생")
+    void throwsExceptionWhenExistsMatch() {
+        // Given
+        Long requesterId = 1L;
+        Long responderId = 2L;
+        String requestMessage = "매칭을 요청합니다!";
+
+        Mockito.doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(1);
+            runnable.run();
+            return null;
+        }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
+
+        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, responderId))
+                .thenReturn(true);
+
+        // When & Then
+        Assertions.assertThatThrownBy(() -> matchService.request(requesterId, responderId, requestMessage))
+                .isInstanceOf(ExistsMatchException.class);
+    }
+
+
+    @Test
+    @DisplayName("두 유저 사이의 매치가 존재하지 않는 경우 매치 생성.")
+    void createMatch() {
+        // Given
+        Long requesterId = 1L;
+        Long responderId = 2L;
+        String requestMessage = "매칭을 요청합니다!";
+
+        Mockito.doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(1);
+            runnable.run();
+            return null;
+        }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
+
+        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, responderId))
+                .thenReturn(false);
+
+        // When
+        matchService.request(requesterId, responderId, requestMessage);
+
+        // Then
+        Mockito.verify(matchRepository).save(
+                Mockito.argThat(match -> match.getRequesterId().equals(requesterId) &&
+                        match.getResponderId().equals(responderId) &&
+                        match.getRequestMessage().getValue().equals(requestMessage))
+        );
+    }
+}

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchRepositoryTest.java
@@ -1,0 +1,83 @@
+package atwoz.atwoz.match.command.domain.match;
+
+import atwoz.atwoz.common.repository.LockRepository;
+import atwoz.atwoz.match.command.domain.match.vo.Message;
+import atwoz.atwoz.match.command.infra.match.MatchRepositoryImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@Import({MatchRepositoryImpl.class, LockRepository.class})
+@DataJpaTest
+public class MatchRepositoryTest {
+
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("서로 매치가 존재하는 경우 True 반환.")
+    void getTrueWhenMatchExistsBetween() {
+        // Given
+        Long responderId = 1L;
+        Long requesterId = 2L;
+        String requestMessage = "매치를 신청합니다.";
+
+        Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
+        entityManager.persist(match);
+        entityManager.flush();
+
+        // When
+        boolean result = matchRepository.existsActiveMatchBetween(requesterId, responderId);
+        boolean otherResult = matchRepository.existsActiveMatchBetween(responderId, requesterId);
+
+        // Then
+        Assertions.assertThat(result).isTrue();
+        Assertions.assertThat(otherResult).isTrue();
+    }
+
+    @Test
+    @DisplayName("매치가 존재하지 않는 경우 False 반환")
+    void getFalseWhenMatchNotExistsBetween() {
+        // Given
+        Long requesterId = 1L;
+        Long responderId = 2L;
+
+        // When
+        boolean result = matchRepository.existsActiveMatchBetween(requesterId, responderId);
+        boolean otherResult = matchRepository.existsActiveMatchBetween(responderId, requesterId);
+
+        // Then
+        Assertions.assertThat(result).isFalse();
+        Assertions.assertThat(otherResult).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 매치가 존재하는 경우 False 반환")
+    void getFalseWhenExpiredMatchExistsBetween() {
+        // Given
+        Long requesterId = 1L;
+        Long responderId = 2L;
+
+        String requestMessage = "매치를 신청합니다.";
+
+        Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
+        match.expired();
+        entityManager.persist(match);
+        entityManager.flush();
+
+        // When
+        boolean result = matchRepository.existsActiveMatchBetween(requesterId, responderId);
+        boolean otherResult = matchRepository.existsActiveMatchBetween(responderId, requesterId);
+
+        // Then
+        Assertions.assertThat(result).isFalse();
+        Assertions.assertThat(otherResult).isFalse();
+    }
+}

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
@@ -38,7 +38,7 @@ public class MatchTest {
     void throwsExceptionWhenMessageIsNull() {
         // Given
         Long requesterId = 1L;
-        Long responderId = null;
+        Long responderId = 2L;
         Message requestMessage = null;
 
         // When & Then

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
@@ -3,63 +3,71 @@ package atwoz.atwoz.match.command.domain.match;
 import atwoz.atwoz.match.command.domain.match.vo.Message;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class MatchTest {
 
-    @Test
-    @DisplayName("요청자 아이디가 null인 경우 예외 반환")
-    void throwsExceptionWhenRequesterIdIsNull() {
-        // Given
-        Long requesterId = null;
-        Long responderId = 2L;
-        Message requestMessage = Message.from("매칭을 요청합니다!");
+    @Nested
+    class Request {
+        @Test
+        @DisplayName("요청자 아이디가 null인 경우 예외 반환")
+        void throwsExceptionWhenRequesterIdIsNull() {
+            // Given
+            Long requesterId = null;
+            Long responderId = 2L;
+            Message requestMessage = Message.from("매칭을 요청합니다!");
 
-        // When & Then
-        Assertions.assertThatThrownBy(() -> Match.request(requesterId, responderId, requestMessage))
-                .isInstanceOf(NullPointerException.class);
+            // When & Then
+            Assertions.assertThatThrownBy(() -> Match.request(requesterId, responderId, requestMessage))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("응답자 아이디가 null인 경우 예외 반환")
+        void throwsExceptionWhenResponderIdIsNull() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = null;
+            Message requestMessage = Message.from("매칭을 요청합니다!");
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> Match.request(requesterId, responderId, requestMessage))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("요청 메세지가 null인 경우 예외 반환")
+        void throwsExceptionWhenMessageIsNull() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Message requestMessage = null;
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> Match.request(requesterId, responderId, requestMessage))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("모든 값이 null이 아닌 경우 성공.")
+        void createMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Message requestMessage = Message.from("매칭을 요청합니다.");
+
+            // When
+            Match match = Match.request(requesterId, responderId, requestMessage);
+
+            // Then
+            Assertions.assertThat(match.getRequesterId()).isEqualTo(requesterId);
+            Assertions.assertThat(match.getResponderId()).isEqualTo(responderId);
+            Assertions.assertThat(match.getRequestMessage()).isEqualTo(requestMessage);
+        }
     }
 
-    @Test
-    @DisplayName("응답자 아이디가 null인 경우 예외 반환")
-    void throwsExceptionWhenResponderIdIsNull() {
-        // Given
-        Long requesterId = 1L;
-        Long responderId = null;
-        Message requestMessage = Message.from("매칭을 요청합니다!");
 
-        // When & Then
-        Assertions.assertThatThrownBy(() -> Match.request(requesterId, responderId, requestMessage))
-                .isInstanceOf(NullPointerException.class);
-    }
 
-    @Test
-    @DisplayName("요청 메세지가 null인 경우 예외 반환")
-    void throwsExceptionWhenMessageIsNull() {
-        // Given
-        Long requesterId = 1L;
-        Long responderId = 2L;
-        Message requestMessage = null;
 
-        // When & Then
-        Assertions.assertThatThrownBy(() -> Match.request(requesterId, responderId, requestMessage))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("모든 값이 null이 아닌 경우 성공.")
-    void createMatch() {
-        // Given
-        Long requesterId = 1L;
-        Long responderId = 2L;
-        Message requestMessage = Message.from("매칭을 요청합니다.");
-
-        // When
-        Match match = Match.request(requesterId, responderId, requestMessage);
-
-        // Then
-        Assertions.assertThat(match.getRequesterId()).isEqualTo(requesterId);
-        Assertions.assertThat(match.getResponderId()).isEqualTo(responderId);
-        Assertions.assertThat(match.getRequestMessage()).isEqualTo(requestMessage);
-    }
 }

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.match.command.domain.match;
 
+import atwoz.atwoz.match.command.domain.match.exception.InvalidMatchStatusChangeException;
 import atwoz.atwoz.match.command.domain.match.vo.Message;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 public class MatchTest {
 
     @Nested
+    @DisplayName("매치 요청 테스트")
     class Request {
         @Test
         @DisplayName("요청자 아이디가 null인 경우 예외 반환")
@@ -67,7 +69,39 @@ public class MatchTest {
         }
     }
 
+    @Nested
+    @DisplayName("매치 상태 변경 테스트")
+    class ChangeStatus {
 
+        @Test
+        @DisplayName("현재 값이 Waiting 상태가 아닌 경우, 예외 반환")
+        void throwsExceptionWhenStatusIsNotWaiting() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Message requestMessage = Message.from("매칭을 요청합니다.");
+            Match match = Match.request(requesterId, responderId, requestMessage);
+            match.expired();
 
+            // When & Then
+            Assertions.assertThatThrownBy(() -> match.approve())
+                    .isInstanceOf(InvalidMatchStatusChangeException.class);
+        }
 
+        @Test
+        @DisplayName("현재 값이 Waiting 상태인 경우, 예외 반환")
+        void changeStatus() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Message requestMessage = Message.from("매칭을 요청합니다.");
+            Match match = Match.request(requesterId, responderId, requestMessage);
+
+            // When
+            match.approve();
+
+            // Then
+            Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.MATCHED);
+        }
+    }
 }


### PR DESCRIPTION
### 관련 이슈
- #95 

<br>

### 작업 내용
- 매치 요청시 발생할 가능성이 존재하는 동시성 문제를 고려하여, 네임드 락 방식을 채택.
- 매치 요청 서비스 구현
- 테스트 코드 작성

<br>

### 참고 자료
- https://techblog.woowahan.com/2631  

<br>

### 노트
- 네임드 락이 저희 스펙에서 좋은 수단인 것 같습니다. (MySQL 지원)
- 소개팅 서비스 특성 상 매칭 작업이 빈번하게 발생할텐데, 락을 대기하는 스레드가 늘어난다면 다른 클라이언트의 쿼리 요청을 처리할 스레드의 부족으로 병목 현상이 발생하지 않을까? 하는 걱정이 있습니다! : 추후, 성능 테스트를 통해 확인하면 좋을 것 같습니다!
- 금빈님께서 프로필 이미지 업로드 후, 바로 데이터를 전송해주는 것이 좋을 것 같다고 하셔서 해당 PR에 함께 수정하였습니다.

#### 문제 상황

<img width="850" alt="image" src="https://github.com/user-attachments/assets/83a32be0-d3ba-4877-8866-7d95f3217c17" />

두 사용자간의 매칭이 2개가 생성되는 문제.


#### 동시 테스트 결과

![image](https://github.com/user-attachments/assets/f03652b8-9834-4f9e-bd41-aca9856a6b5d)

해당 로그를 보시면, 83번 쿼리가 락을 얻은 뒤 매치 생성을 위한 새로운 트랜잭션(84번)을 생성하여 커밋을 한 뒤 락을 해제하여 해당 트랜잭션을 해제하였습니다. 

이후 82번, 81번 쿼리는 각각의 트랜잭션에서는 이미 매칭이 존재하기 때문에 락을 해제하며 rollback 이 발생하는 것을 확인할 수 있습니다!


