### PR TITLE
매치 응답 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
@@ -34,13 +34,13 @@ public class MatchService {
     @Transactional
     public void approve(Long responderId, MatchResponseDto respondDto) {
         Match match = getWaitingMatchByIdAndResponderId(respondDto.matchId(), responderId);
-        match.approve();
+        match.approve(Message.from(respondDto.responseMessage()));
     }
 
     @Transactional
     public void reject(Long responderId, MatchResponseDto respondDto) {
         Match match = getWaitingMatchByIdAndResponderId(respondDto.matchId(), responderId);
-        match.reject();
+        match.reject(Message.from(respondDto.responseMessage()));
     }
 
     @Transactional

--- a/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
@@ -33,19 +33,19 @@ public class MatchService {
 
     @Transactional
     public void approve(Long responderId, MatchResponseDto respondDto) {
-        Match match = getWaitingMatchById(respondDto.matchId());
+        Match match = getWaitingMatchByIdAndResponderId(respondDto.matchId(), responderId);
         match.approve();
     }
 
     @Transactional
     public void reject(Long responderId, MatchResponseDto respondDto) {
-        Match match = getWaitingMatchById(respondDto.matchId());
+        Match match = getWaitingMatchByIdAndResponderId(respondDto.matchId(), responderId);
         match.reject();
     }
 
     @Transactional
     public void rejectCheck(Long memberId, Long matchId) {
-        Match match = getRejectedMatchById(matchId);
+        Match match = getRejectedMatchByIdAndRequesterId(matchId, memberId);
         match.checkRejected();
     }
 
@@ -57,14 +57,18 @@ public class MatchService {
         return Math.max(requesterId, responderId) + ":" + Math.min(requesterId, responderId);
     }
 
-    private Match getWaitingMatchById(Long id) {
-        Match match = matchRepository.findById(id).orElseThrow(MatchNotFoundException::new);
+    private Match getWaitingMatchByIdAndResponderId(Long id, Long responderId) {
+        Match match = matchRepository.findByIdAndResponderId(id, responderId)
+                .orElseThrow(MatchNotFoundException::new);
+
         if (match.getStatus() != MatchStatus.WAITING) throw new MatchNotFoundException();
         return match;
     }
 
-    private Match getRejectedMatchById(Long id) {
-        Match match = matchRepository.findById(id).orElseThrow(MatchNotFoundException::new);
+    private Match getRejectedMatchByIdAndRequesterId(Long id, Long requesterId) {
+        Match match = matchRepository.findByIdAndRequesterId(id, requesterId)
+                .orElseThrow(MatchNotFoundException::new);
+
         if (match.getStatus() != MatchStatus.REJECTED) throw new MatchNotFoundException();
         return match;
     }

--- a/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.match.command.application.match;
 
 import atwoz.atwoz.match.command.application.match.exception.ExistsMatchException;
+import atwoz.atwoz.match.command.application.match.exception.InvalidMatchUpdateException;
 import atwoz.atwoz.match.command.application.match.exception.MatchNotFoundException;
 import atwoz.atwoz.match.command.domain.match.Match;
 import atwoz.atwoz.match.command.domain.match.MatchRepository;
@@ -38,14 +39,14 @@ public class MatchService {
     }
 
     @Transactional
-    public void reject(Long matchId, Long responderId, MatchResponseDto respondDto) {
+    public void reject(Long matchId, Long responderId) {
         Match match = getWaitingMatchByIdAndResponderId(matchId, responderId);
-        match.reject(Message.from(respondDto.responseMessage()));
+        match.reject();
     }
 
     @Transactional
-    public void rejectCheck(Long memberId, Long matchId) {
-        Match match = getRejectedMatchByIdAndRequesterId(matchId, memberId);
+    public void rejectCheck(Long requesterId, Long matchId) {
+        Match match = getRejectedMatchByIdAndRequesterId(matchId, requesterId);
         match.checkRejected();
     }
 
@@ -61,7 +62,7 @@ public class MatchService {
         Match match = matchRepository.findByIdAndResponderId(id, responderId)
                 .orElseThrow(MatchNotFoundException::new);
 
-        if (match.getStatus() != MatchStatus.WAITING) throw new MatchNotFoundException();
+        if (match.getStatus() != MatchStatus.WAITING) throw new InvalidMatchUpdateException();
         return match;
     }
 
@@ -69,7 +70,7 @@ public class MatchService {
         Match match = matchRepository.findByIdAndRequesterId(id, requesterId)
                 .orElseThrow(MatchNotFoundException::new);
 
-        if (match.getStatus() != MatchStatus.REJECTED) throw new MatchNotFoundException();
+        if (match.getStatus() != MatchStatus.REJECTED) throw new InvalidMatchUpdateException();
         return match;
     }
 }

--- a/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
@@ -32,14 +32,14 @@ public class MatchService {
     }
 
     @Transactional
-    public void approve(Long responderId, MatchResponseDto respondDto) {
-        Match match = getWaitingMatchByIdAndResponderId(respondDto.matchId(), responderId);
+    public void approve(Long matchId, Long responderId, MatchResponseDto respondDto) {
+        Match match = getWaitingMatchByIdAndResponderId(matchId, responderId);
         match.approve(Message.from(respondDto.responseMessage()));
     }
 
     @Transactional
-    public void reject(Long responderId, MatchResponseDto respondDto) {
-        Match match = getWaitingMatchByIdAndResponderId(respondDto.matchId(), responderId);
+    public void reject(Long matchId, Long responderId, MatchResponseDto respondDto) {
+        Match match = getWaitingMatchByIdAndResponderId(matchId, responderId);
         match.reject(Message.from(respondDto.responseMessage()));
     }
 

--- a/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/MatchService.java
@@ -1,10 +1,13 @@
 package atwoz.atwoz.match.command.application.match;
 
 import atwoz.atwoz.match.command.application.match.exception.ExistsMatchException;
+import atwoz.atwoz.match.command.application.match.exception.MatchNotFoundException;
 import atwoz.atwoz.match.command.domain.match.Match;
 import atwoz.atwoz.match.command.domain.match.MatchRepository;
+import atwoz.atwoz.match.command.domain.match.MatchStatus;
 import atwoz.atwoz.match.command.domain.match.vo.Message;
 import atwoz.atwoz.match.presentation.dto.MatchRequestDto;
+import atwoz.atwoz.match.presentation.dto.MatchResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +31,23 @@ public class MatchService {
         });
     }
 
+    @Transactional
+    public void approve(Long responderId, MatchResponseDto respondDto) {
+        Match match = getWaitingMatchById(respondDto.matchId());
+        match.approve();
+    }
+
+    @Transactional
+    public void reject(Long responderId, MatchResponseDto respondDto) {
+        Match match = getWaitingMatchById(respondDto.matchId());
+        match.reject();
+    }
+
+    @Transactional
+    public void rejectCheck(Long memberId, Long matchId) {
+        Match match = getRejectedMatchById(matchId);
+        match.checkRejected();
+    }
 
     private boolean existsMutualMatch(Long requesterId, Long responderId) {
         return matchRepository.existsActiveMatchBetween(requesterId, responderId);
@@ -35,5 +55,17 @@ public class MatchService {
 
     private String generateKey(Long requesterId, Long responderId) {
         return Math.max(requesterId, responderId) + ":" + Math.min(requesterId, responderId);
+    }
+
+    private Match getWaitingMatchById(Long id) {
+        Match match = matchRepository.findById(id).orElseThrow(MatchNotFoundException::new);
+        if (match.getStatus() != MatchStatus.WAITING) throw new MatchNotFoundException();
+        return match;
+    }
+
+    private Match getRejectedMatchById(Long id) {
+        Match match = matchRepository.findById(id).orElseThrow(MatchNotFoundException::new);
+        if (match.getStatus() != MatchStatus.REJECTED) throw new MatchNotFoundException();
+        return match;
     }
 }

--- a/src/main/java/atwoz/atwoz/match/command/application/match/exception/InvalidMatchUpdateException.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/exception/InvalidMatchUpdateException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.match.command.application.match.exception;
+
+public class InvalidMatchUpdateException extends RuntimeException {
+    public InvalidMatchUpdateException() {
+        super("해당 상태로 변경이 불가능한 매치입니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/application/match/exception/MatchNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/match/command/application/match/exception/MatchNotFoundException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.match.command.application.match.exception;
+
+public class MatchNotFoundException extends RuntimeException {
+    public MatchNotFoundException() {
+        super("해당 매치를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
@@ -48,21 +48,23 @@ public class Match {
     @Column(columnDefinition = "varchar(50)")
     private MatchStatus status;
 
-    public void approve() {
+    public void approve(@NonNull Message message) {
         validateChangeStatus();
         status = MatchStatus.MATCHED;
+        responseMessage = message;
+        Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
+    }
+
+    public void reject(@NonNull Message message) {
+        validateChangeStatus();
+        status = MatchStatus.REJECTED;
+        responseMessage = message;
         Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
     }
 
     public void expire() {
         validateChangeStatus();
         status = MatchStatus.EXPIRED;
-        Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
-    }
-
-    public void reject() {
-        validateChangeStatus();
-        status = MatchStatus.REJECTED;
         Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
     }
 

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
@@ -52,14 +52,19 @@ public class Match {
         status = MatchStatus.MATCHED;
     }
 
-    public void expired() {
+    public void expire() {
         validateChangeStatus();
         status = MatchStatus.EXPIRED;
     }
 
-    public void rejected() {
+    public void reject() {
         validateChangeStatus();
         status = MatchStatus.REJECTED;
+    }
+
+    public void checkRejected() {
+        validateChangeRejectChecked();
+        status = MatchStatus.REJECT_CHECKED;
     }
 
     public static Match request(long requesterId, long responderId, @NonNull Message requestMessage) {
@@ -76,6 +81,11 @@ public class Match {
 
     private void validateChangeStatus() {
         if (status != MatchStatus.WAITING)
+            throw new InvalidMatchStatusChangeException();
+    }
+
+    private void validateChangeRejectChecked() {
+        if (status != MatchStatus.REJECTED)
             throw new InvalidMatchStatusChangeException();
     }
 }

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
@@ -55,10 +55,9 @@ public class Match {
         Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
     }
 
-    public void reject(@NonNull Message message) {
+    public void reject() {
         validateChangeStatus();
         status = MatchStatus.REJECTED;
-        responseMessage = message;
         Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
     }
 

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/Match.java
@@ -3,6 +3,7 @@ package atwoz.atwoz.match.command.domain.match;
 import atwoz.atwoz.common.event.Events;
 import atwoz.atwoz.match.command.domain.match.event.MatchRequestCompletedEvent;
 import atwoz.atwoz.match.command.domain.match.event.MatchRequestedEvent;
+import atwoz.atwoz.match.command.domain.match.event.MatchRespondedEvent;
 import atwoz.atwoz.match.command.domain.match.exception.InvalidMatchStatusChangeException;
 import atwoz.atwoz.match.command.domain.match.vo.Message;
 import jakarta.persistence.*;
@@ -50,16 +51,19 @@ public class Match {
     public void approve() {
         validateChangeStatus();
         status = MatchStatus.MATCHED;
+        Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
     }
 
     public void expire() {
         validateChangeStatus();
         status = MatchStatus.EXPIRED;
+        Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
     }
 
     public void reject() {
         validateChangeStatus();
         status = MatchStatus.REJECTED;
+        Events.raise(MatchRespondedEvent.of(requesterId, responderId, status));
     }
 
     public void checkRejected() {

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/MatchRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/MatchRepository.java
@@ -1,9 +1,13 @@
 package atwoz.atwoz.match.command.domain.match;
 
+import java.util.Optional;
+
 public interface MatchRepository {
     void save(Match match);
 
     boolean existsActiveMatchBetween(Long memberId, Long anotherMemberId);
 
     void withNamedLock(String key, Runnable action);
+
+    Optional<Match> findById(Long id);
 }

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/MatchRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/MatchRepository.java
@@ -10,4 +10,8 @@ public interface MatchRepository {
     void withNamedLock(String key, Runnable action);
 
     Optional<Match> findById(Long id);
+
+    Optional<Match> findByIdAndRequesterId(Long id, Long requesterId);
+
+    Optional<Match> findByIdAndResponderId(Long id, Long responderId);
 }

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/MatchStatus.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/MatchStatus.java
@@ -7,6 +7,7 @@ public enum MatchStatus {
     WAITING("응답 대기중"),
     MATCHED("매칭 완료."),
     EXPIRED("만료됨"),
+    REJECT_CHECKED("거절 확인"),
     REJECTED("거절");
 
     private final String description;

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRespondedEvent.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRespondedEvent.java
@@ -1,0 +1,19 @@
+package atwoz.atwoz.match.command.domain.match.event;
+
+import atwoz.atwoz.common.event.Event;
+import atwoz.atwoz.match.command.domain.match.MatchStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchRespondedEvent extends Event {
+    Long requesterId;
+    Long responderId;
+    MatchStatus matchStatus;
+
+    public static MatchRespondedEvent of(Long requesterId, Long responderId, MatchStatus matchStatus) {
+        return new MatchRespondedEvent(requesterId, responderId, matchStatus);
+    }
+}

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRespondedEvent.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRespondedEvent.java
@@ -11,9 +11,9 @@ import lombok.Getter;
 public class MatchRespondedEvent extends Event {
     Long requesterId;
     Long responderId;
-    MatchStatus matchStatus;
+    String matchStatus;
 
     public static MatchRespondedEvent of(Long requesterId, Long responderId, MatchStatus matchStatus) {
-        return new MatchRespondedEvent(requesterId, responderId, matchStatus);
+        return new MatchRespondedEvent(requesterId, responderId, matchStatus.toString());
     }
 }

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
@@ -4,6 +4,8 @@ import atwoz.atwoz.match.command.domain.match.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface MatchJpaRepository extends JpaRepository<Match, Long> {
 
     @Query(value = """
@@ -15,4 +17,8 @@ public interface MatchJpaRepository extends JpaRepository<Match, Long> {
             AND m.status <> 'EXPIRED'
             """)
     boolean existsActiveMatchBetween(Long memberId, Long anotherMemberId);
+
+    Optional<Match> findByIdAndRequesterId(Long id, Long requesterId);
+
+    Optional<Match> findByIdAndResponderId(Long id, Long responderId);
 }

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchJpaRepository.java
@@ -14,7 +14,7 @@ public interface MatchJpaRepository extends JpaRepository<Match, Long> {
             FROM Match m
             WHERE ((m.requesterId = :memberId AND m.responderId = :anotherMemberId)
             OR (m.requesterId = :anotherMemberId AND m.responderId = :memberId))
-            AND m.status <> 'EXPIRED'
+            AND m.status <> 'EXPIRED' AND m.status <> 'REJECT_CHECKED'
             """)
     boolean existsActiveMatchBetween(Long memberId, Long anotherMemberId);
 

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
@@ -45,4 +45,14 @@ public class MatchRepositoryImpl implements MatchRepository {
     public Optional<Match> findById(Long id) {
         return matchJpaRepository.findById(id);
     }
+
+    @Override
+    public Optional<Match> findByIdAndRequesterId(Long id, Long requesterId) {
+        return matchJpaRepository.findByIdAndRequesterId(id, requesterId);
+    }
+
+    @Override
+    public Optional<Match> findByIdAndResponderId(Long id, Long responderId) {
+        return matchJpaRepository.findByIdAndResponderId(id, responderId);
+    }
 }

--- a/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/match/command/infra/match/MatchRepositoryImpl.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class MatchRepositoryImpl implements MatchRepository {
@@ -37,5 +39,10 @@ public class MatchRepositoryImpl implements MatchRepository {
         } finally {
             lockRepository.releaseLock(key);
         }
+    }
+
+    @Override
+    public Optional<Match> findById(Long id) {
+        return matchJpaRepository.findById(id);
     }
 }

--- a/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
@@ -6,6 +6,7 @@ import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.match.command.application.match.MatchService;
 import atwoz.atwoz.match.presentation.dto.MatchRequestDto;
+import atwoz.atwoz.match.presentation.dto.MatchResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,24 @@ public class MatchController {
     @PostMapping("/request")
     public ResponseEntity<BaseResponse<Void>> requestMatch(@RequestBody MatchRequestDto matchRequestDto, @AuthPrincipal AuthContext authContext) {
         matchService.request(authContext.getId(), matchRequestDto);
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @PutMapping("/approve")
+    public ResponseEntity<BaseResponse<Void>> approveMatch(@RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
+        matchService.approve(authContext.getId(), matchResponseDto);
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @PutMapping("/reject")
+    public ResponseEntity<BaseResponse<Void>> rejectMatch(@RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
+        matchService.approve(authContext.getId(), matchResponseDto);
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @PutMapping("/check/{id}")
+    public ResponseEntity<BaseResponse<Void>> check(@AuthPrincipal AuthContext authContext, @PathVariable Long id) {
+        matchService.rejectCheck(authContext.getId(), id);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
@@ -31,7 +31,7 @@ public class MatchController {
 
     @PutMapping("/reject")
     public ResponseEntity<BaseResponse<Void>> rejectMatch(@RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
-        matchService.approve(authContext.getId(), matchResponseDto);
+        matchService.reject(authContext.getId(), matchResponseDto);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 

--- a/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
@@ -23,21 +23,21 @@ public class MatchController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
-    @PutMapping("/approve")
-    public ResponseEntity<BaseResponse<Void>> approveMatch(@RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
-        matchService.approve(authContext.getId(), matchResponseDto);
+    @PatchMapping("/{matchId}/approve")
+    public ResponseEntity<BaseResponse<Void>> approveMatch(@PathVariable Long matchId, @RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
+        matchService.approve(matchId, authContext.getId(), matchResponseDto);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
-    @PutMapping("/reject")
-    public ResponseEntity<BaseResponse<Void>> rejectMatch(@RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
-        matchService.reject(authContext.getId(), matchResponseDto);
+    @PatchMapping("/{matchId}/reject")
+    public ResponseEntity<BaseResponse<Void>> rejectMatch(@PathVariable Long matchId, @RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
+        matchService.reject(matchId, authContext.getId(), matchResponseDto);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
-    @PutMapping("/check/{id}")
-    public ResponseEntity<BaseResponse<Void>> check(@AuthPrincipal AuthContext authContext, @PathVariable Long id) {
-        matchService.rejectCheck(authContext.getId(), id);
+    @PatchMapping("/{matchId}/check")
+    public ResponseEntity<BaseResponse<Void>> check(@PathVariable Long matchId, @AuthPrincipal AuthContext authContext) {
+        matchService.rejectCheck(authContext.getId(), matchId);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
@@ -30,8 +30,8 @@ public class MatchController {
     }
 
     @PatchMapping("/{matchId}/reject")
-    public ResponseEntity<BaseResponse<Void>> rejectMatch(@PathVariable Long matchId, @RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
-        matchService.reject(matchId, authContext.getId(), matchResponseDto);
+    public ResponseEntity<BaseResponse<Void>> rejectMatch(@PathVariable Long matchId, @AuthPrincipal AuthContext authContext) {
+        matchService.reject(matchId, authContext.getId());
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 

--- a/src/main/java/atwoz/atwoz/match/presentation/dto/MatchResponseDto.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/dto/MatchResponseDto.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.match.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MatchResponseDto(
+        Long matchId,
+        @NotBlank String responseMessage
+) {
+}

--- a/src/main/java/atwoz/atwoz/match/presentation/dto/MatchResponseDto.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/dto/MatchResponseDto.java
@@ -3,7 +3,6 @@ package atwoz.atwoz.match.presentation.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record MatchResponseDto(
-        Long matchId,
         @NotBlank String responseMessage
 ) {
 }

--- a/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
@@ -1,16 +1,24 @@
 package atwoz.atwoz.match.command.application.match;
 
 import atwoz.atwoz.match.command.application.match.exception.ExistsMatchException;
+import atwoz.atwoz.match.command.application.match.exception.MatchNotFoundException;
+import atwoz.atwoz.match.command.domain.match.Match;
 import atwoz.atwoz.match.command.domain.match.MatchRepository;
+import atwoz.atwoz.match.command.domain.match.MatchStatus;
+import atwoz.atwoz.match.command.domain.match.vo.Message;
 import atwoz.atwoz.match.presentation.dto.MatchRequestDto;
+import atwoz.atwoz.match.presentation.dto.MatchResponseDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 public class MatchServiceTest {
@@ -21,56 +29,198 @@ public class MatchServiceTest {
     @InjectMocks
     private MatchService matchService;
 
-    @Test
-    @DisplayName("이미 두 유저간의 진행중인 매치가 존재하는 경우, 예외 발생")
-    void throwsExceptionWhenExistsMatch() {
-        // Given
-        Long requesterId = 1L;
-        Long responderId = 2L;
-        String requestMessage = "매칭을 요청합니다!";
-        MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
+    @Nested
+    @DisplayName("매치 요청 테스트")
+    class Request {
+        @Test
+        @DisplayName("이미 두 유저간의 진행중인 매치가 존재하는 경우, 예외 발생")
+        void throwsExceptionWhenExistsMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            String requestMessage = "매칭을 요청합니다!";
+            MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
 
-        Mockito.doAnswer(invocation -> {
-            Runnable runnable = invocation.getArgument(1);
-            runnable.run();
-            return null;
-        }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
+            Mockito.doAnswer(invocation -> {
+                Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return null;
+            }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
 
-        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
-                .thenReturn(true);
+            Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
+                    .thenReturn(true);
 
-        // When & Then
-        Assertions.assertThatThrownBy(() -> matchService.request(requesterId, requestDto))
-                .isInstanceOf(ExistsMatchException.class);
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.request(requesterId, requestDto))
+                    .isInstanceOf(ExistsMatchException.class);
+        }
+
+
+        @Test
+        @DisplayName("두 유저 사이의 매치가 존재하지 않는 경우 매치 생성.")
+        void createMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            String requestMessage = "매칭을 요청합니다!";
+            MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
+
+            Mockito.doAnswer(invocation -> {
+                Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return null;
+            }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
+
+            Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
+                    .thenReturn(false);
+
+            // When
+            matchService.request(requesterId, requestDto);
+
+            // Then
+            Mockito.verify(matchRepository).save(
+                    Mockito.argThat(match -> match.getRequesterId().equals(requesterId) &&
+                            match.getResponderId().equals(responderId) &&
+                            match.getRequestMessage().getValue().equals(requestMessage))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("매치 수락 테스트")
+    class Approve {
+
+        @DisplayName("응답자의 아이디가 일치하지 않은 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenResponderIdIsNotEqual() {
+            // Given
+            Long responderId = 1L;
+            Long matchId = 1L;
+            String responseMessage = "매치 수락할게요";
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.empty());
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.approve(matchId, responseDto))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치의 상태가 대기중이 아닐 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenStatusIsNotWaiting() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String responseMessage = "매치 수락할게요";
+            Match match = Match.request(requesterId, responderId, Message.from(responseMessage));
+
+            match.reject();
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.of(match));
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.approve(responderId, responseDto))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치의 상태가 대기중이며, 응답자 아이디가 일치할 경우 수락.")
+        @Test
+        void approveMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String responseMessage = "매치 수락할게요";
+            Match match = Match.request(requesterId, responderId, Message.from(responseMessage));
+
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.of(match));
+
+            // When
+            matchService.approve(responderId, responseDto);
+
+            // Then
+            Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.MATCHED);
+        }
+    }
+
+    @Nested
+    @DisplayName("매치 거절 테스트")
+    class Reject {
+
+        @DisplayName("응답자의 아이디가 일치하지 않은 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenResponderIdIsNotEqual() {
+            // Given
+            Long responderId = 1L;
+            Long matchId = 1L;
+            String responseMessage = "매치 거절할게요";
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.empty());
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.reject(matchId, responseDto))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치의 상태가 대기중이 아닐 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenStatusIsNotWaiting() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String responseMessage = "매치 수락할게요";
+            Match match = Match.request(requesterId, responderId, Message.from(responseMessage));
+
+            match.approve();
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.of(match));
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.reject(responderId, responseDto))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치의 상태가 대기중이며, 응답자 아이디가 일치할 경우 거절.")
+        @Test
+        void rejectMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String responseMessage = "매치 거절할게요";
+            Match match = Match.request(requesterId, responderId, Message.from(responseMessage));
+
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.of(match));
+
+            // When
+            matchService.reject(responderId, responseDto);
+
+            // Then
+            Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.REJECTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("매치 거절 확인 테스트")
+    class RejectCheck {
+        
     }
 
 
-    @Test
-    @DisplayName("두 유저 사이의 매치가 존재하지 않는 경우 매치 생성.")
-    void createMatch() {
-        // Given
-        Long requesterId = 1L;
-        Long responderId = 2L;
-        String requestMessage = "매칭을 요청합니다!";
-        MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
-
-        Mockito.doAnswer(invocation -> {
-            Runnable runnable = invocation.getArgument(1);
-            runnable.run();
-            return null;
-        }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
-
-        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
-                .thenReturn(false);
-
-        // When
-        matchService.request(requesterId, requestDto);
-
-        // Then
-        Mockito.verify(matchRepository).save(
-                Mockito.argThat(match -> match.getRequesterId().equals(requesterId) &&
-                        match.getResponderId().equals(responderId) &&
-                        match.getRequestMessage().getValue().equals(requestMessage))
-        );
-    }
 }

--- a/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
@@ -10,9 +10,7 @@ import atwoz.atwoz.match.command.domain.match.vo.Message;
 import atwoz.atwoz.match.presentation.dto.MatchRequestDto;
 import atwoz.atwoz.match.presentation.dto.MatchResponseDto;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -23,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mockStatic;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +31,20 @@ public class MatchServiceTest {
 
     @InjectMocks
     private MatchService matchService;
+
+    private static MockedStatic<Events> mockedEvents;
+
+    @BeforeEach
+    void setUp() {
+        mockedEvents = Mockito.mockStatic(Events.class);
+        mockedEvents.when(() -> Events.raise(Mockito.any()))
+                .thenAnswer(invocation -> null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedEvents.close();
+    }
 
     @Nested
     @DisplayName("매치 요청 테스트")
@@ -81,9 +92,8 @@ public class MatchServiceTest {
                     .thenReturn(false);
 
             // When
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                matchService.request(requesterId, requestDto);
-            }
+            matchService.request(requesterId, requestDto);
+
 
             // Then
             Mockito.verify(matchRepository).save(
@@ -124,12 +134,10 @@ public class MatchServiceTest {
             Long matchId = 3L;
             String responseMessage = "매치 수락할게요";
             MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
-            Match match;
 
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                match = Match.request(requesterId, responderId, Message.from(responseMessage));
-                match.reject(Message.from(responseMessage));
-            }
+            Match match = Match.request(requesterId, responderId, Message.from(responseMessage));
+            match.reject(Message.from(responseMessage));
+
             Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
                     .thenReturn(Optional.of(match));
 
@@ -146,10 +154,8 @@ public class MatchServiceTest {
             Long responderId = 2L;
             Long matchId = 3L;
             String responseMessage = "매치 수락할게요";
-            Match match;
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                match = Match.request(requesterId, responderId, Message.from(responseMessage));
-            }
+            Match match = Match.request(requesterId, responderId, Message.from(responseMessage));
+
 
             MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
 
@@ -157,9 +163,8 @@ public class MatchServiceTest {
                     .thenReturn(Optional.of(match));
 
             // When
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                matchService.approve(matchId, responderId, responseDto);
-            }
+            matchService.approve(matchId, responderId, responseDto);
+
 
             // Then
             Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.MATCHED);
@@ -198,11 +203,9 @@ public class MatchServiceTest {
             String responseMessage = "매치 수락할게요";
             MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
 
-            Match match;
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                match = Match.request(requesterId, responderId, Message.from(responseMessage));
-                match.approve(Message.from(responseMessage));
-            }
+            Match match = Match.request(requesterId, responderId, Message.from(responseMessage));
+            match.approve(Message.from(responseMessage));
+
 
             Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
                     .thenReturn(Optional.of(match));
@@ -223,9 +226,8 @@ public class MatchServiceTest {
             String responseMessage = "매치 거절할게요";
             Match match;
 
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                match = Match.request(requesterId, responderId, Message.from(requestMessage));
-            }
+            match = Match.request(requesterId, responderId, Message.from(requestMessage));
+
 
             MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
 
@@ -233,9 +235,8 @@ public class MatchServiceTest {
                     .thenReturn(Optional.of(match));
 
             // When
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                matchService.reject(matchId, responderId, responseDto);
-            }
+            matchService.reject(matchId, responderId, responseDto);
+
 
             // Then
             Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.REJECTED);
@@ -256,10 +257,7 @@ public class MatchServiceTest {
             Long matchId = 3L;
             String requestMessage = "매치 신청할게요";
 
-            Match match;
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                match = Match.request(requesterId, responderId, Message.from(requestMessage));
-            }
+            Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
 
             Mockito.when(matchRepository.findByIdAndRequesterId(matchId, requesterId))
                     .thenReturn(Optional.of(match));
@@ -294,11 +292,9 @@ public class MatchServiceTest {
             String requestMessage = "매치 신청할게요";
             String responseMessage = "매치 거절할게요";
 
-            Match match;
-            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                match = Match.request(requesterId, responderId, Message.from(requestMessage));
-                match.reject(Message.from(responseMessage));
-            }
+            Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
+            match.reject(Message.from(responseMessage));
+
 
             Mockito.when(matchRepository.findByIdAndRequesterId(matchId, requesterId))
                     .thenReturn(Optional.of(match));

--- a/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
@@ -2,10 +2,16 @@ package atwoz.atwoz.match.command.application.match;
 
 import atwoz.atwoz.common.event.Events;
 import atwoz.atwoz.match.command.application.match.exception.ExistsMatchException;
+import atwoz.atwoz.match.command.application.match.exception.MatchNotFoundException;
+import atwoz.atwoz.match.command.domain.match.Match;
 import atwoz.atwoz.match.command.domain.match.MatchRepository;
+import atwoz.atwoz.match.command.domain.match.MatchStatus;
+import atwoz.atwoz.match.command.domain.match.vo.Message;
 import atwoz.atwoz.match.presentation.dto.MatchRequestDto;
+import atwoz.atwoz.match.presentation.dto.MatchResponseDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,7 +20,11 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
+
 
 @ExtendWith(MockitoExtension.class)
 public class MatchServiceTest {
@@ -25,58 +35,279 @@ public class MatchServiceTest {
     @InjectMocks
     private MatchService matchService;
 
-    @Test
-    @DisplayName("이미 두 유저간의 진행중인 매치가 존재하는 경우, 예외 발생")
-    void throwsExceptionWhenExistsMatch() {
-        // Given
-        Long requesterId = 1L;
-        Long responderId = 2L;
-        String requestMessage = "매칭을 요청합니다!";
-        MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
+    @Nested
+    @DisplayName("매치 요청 테스트")
+    class Request {
+        @Test
+        @DisplayName("이미 두 유저간의 진행중인 매치가 존재하는 경우, 예외 발생")
+        void throwsExceptionWhenExistsMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            String requestMessage = "매칭을 요청합니다!";
+            MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
 
-        Mockito.doAnswer(invocation -> {
-            Runnable runnable = invocation.getArgument(1);
-            runnable.run();
-            return null;
-        }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
+            Mockito.doAnswer(invocation -> {
+                Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return null;
+            }).when(matchRepository).withNamedLock(any(), any());
 
-        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
-                .thenReturn(true);
+            Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
+                    .thenReturn(true);
 
-        // When & Then
-        Assertions.assertThatThrownBy(() -> matchService.request(requesterId, requestDto))
-                .isInstanceOf(ExistsMatchException.class);
-    }
-
-
-    @Test
-    @DisplayName("두 유저 사이의 매치가 존재하지 않는 경우 매치 생성.")
-    void createMatch() {
-        // Given
-        Long requesterId = 1L;
-        Long responderId = 2L;
-        String requestMessage = "매칭을 요청합니다!";
-        MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
-
-        Mockito.doAnswer(invocation -> {
-            Runnable runnable = invocation.getArgument(1);
-            runnable.run();
-            return null;
-        }).when(matchRepository).withNamedLock(Mockito.any(), Mockito.any());
-
-        Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
-                .thenReturn(false);
-
-        // When
-        try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-            matchService.request(requesterId, requestDto);
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.request(requesterId, requestDto))
+                    .isInstanceOf(ExistsMatchException.class);
         }
 
-        // Then
-        Mockito.verify(matchRepository).save(
-                Mockito.argThat(match -> match.getRequesterId().equals(requesterId) &&
-                        match.getResponderId().equals(responderId) &&
-                        match.getRequestMessage().getValue().equals(requestMessage))
-        );
+
+        @Test
+        @DisplayName("두 유저 사이의 매치가 존재하지 않는 경우 매치 생성.")
+        void createMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            String requestMessage = "매칭을 요청합니다!";
+            MatchRequestDto requestDto = new MatchRequestDto(responderId, requestMessage);
+
+            Mockito.doAnswer(invocation -> {
+                Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return null;
+            }).when(matchRepository).withNamedLock(any(), any());
+
+            Mockito.when(matchRepository.existsActiveMatchBetween(requesterId, requestDto.responderId()))
+                    .thenReturn(false);
+
+            // When
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                matchService.request(requesterId, requestDto);
+            }
+
+            // Then
+            Mockito.verify(matchRepository).save(
+                    Mockito.argThat(match -> match.getRequesterId().equals(requesterId) &&
+                            match.getResponderId().equals(responderId) &&
+                            match.getRequestMessage().getValue().equals(requestMessage))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("매치 수락 테스트")
+    class Approve {
+
+        @DisplayName("응답자의 아이디가 일치하지 않은 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenResponderIdIsNotEqual() {
+            // Given
+            Long responderId = 1L;
+            Long matchId = 1L;
+            String responseMessage = "매치 수락할게요";
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.empty());
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.approve(matchId, responseDto))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치의 상태가 대기중이 아닐 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenStatusIsNotWaiting() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String responseMessage = "매치 수락할게요";
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+            Match match;
+
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                match = Match.request(requesterId, responderId, Message.from(responseMessage));
+                match.reject(Message.from(responseMessage));
+            }
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.of(match));
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.approve(responderId, responseDto))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치의 상태가 대기중이며, 응답자 아이디가 일치할 경우 수락.")
+        @Test
+        void approveMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String responseMessage = "매치 수락할게요";
+            Match match;
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                match = Match.request(requesterId, responderId, Message.from(responseMessage));
+            }
+
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.of(match));
+
+            // When
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                matchService.approve(responderId, responseDto);
+            }
+
+            // Then
+            Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.MATCHED);
+            Assertions.assertThat(match.getResponseMessage().getValue()).isEqualTo(responseMessage);
+        }
+    }
+
+    @Nested
+    @DisplayName("매치 거절 테스트")
+    class Reject {
+
+        @DisplayName("응답자의 아이디가 일치하지 않은 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenResponderIdIsNotEqual() {
+            // Given
+            Long responderId = 1L;
+            Long matchId = 1L;
+            String responseMessage = "매치 거절할게요";
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.empty());
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.reject(matchId, responseDto))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치의 상태가 대기중이 아닐 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenStatusIsNotWaiting() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String responseMessage = "매치 수락할게요";
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Match match;
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                match = Match.request(requesterId, responderId, Message.from(responseMessage));
+                match.approve(Message.from(responseMessage));
+            }
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.of(match));
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.reject(responderId, responseDto))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치의 상태가 대기중이며, 응답자 아이디가 일치할 경우 거절.")
+        @Test
+        void rejectMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String requestMessage = "매치 신청할게요";
+            String responseMessage = "매치 거절할게요";
+            Match match;
+
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                match = Match.request(requesterId, responderId, Message.from(requestMessage));
+            }
+
+            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+
+            Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
+                    .thenReturn(Optional.of(match));
+
+            // When
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                matchService.reject(responderId, responseDto);
+            }
+
+            // Then
+            Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.REJECTED);
+            Assertions.assertThat(match.getResponseMessage().getValue()).isEqualTo(responseMessage);
+        }
+    }
+
+    @Nested
+    @DisplayName("매치 거절 확인 테스트")
+    class RejectCheck {
+
+        @DisplayName("매치 상태가 거절이 아닌 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenMatchStatusIsNotRejected() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String requestMessage = "매치 신청할게요";
+
+            Match match;
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                match = Match.request(requesterId, responderId, Message.from(requestMessage));
+            }
+
+            Mockito.when(matchRepository.findByIdAndRequesterId(matchId, requesterId))
+                    .thenReturn(Optional.of(match));
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.rejectCheck(requesterId, matchId))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치가 존재하지 않는 경우, 예외 발생")
+        @Test
+        void throwsExceptionWhenRequesterIdIsNotEqualMemberId() {
+            // Given
+            Long requesterId = 2L;
+            Long matchId = 3L;
+
+            Mockito.when(matchRepository.findByIdAndRequesterId(matchId, requesterId))
+                    .thenReturn(Optional.empty());
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> matchService.rejectCheck(requesterId, matchId))
+                    .isInstanceOf(MatchNotFoundException.class);
+        }
+
+        @DisplayName("매치가 존재하며, 해당 상태가 거절일 경우 상태 변경")
+        @Test
+        void checkMatch() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Long matchId = 3L;
+            String requestMessage = "매치 신청할게요";
+            String responseMessage = "매치 거절할게요";
+
+            Match match;
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                match = Match.request(requesterId, responderId, Message.from(requestMessage));
+                match.reject(Message.from(responseMessage));
+            }
+
+            Mockito.when(matchRepository.findByIdAndRequesterId(matchId, requesterId))
+                    .thenReturn(Optional.of(match));
+
+            // When
+            matchService.rejectCheck(requesterId, matchId);
+
+            // Then
+            Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.REJECT_CHECKED);
+        }
     }
 }

--- a/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/application/match/MatchServiceTest.java
@@ -105,13 +105,13 @@ public class MatchServiceTest {
             Long responderId = 1L;
             Long matchId = 1L;
             String responseMessage = "매치 수락할게요";
-            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+            MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
 
             Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
                     .thenReturn(Optional.empty());
 
             // When & Then
-            Assertions.assertThatThrownBy(() -> matchService.approve(matchId, responseDto))
+            Assertions.assertThatThrownBy(() -> matchService.approve(matchId, responderId, responseDto))
                     .isInstanceOf(MatchNotFoundException.class);
         }
 
@@ -123,7 +123,7 @@ public class MatchServiceTest {
             Long responderId = 2L;
             Long matchId = 3L;
             String responseMessage = "매치 수락할게요";
-            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+            MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
             Match match;
 
             try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
@@ -134,7 +134,7 @@ public class MatchServiceTest {
                     .thenReturn(Optional.of(match));
 
             // When & Then
-            Assertions.assertThatThrownBy(() -> matchService.approve(responderId, responseDto))
+            Assertions.assertThatThrownBy(() -> matchService.approve(matchId, responderId, responseDto))
                     .isInstanceOf(MatchNotFoundException.class);
         }
 
@@ -151,14 +151,14 @@ public class MatchServiceTest {
                 match = Match.request(requesterId, responderId, Message.from(responseMessage));
             }
 
-            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+            MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
 
             Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
                     .thenReturn(Optional.of(match));
 
             // When
             try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                matchService.approve(responderId, responseDto);
+                matchService.approve(matchId, responderId, responseDto);
             }
 
             // Then
@@ -178,13 +178,13 @@ public class MatchServiceTest {
             Long responderId = 1L;
             Long matchId = 1L;
             String responseMessage = "매치 거절할게요";
-            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+            MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
 
             Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
                     .thenReturn(Optional.empty());
 
             // When & Then
-            Assertions.assertThatThrownBy(() -> matchService.reject(matchId, responseDto))
+            Assertions.assertThatThrownBy(() -> matchService.reject(matchId, responderId, responseDto))
                     .isInstanceOf(MatchNotFoundException.class);
         }
 
@@ -196,7 +196,7 @@ public class MatchServiceTest {
             Long responderId = 2L;
             Long matchId = 3L;
             String responseMessage = "매치 수락할게요";
-            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+            MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
 
             Match match;
             try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
@@ -208,7 +208,7 @@ public class MatchServiceTest {
                     .thenReturn(Optional.of(match));
 
             // When & Then
-            Assertions.assertThatThrownBy(() -> matchService.reject(responderId, responseDto))
+            Assertions.assertThatThrownBy(() -> matchService.reject(matchId, responderId, responseDto))
                     .isInstanceOf(MatchNotFoundException.class);
         }
 
@@ -227,14 +227,14 @@ public class MatchServiceTest {
                 match = Match.request(requesterId, responderId, Message.from(requestMessage));
             }
 
-            MatchResponseDto responseDto = new MatchResponseDto(matchId, responseMessage);
+            MatchResponseDto responseDto = new MatchResponseDto(responseMessage);
 
             Mockito.when(matchRepository.findByIdAndResponderId(matchId, responderId))
                     .thenReturn(Optional.of(match));
 
             // When
             try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-                matchService.reject(responderId, responseDto);
+                matchService.reject(matchId, responderId, responseDto);
             }
 
             // Then

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchRepositoryTest.java
@@ -78,7 +78,8 @@ public class MatchRepositoryTest {
         try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
             match = Match.request(requesterId, responderId, Message.from(requestMessage));
         }
-        match.expired();
+
+        match.expire();
         entityManager.persist(match);
         entityManager.flush();
 

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchRepositoryTest.java
@@ -68,7 +68,7 @@ public class MatchRepositoryTest {
         String requestMessage = "매치를 신청합니다.";
 
         Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
-        match.expired();
+        match.expire();
         entityManager.persist(match);
         entityManager.flush();
 

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchRepositoryTest.java
@@ -5,15 +5,16 @@ import atwoz.atwoz.common.repository.LockRepository;
 import atwoz.atwoz.match.command.domain.match.vo.Message;
 import atwoz.atwoz.match.command.infra.match.MatchRepositoryImpl;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
-
-import static org.mockito.Mockito.mockStatic;
 
 @Import({MatchRepositoryImpl.class, LockRepository.class})
 @DataJpaTest
@@ -25,6 +26,21 @@ public class MatchRepositoryTest {
     @Autowired
     private TestEntityManager entityManager;
 
+    private static MockedStatic<Events> mockedEvents;
+
+
+    @BeforeEach
+    void setUp() {
+        mockedEvents = Mockito.mockStatic(Events.class);
+        mockedEvents.when(() -> Events.raise(Mockito.any()))
+                .thenAnswer(invocation -> null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedEvents.close();
+    }
+
     @Test
     @DisplayName("서로 매치가 존재하는 경우 True 반환.")
     void getTrueWhenMatchExistsBetween() {
@@ -33,10 +49,8 @@ public class MatchRepositoryTest {
         Long requesterId = 2L;
         String requestMessage = "매치를 신청합니다.";
 
-        Match match;
-        try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-            match = Match.request(requesterId, responderId, Message.from(requestMessage));
-        }
+        Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
+
         entityManager.persist(match);
         entityManager.flush();
 
@@ -74,12 +88,34 @@ public class MatchRepositoryTest {
 
         String requestMessage = "매치를 신청합니다.";
 
-        Match match;
-        try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
-            match = Match.request(requesterId, responderId, Message.from(requestMessage));
-        }
-
+        Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
         match.expire();
+
+        entityManager.persist(match);
+        entityManager.flush();
+
+        // When
+        boolean result = matchRepository.existsActiveMatchBetween(requesterId, responderId);
+        boolean otherResult = matchRepository.existsActiveMatchBetween(responderId, requesterId);
+
+        // Then
+        Assertions.assertThat(result).isFalse();
+        Assertions.assertThat(otherResult).isFalse();
+    }
+
+    @Test
+    @DisplayName("거절 확인이 된 매치가 존재하는 경우, False 반환")
+    void getFalseWhenRejectCheckedMatchExistsBetween() {
+        // Given
+        Long requesterId = 1L;
+        Long responderId = 2L;
+
+        String requestMessage = "매치를 신청합니다.";
+
+        Match match = Match.request(requesterId, responderId, Message.from(requestMessage));
+        match.reject();
+        match.checkRejected();
+
         entityManager.persist(match);
         entityManager.flush();
 

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.match.command.domain.match;
 
+import atwoz.atwoz.common.event.Events;
 import atwoz.atwoz.match.command.domain.match.exception.InvalidMatchStatusChangeException;
 import atwoz.atwoz.match.command.domain.match.vo.Message;
 import org.assertj.core.api.Assertions;
@@ -89,14 +90,16 @@ public class MatchTest {
             Long requesterId = 1L;
             Long responderId = 2L;
             Message requestMessage = Message.from("매칭을 요청합니다.");
+            Message responseMessage = Message.from("매칭을 수락합니다.");
             Match match;
             try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
                 match = Match.request(requesterId, responderId, requestMessage);
+                match.expire();
             }
-            match.expired();
+
 
             // When & Then
-            Assertions.assertThatThrownBy(() -> match.approve())
+            Assertions.assertThatThrownBy(() -> match.approve(responseMessage))
                     .isInstanceOf(InvalidMatchStatusChangeException.class);
         }
 
@@ -107,11 +110,13 @@ public class MatchTest {
             Long requesterId = 1L;
             Long responderId = 2L;
             Message requestMessage = Message.from("매칭을 요청합니다.");
+            Message responseMessage = Message.from("매칭을 수락합니다.");
+
             Match match;
             try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
                 match = Match.request(requesterId, responderId, requestMessage);
             }
-            Message responseMessage = Message.from("매칭을 수락합니다.");
+
 
             // When
             match.approve(responseMessage);
@@ -128,7 +133,11 @@ public class MatchTest {
             Long requesterId = 1L;
             Long responderId = 2L;
             Message requestMessage = Message.from("매칭을 요청합니다.");
-            Match match = Match.request(requesterId, responderId, requestMessage);
+            Match match;
+
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                match = Match.request(requesterId, responderId, requestMessage);
+            }
 
             // When & Then
             Assertions.assertThatThrownBy(() -> match.checkRejected())
@@ -143,8 +152,14 @@ public class MatchTest {
             Long responderId = 2L;
             Message requestMessage = Message.from("매칭을 요청합니다.");
             Message responseMessage = Message.from("매칭을 거절합니다.");
-            Match match = Match.request(requesterId, responderId, requestMessage);
-            match.reject(responseMessage);
+
+
+            Match match;
+            try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
+                match = Match.request(requesterId, responderId, requestMessage);
+                match.reject(responseMessage);
+            }
+
 
             // When
             match.checkRejected();

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
@@ -140,7 +140,7 @@ public class MatchTest {
             }
 
             // When & Then
-            Assertions.assertThatThrownBy(() -> match.checkRejected())
+            Assertions.assertThatThrownBy(match::checkRejected)
                     .isInstanceOf(InvalidMatchStatusChangeException.class);
         }
 
@@ -157,7 +157,7 @@ public class MatchTest {
             Match match;
             try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
                 match = Match.request(requesterId, responderId, requestMessage);
-                match.reject(responseMessage);
+                match.reject();
             }
 
 

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
@@ -81,11 +81,12 @@ public class MatchTest {
             Long requesterId = 1L;
             Long responderId = 2L;
             Message requestMessage = Message.from("매칭을 요청합니다.");
+            Message responseMessage = Message.from("매칭을 수락합니다.");
             Match match = Match.request(requesterId, responderId, requestMessage);
             match.expire();
 
             // When & Then
-            Assertions.assertThatThrownBy(() -> match.approve())
+            Assertions.assertThatThrownBy(() -> match.approve(responseMessage))
                     .isInstanceOf(InvalidMatchStatusChangeException.class);
         }
 
@@ -96,13 +97,15 @@ public class MatchTest {
             Long requesterId = 1L;
             Long responderId = 2L;
             Message requestMessage = Message.from("매칭을 요청합니다.");
+            Message responseMessage = Message.from("매칭을 수락합니다.");
             Match match = Match.request(requesterId, responderId, requestMessage);
 
             // When
-            match.approve();
+            match.approve(responseMessage);
 
             // Then
             Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.MATCHED);
+            Assertions.assertThat(match.getResponseMessage().getValue()).isEqualTo(responseMessage.getValue());
         }
 
         @Test
@@ -126,8 +129,9 @@ public class MatchTest {
             Long requesterId = 1L;
             Long responderId = 2L;
             Message requestMessage = Message.from("매칭을 요청합니다.");
+            Message responseMessage = Message.from("매칭을 거절합니다.");
             Match match = Match.request(requesterId, responderId, requestMessage);
-            match.reject();
+            match.reject(responseMessage);
 
             // When
             match.checkRejected();

--- a/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
+++ b/src/test/java/atwoz/atwoz/match/command/domain/match/MatchTest.java
@@ -82,7 +82,7 @@ public class MatchTest {
             Long responderId = 2L;
             Message requestMessage = Message.from("매칭을 요청합니다.");
             Match match = Match.request(requesterId, responderId, requestMessage);
-            match.expired();
+            match.expire();
 
             // When & Then
             Assertions.assertThatThrownBy(() -> match.approve())
@@ -103,6 +103,37 @@ public class MatchTest {
 
             // Then
             Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.MATCHED);
+        }
+
+        @Test
+        @DisplayName("현재 값이 Reject 상태가 아닌 경우, Check 상태로 변경 시, 예외 반환")
+        void throwsExceptionWhenStatusIsNotReject() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Message requestMessage = Message.from("매칭을 요청합니다.");
+            Match match = Match.request(requesterId, responderId, requestMessage);
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> match.checkRejected())
+                    .isInstanceOf(InvalidMatchStatusChangeException.class);
+        }
+
+        @Test
+        @DisplayName("현재 값이 Reject 상태인 경우, Check 상태로 변경.")
+        void changeStatusToCheck() {
+            // Given
+            Long requesterId = 1L;
+            Long responderId = 2L;
+            Message requestMessage = Message.from("매칭을 요청합니다.");
+            Match match = Match.request(requesterId, responderId, requestMessage);
+            match.reject();
+
+            // When
+            match.checkRejected();
+
+            // Then
+            Assertions.assertThat(match.getStatus()).isEqualTo(MatchStatus.REJECT_CHECKED);
         }
     }
 }


### PR DESCRIPTION
### 관련 이슈
- closes #95 

<br>

### 작업 내용
- 수락 / 거절 / 거절 확인에 대한 각각의 서비스 계층 메서드 작성.
- 컨트롤러 계층 메서드 작성
- 테스트 코드 작성.

<br>

### 참고 자료
-

<br>

### 노트
- 컨트롤러 진입점을 하나의 경로로 두고 분기를 할 지, 여러 진입점을 둘 지 고민하다가 일단 각각 응답별로 진입점을 두었습니다...! 
- 알림의 경우 요청/수락/거절에 대해서 모두 각기 다른 내용의 알림이 나올 것 같아서, 이벤트에 Status 값을 함께 추가하였습니다
- 단위 테스트 시, 서비스 계층 테스트에서는 Events.raise 를 호출하지 않기 위해 `Events.setPublisher(null)` 을 호출한 뒤 검즘하는 방식으로 수정하는 것은 어떨까요? (이미 도메인 계층에서 검증이 되고 있으니..??)