### PR TITLE
Firebase 세팅

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Spring profiles
-SPRING_PROFILES_ACTIVE=local || delpoy
+SPRING_PROFILES_ACTIVE=local || deploy
 
 # Application server configuration
 APP_HOST_PORT=8080
@@ -27,13 +27,16 @@ AWS_S3_ACCESS_KEY=
 AWS_S3_SECRET_KEY=
 AWS_S3_BUCKET_NAME=
 
-## Swagger configuration
+# Swagger configuration
 SPRINGDOC_ENABLED=true
 SWAGGER_UI_ENABLED=true
 
-## APP Store configuration
+# APP Store configuration
 APP_STORE_KEY_ID=
 APP_STORE_PRIVATE_KEY_STRING=
 APP_STORE_ISSUER_ID=
 APP_STORE_ENVIRONMENT=
 APP_STORE_BUNDLE_ID=
+
+# Firebase configuration
+GOOGLE_APPLICATION_CREDENTIALS=

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### ENV ###
 *.env
+
+### screts ###
+secrets/

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // AWS
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // Firebase
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
+
     // JWT
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "${APP_HOST_PORT:-8080}:${APP_CONTAINER_PORT:-8080}"
     volumes:
       - .:/app
+      - ./secrets:/etc/credentials:ro
     depends_on:
       - db
       - redis

--- a/src/main/java/atwoz/atwoz/notification/infra/FirebaseConfig.java
+++ b/src/main/java/atwoz/atwoz/notification/infra/FirebaseConfig.java
@@ -1,0 +1,22 @@
+package atwoz.atwoz.notification.infra;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    private void init() throws IOException {
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.getApplicationDefault())
+                .build();
+
+        FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/java/atwoz/atwoz/notification/infra/FirebaseConfig.java
+++ b/src/main/java/atwoz/atwoz/notification/infra/FirebaseConfig.java
@@ -4,11 +4,13 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 
 @Configuration
+@Profile("!test")
 public class FirebaseConfig {
 
     @PostConstruct

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    active: test
+
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
### 관련 이슈
- closes #102 

<br>

### 작업 내용
- Firebase 세팅
- test 프로필 생성

<br>

### 참고 자료
- https://firebase.google.com/docs/admin/setup

<br>

### To-do's
Firebase 세팅을 위해 로컬에서 하셔야되는 작업입니다.
1. secrets 디렉토리를 만들어 atwoz-firebase.json 파일 저장
2.  .env에 `GOOGLE_APPLICATION_CREDENTIALS`를 `/etc/credentials/atwoz-firebase.json`로 설정

도커에 볼륨으로 들어가게 해놨는데, 이게 개발 서버에서도 잘 되는지는 확인해봐야할것 같습니다.

<br>

### 노트
알림 기능을 구현하기 위해 다음과 같은 선택지에서 고민했는데요,

1. 기존 시스템에서 APNs 사용
2. 타사 푸시 서비스 사용(FCM 등)
3. 알림 작업 서버 구축

제한된 개발 시간과 리소스를 고려하면 일단 2번으로 진행하는게 맞는것 같아서 FCM을 사용하기로 결정했습니다.