### PR TITLE
소개받고 싶은 이성 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/MemberIdealNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/MemberIdealNotFoundException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.command.application.introduction.exception;
+
+public class MemberIdealNotFoundException extends RuntimeException {
+    public MemberIdealNotFoundException() {
+        super("멤버의 이상형이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
@@ -1,0 +1,86 @@
+package atwoz.atwoz.member.command.domain.introduction;
+
+import atwoz.atwoz.common.entity.BaseEntity;
+import atwoz.atwoz.member.command.domain.introduction.vo.AgeRange;
+import atwoz.atwoz.member.command.domain.member.DrinkingStatus;
+import atwoz.atwoz.member.command.domain.member.Region;
+import atwoz.atwoz.member.command.domain.member.Religion;
+import atwoz.atwoz.member.command.domain.member.SmokingStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "member_ideals")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberIdeal extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    @Getter
+    @Embedded
+    private AgeRange ageRange;
+
+    @Getter
+    @ElementCollection
+    @CollectionTable(name = "member_ideal_hobbies", joinColumns = @JoinColumn(name = "member_ideal_id"))
+    @Column(name = "hobby_id")
+    private Set<Long> hobbyIds = new HashSet<>();
+
+    @Getter
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(50)")
+    private Region region;
+
+    @Getter
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(50)")
+    private Religion religion;
+
+    @Getter
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(50)")
+    private SmokingStatus smokingStatus;
+
+    @Getter
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(50)")
+    private DrinkingStatus drinkingStatus;
+
+    public static MemberIdeal of(
+            Long memberId,
+            AgeRange ageRange,
+            Set<Long> hobbyIds,
+            Region region,
+            Religion religion,
+            SmokingStatus smokingStatus,
+            DrinkingStatus drinkingStatus
+    ) {
+        return new MemberIdeal(memberId, ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus);
+    }
+
+    private MemberIdeal(
+            Long memberId,
+            AgeRange ageRange,
+            Set<Long> hobbyIds,
+            Region region,
+            Religion religion,
+            SmokingStatus smokingStatus,
+            DrinkingStatus drinkingStatus
+    ) {
+        this.memberId = memberId;
+        this.ageRange = ageRange;
+        this.hobbyIds = hobbyIds;
+        this.region = region;
+        this.religion = religion;
+        this.smokingStatus = smokingStatus;
+        this.drinkingStatus = drinkingStatus;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdealCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdealCommandRepository.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.member.command.domain.introduction;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberIdealCommandRepository extends JpaRepository<MemberIdeal, Long> {
+    Optional<MemberIdeal> findByMemberId(Long memberId);
+}

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIntroduction.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIntroduction.java
@@ -1,0 +1,29 @@
+package atwoz.atwoz.member.command.domain.introduction;
+
+import atwoz.atwoz.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@Table(name = "member_introductions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberIntroduction extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private Long introducedMemberId;
+
+    public static MemberIntroduction of(Long memberId, Long introducedMemberId) {
+        return new MemberIntroduction(memberId, introducedMemberId);
+    }
+
+    private MemberIntroduction(@NonNull Long memberId, @NonNull Long introducedMemberId) {
+        this.memberId = memberId;
+        this.introducedMemberId = introducedMemberId;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/exception/InvalidAgeRangeException.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/exception/InvalidAgeRangeException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.command.domain.introduction.exception;
+
+public class InvalidAgeRangeException extends RuntimeException {
+    public InvalidAgeRangeException() {
+        super("나이 범위가 유효하지 않습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
@@ -1,0 +1,44 @@
+package atwoz.atwoz.member.command.domain.introduction.vo;
+
+import atwoz.atwoz.member.command.domain.introduction.exception.InvalidAgeRangeException;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NonNull;
+
+@Getter
+@Embeddable
+public class AgeRange {
+    private static final Integer MIN_VALUE = 20;
+    private static final Integer MAX_VALUE = 47;
+
+    private final Integer minAge;
+    private final Integer maxAge;
+
+    protected AgeRange() {
+        this.minAge = MIN_VALUE;
+        this.maxAge = MAX_VALUE;
+    }
+
+    public static AgeRange init() {
+        return new AgeRange();
+    }
+
+    public static AgeRange of(Integer minAge, Integer maxAge) {
+        return new AgeRange(minAge, maxAge);
+    }
+
+    private AgeRange(@NonNull Integer minAge, @NonNull Integer maxAge) {
+        validateAgeRange(minAge, maxAge);
+        this.minAge = minAge;
+        this.maxAge = maxAge;
+    }
+
+    private void validateAgeRange(Integer minAge, Integer maxAge) {
+        if (minAge < MIN_VALUE || maxAge > MAX_VALUE) {
+            throw new InvalidAgeRangeException();
+        }
+        if (minAge > maxAge) {
+            throw new InvalidAgeRangeException();
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
@@ -19,10 +19,6 @@ public class AgeRange {
         this.maxAge = MAX_VALUE;
     }
 
-    public static AgeRange init() {
-        return new AgeRange();
-    }
-
     public static AgeRange of(Integer minAge, Integer maxAge) {
         return new AgeRange(minAge, maxAge);
     }

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Gender.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Gender.java
@@ -23,4 +23,8 @@ public enum Gender {
             throw new InvalidMemberEnumValueException(value);
         }
     }
+
+    public Gender getOpposite() {
+        return this == MALE ? FEMALE : MALE;
+    }
 }

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Grade.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Grade.java
@@ -1,0 +1,16 @@
+package atwoz.atwoz.member.command.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public enum Grade {
+    DIAMOND("다이아몬드"),
+    GOLD("골드"),
+    SILVER("실버");
+
+    private final String description;
+
+    Grade(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
@@ -37,6 +37,10 @@ public class Member extends SoftDeleteBaseEntity {
     @Getter
     private boolean isVip;
 
+    @Embedded
+    @Getter
+    private Grade grade;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)")
     private ActivityStatus activityStatus;

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionController.java
@@ -1,0 +1,57 @@
+package atwoz.atwoz.member.presentation.introduction;
+
+import atwoz.atwoz.auth.presentation.AuthContext;
+import atwoz.atwoz.auth.presentation.AuthPrincipal;
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.member.query.introduction.application.IntroductionQueryService;
+import atwoz.atwoz.member.query.introduction.application.MemberIntroductionProfileView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member/introduction")
+public class MemberIntroductionController {
+    private final IntroductionQueryService introductionQueryService;
+
+    @GetMapping("/grade")
+    public ResponseEntity<BaseResponse<List<MemberIntroductionProfileView>>> findDiamondGradeIntroductions(@AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        List<MemberIntroductionProfileView> introductionProfileViews = introductionQueryService.findDiamondGradeIntroductions(memberId);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, introductionProfileViews));
+    }
+
+    @GetMapping("/hobby")
+    public ResponseEntity<BaseResponse<List<MemberIntroductionProfileView>>> findSameHobbyIntroductions(@AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        List<MemberIntroductionProfileView> introductionProfileViews = introductionQueryService.findSameHobbyIntroductions(memberId);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, introductionProfileViews));
+    }
+
+    @GetMapping("/religion")
+    public ResponseEntity<BaseResponse<List<MemberIntroductionProfileView>>> findSameReligionIntroductions(@AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        List<MemberIntroductionProfileView> introductionProfileViews = introductionQueryService.findSameReligionIntroductions(memberId);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, introductionProfileViews));
+    }
+
+    @GetMapping("/region")
+    public ResponseEntity<BaseResponse<List<MemberIntroductionProfileView>>> findSameRegionIntroductions(@AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        List<MemberIntroductionProfileView> introductionProfileViews = introductionQueryService.findSameRegionIntroductions(memberId);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, introductionProfileViews));
+    }
+
+    @GetMapping("/recent")
+    public ResponseEntity<BaseResponse<List<MemberIntroductionProfileView>>> findRecentlyJoinedIntroductions(@AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        List<MemberIntroductionProfileView> introductionProfileViews = introductionQueryService.findRecentlyJoinedIntroductions(memberId);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, introductionProfileViews));
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionExceptionHandler.java
@@ -1,0 +1,22 @@
+package atwoz.atwoz.member.presentation.introduction;
+
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class MemberIntroductionExceptionHandler {
+
+    @ExceptionHandler(MemberIdealNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMemberIdealNotFoundException(MemberIdealNotFoundException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(404)
+                .body(BaseResponse.from(StatusType.NOT_FOUND));
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionCacheKeyPrefix.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionCacheKeyPrefix.java
@@ -1,0 +1,18 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import lombok.Getter;
+
+@Getter
+public enum IntroductionCacheKeyPrefix {
+    DIAMOND("diamond:"),
+    SAME_HOBBY("hobby:"),
+    SAME_RELIGION("religion:"),
+    SAME_REGION("region:"),
+    RECENTLY_JOINED("recentlyJoined:");
+
+    private final String prefix;
+
+    IntroductionCacheKeyPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcher.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcher.java
@@ -1,0 +1,69 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
+import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import atwoz.atwoz.member.query.introduction.intra.IntroductionQueryRepository;
+import atwoz.atwoz.member.query.introduction.intra.IntroductionRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class IntroductionMemberIdFetcher {
+
+    private final IntroductionQueryRepository introductionQueryRepository;
+    private final IntroductionRedisRepository introductionRedisRepository;
+    private final MemberCommandRepository memberCommandRepository;
+    private final MemberIdealCommandRepository memberIdealCommandRepository;
+
+    @FunctionalInterface
+    public interface IntroductionConditionSupplier<T> {
+        IntroductionSearchCondition get(Set<Long> excludedMemberIds, MemberIdeal memberIdeal, Member member, T criteria);
+    }
+
+    public <T> Set<Long> fetch(long memberId, IntroductionCacheKeyPrefix cacheKeyPrefix, T criteria, IntroductionConditionSupplier<T> supplier) {
+        String cacheKey = buildKey(cacheKeyPrefix, memberId);
+        Set<Long> cachedIds = introductionRedisRepository.findIntroductionMemberIds(cacheKey);
+        if (!cachedIds.isEmpty()) {
+            return cachedIds;
+        }
+        Set<Long> excludedMemberIds = findExcludedMemberIds(memberId);
+        MemberIdeal memberIdeal = memberIdealCommandRepository.findByMemberId(memberId)
+                .orElseThrow(MemberIdealNotFoundException::new);
+        Member member = memberCommandRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        IntroductionSearchCondition condition = supplier.get(excludedMemberIds, memberIdeal, member, criteria);
+        Set<Long> introductionMemberIds = introductionQueryRepository.findAllIntroductionMemberId(condition);
+        introductionRedisRepository.saveIntroductionMemberIds(cacheKey, introductionMemberIds, getExpireAt());
+        return introductionMemberIds;
+    }
+
+    private Set<Long> findExcludedMemberIds(long memberId) {
+        Set<Long> excludedMemberIds = new HashSet<>();
+        excludedMemberIds.add(memberId);
+        excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestedMemberId(memberId));
+        excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestingMemberId(memberId));
+        excludedMemberIds.addAll(introductionQueryRepository.findAllIntroducedMemberId(memberId));
+        return excludedMemberIds;
+    }
+
+    private Date getExpireAt() {
+        LocalDateTime expireDateTime = LocalDate.now().plusDays(1).atStartOfDay();
+        return Date.from(expireDateTime.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    private String buildKey(IntroductionCacheKeyPrefix prefix, long memberId) {
+        return prefix.getPrefix() + memberId;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionQueryService.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionQueryService.java
@@ -72,7 +72,7 @@ public class IntroductionQueryService {
                 memberId,
                 IntroductionCacheKeyPrefix.DIAMOND,
                 Grade.DIAMOND,
-                (excluded, ideal, member, grade) -> IntroductionSearchCondition.ofGrade(excluded, ideal, grade)
+                (excluded, ideal, member, grade) -> IntroductionSearchCondition.ofGrade(excluded, ideal, member.getGender().getOpposite(), grade)
         );
     }
 
@@ -82,7 +82,7 @@ public class IntroductionQueryService {
                 IntroductionCacheKeyPrefix.SAME_HOBBY,
                 null,
                 (excluded, ideal, member, unused) ->
-                        IntroductionSearchCondition.ofHobbyIds(excluded, ideal, member.getProfile().getHobbyIds())
+                        IntroductionSearchCondition.ofHobbyIds(excluded, ideal, member.getGender().getOpposite(), member.getProfile().getHobbyIds())
         );
     }
 
@@ -92,7 +92,7 @@ public class IntroductionQueryService {
                 IntroductionCacheKeyPrefix.SAME_RELIGION,
                 null,
                 (excluded, ideal, member, unused) ->
-                        IntroductionSearchCondition.ofReligion(excluded, ideal, member.getProfile().getReligion())
+                        IntroductionSearchCondition.ofReligion(excluded, ideal, member.getGender().getOpposite(), member.getProfile().getReligion())
         );
     }
 
@@ -102,7 +102,7 @@ public class IntroductionQueryService {
                 IntroductionCacheKeyPrefix.SAME_REGION,
                 null,
                 (excluded, ideal, member, unused) ->
-                        IntroductionSearchCondition.ofRegion(excluded, ideal, member.getProfile().getRegion())
+                        IntroductionSearchCondition.ofRegion(excluded, ideal, member.getGender().getOpposite(), member.getProfile().getRegion())
         );
     }
 
@@ -112,7 +112,7 @@ public class IntroductionQueryService {
                 IntroductionCacheKeyPrefix.RECENTLY_JOINED,
                 null,
                 (excluded, ideal, member, unused) ->
-                        IntroductionSearchCondition.ofJoinDate(excluded, ideal, getRecentlyJoinedCutoffDate())
+                        IntroductionSearchCondition.ofJoinDate(excluded, ideal, member.getGender().getOpposite(), getRecentlyJoinedCutoffDate())
         );
     }
 

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionSearchCondition.java
@@ -4,6 +4,7 @@ import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
 import atwoz.atwoz.member.command.domain.introduction.vo.AgeRange;
 import atwoz.atwoz.member.command.domain.member.*;
 import lombok.Getter;
+import lombok.NonNull;
 
 import java.time.LocalDateTime;
 import java.util.Set;
@@ -19,11 +20,13 @@ public class IntroductionSearchCondition {
     private final String smokingStatus;
     private final String drinkingStatus;
     private final String memberGrade;
+    private final String gender;
     private final LocalDateTime joinedAfter;
 
     public static IntroductionSearchCondition ofGrade(
             Set<Long> excludedMemberIds,
             MemberIdeal memberIdeal,
+            Gender gender,
             Grade grade
     ) {
         return new IntroductionSearchCondition(
@@ -35,6 +38,7 @@ public class IntroductionSearchCondition {
                 memberIdeal.getSmokingStatus(),
                 memberIdeal.getDrinkingStatus(),
                 grade,
+                gender,
                 null
         );
     }
@@ -42,6 +46,7 @@ public class IntroductionSearchCondition {
     public static IntroductionSearchCondition ofHobbyIds(
             Set<Long> excludedMemberIds,
             MemberIdeal memberIdeal,
+            Gender gender,
             Set<Long> hobbyIds
     ) {
         return new IntroductionSearchCondition(
@@ -53,6 +58,7 @@ public class IntroductionSearchCondition {
                 memberIdeal.getSmokingStatus(),
                 memberIdeal.getDrinkingStatus(),
                 null,
+                gender,
                 null
         );
     }
@@ -60,6 +66,7 @@ public class IntroductionSearchCondition {
     public static IntroductionSearchCondition ofReligion(
             Set<Long> excludedMemberIds,
             MemberIdeal memberIdeal,
+            Gender gender,
             Religion religion
     ) {
         return new IntroductionSearchCondition(
@@ -71,6 +78,7 @@ public class IntroductionSearchCondition {
                 memberIdeal.getSmokingStatus(),
                 memberIdeal.getDrinkingStatus(),
                 null,
+                gender,
                 null
         );
     }
@@ -78,6 +86,7 @@ public class IntroductionSearchCondition {
     public static IntroductionSearchCondition ofRegion(
             Set<Long> excludedMemberIds,
             MemberIdeal memberIdeal,
+            Gender gender,
             Region region
     ) {
         return new IntroductionSearchCondition(
@@ -89,6 +98,7 @@ public class IntroductionSearchCondition {
                 memberIdeal.getSmokingStatus(),
                 memberIdeal.getDrinkingStatus(),
                 null,
+                gender,
                 null
         );
     }
@@ -96,6 +106,7 @@ public class IntroductionSearchCondition {
     public static IntroductionSearchCondition ofJoinDate(
             Set<Long> excludedMemberIds,
             MemberIdeal memberIdeal,
+            Gender gender,
             LocalDateTime joinedAfter
     ) {
         return new IntroductionSearchCondition(
@@ -107,6 +118,7 @@ public class IntroductionSearchCondition {
                 memberIdeal.getSmokingStatus(),
                 memberIdeal.getDrinkingStatus(),
                 null,
+                gender,
                 joinedAfter
         );
     }
@@ -120,6 +132,7 @@ public class IntroductionSearchCondition {
             SmokingStatus smokingStatus,
             DrinkingStatus drinkingStatus,
             Grade memberGrade,
+            @NonNull Gender gender,
             LocalDateTime joinedAfter
     ) {
         this.excludedMemberIds = excludedMemberIds;
@@ -131,6 +144,7 @@ public class IntroductionSearchCondition {
         this.smokingStatus = (smokingStatus != null) ? smokingStatus.name() : null;
         this.drinkingStatus = (drinkingStatus != null) ? drinkingStatus.name() : null;
         this.memberGrade = (memberGrade != null) ? memberGrade.name() : null;
+        this.gender = gender.name();
         this.joinedAfter = joinedAfter;
     }
 }

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionSearchCondition.java
@@ -1,0 +1,136 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.vo.AgeRange;
+import atwoz.atwoz.member.command.domain.member.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Getter
+public class IntroductionSearchCondition {
+    private final Set<Long> excludedMemberIds;
+    private final Integer minAge;
+    private final Integer maxAge;
+    private final Set<Long> hobbyIds;
+    private final String region;
+    private final String religion;
+    private final String smokingStatus;
+    private final String drinkingStatus;
+    private final String memberGrade;
+    private final LocalDateTime joinedAfter;
+
+    public static IntroductionSearchCondition ofGrade(
+            Set<Long> excludedMemberIds,
+            MemberIdeal memberIdeal,
+            Grade grade
+    ) {
+        return new IntroductionSearchCondition(
+                excludedMemberIds,
+                memberIdeal.getAgeRange(),
+                memberIdeal.getHobbyIds(),
+                memberIdeal.getRegion(),
+                memberIdeal.getReligion(),
+                memberIdeal.getSmokingStatus(),
+                memberIdeal.getDrinkingStatus(),
+                grade,
+                null
+        );
+    }
+
+    public static IntroductionSearchCondition ofHobbyIds(
+            Set<Long> excludedMemberIds,
+            MemberIdeal memberIdeal,
+            Set<Long> hobbyIds
+    ) {
+        return new IntroductionSearchCondition(
+                excludedMemberIds,
+                memberIdeal.getAgeRange(),
+                hobbyIds,
+                memberIdeal.getRegion(),
+                memberIdeal.getReligion(),
+                memberIdeal.getSmokingStatus(),
+                memberIdeal.getDrinkingStatus(),
+                null,
+                null
+        );
+    }
+
+    public static IntroductionSearchCondition ofReligion(
+            Set<Long> excludedMemberIds,
+            MemberIdeal memberIdeal,
+            Religion religion
+    ) {
+        return new IntroductionSearchCondition(
+                excludedMemberIds,
+                memberIdeal.getAgeRange(),
+                memberIdeal.getHobbyIds(),
+                memberIdeal.getRegion(),
+                religion,
+                memberIdeal.getSmokingStatus(),
+                memberIdeal.getDrinkingStatus(),
+                null,
+                null
+        );
+    }
+
+    public static IntroductionSearchCondition ofRegion(
+            Set<Long> excludedMemberIds,
+            MemberIdeal memberIdeal,
+            Region region
+    ) {
+        return new IntroductionSearchCondition(
+                excludedMemberIds,
+                memberIdeal.getAgeRange(),
+                memberIdeal.getHobbyIds(),
+                region,
+                memberIdeal.getReligion(),
+                memberIdeal.getSmokingStatus(),
+                memberIdeal.getDrinkingStatus(),
+                null,
+                null
+        );
+    }
+
+    public static IntroductionSearchCondition ofJoinDate(
+            Set<Long> excludedMemberIds,
+            MemberIdeal memberIdeal,
+            LocalDateTime joinedAfter
+    ) {
+        return new IntroductionSearchCondition(
+                excludedMemberIds,
+                memberIdeal.getAgeRange(),
+                memberIdeal.getHobbyIds(),
+                memberIdeal.getRegion(),
+                memberIdeal.getReligion(),
+                memberIdeal.getSmokingStatus(),
+                memberIdeal.getDrinkingStatus(),
+                null,
+                joinedAfter
+        );
+    }
+
+    private IntroductionSearchCondition(
+            Set<Long> excludedMemberIds,
+            AgeRange ageRange,
+            Set<Long> hobbyIds,
+            Region region,
+            Religion religion,
+            SmokingStatus smokingStatus,
+            DrinkingStatus drinkingStatus,
+            Grade memberGrade,
+            LocalDateTime joinedAfter
+    ) {
+        this.excludedMemberIds = excludedMemberIds;
+        this.minAge = (ageRange != null) ? ageRange.getMinAge() : null;
+        this.maxAge = (ageRange != null) ? ageRange.getMaxAge() : null;
+        this.hobbyIds = hobbyIds;
+        this.region = (region != null) ? region.name() : null;
+        this.religion = (religion != null) ? religion.name() : null;
+        this.smokingStatus = (smokingStatus != null) ? smokingStatus.name() : null;
+        this.drinkingStatus = (drinkingStatus != null) ? drinkingStatus.name() : null;
+        this.memberGrade = (memberGrade != null) ? memberGrade.name() : null;
+        this.joinedAfter = joinedAfter;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/MemberIntroductionProfileView.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/MemberIntroductionProfileView.java
@@ -1,0 +1,12 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import java.util.List;
+
+public record MemberIntroductionProfileView(
+        long memberId,
+        String profileImageUrl,
+        List<String> tags,
+        String interviewAnswerContent,
+        boolean isIntroduced
+) {
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/MemberIntroductionProfileViewMapper.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/MemberIntroductionProfileViewMapper.java
@@ -1,0 +1,82 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import atwoz.atwoz.member.query.introduction.intra.InterviewAnswerQueryResult;
+import atwoz.atwoz.member.query.introduction.intra.MemberIntroductionProfileQueryResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class MemberIntroductionProfileViewMapper {
+
+    public static List<MemberIntroductionProfileView> mapWithDefaultTag(
+            List<MemberIntroductionProfileQueryResult> profileResults,
+            List<InterviewAnswerQueryResult> interviewResults
+    ) {
+        return map(profileResults, interviewResults, MemberIntroductionProfileViewMapper::toDefaultTags);
+    }
+
+    public static List<MemberIntroductionProfileView> mapWithSameHobbyTag(
+            List<MemberIntroductionProfileQueryResult> profileResults,
+            List<InterviewAnswerQueryResult> interviewResults
+    ) {
+        return map(profileResults, interviewResults, MemberIntroductionProfileViewMapper::toSameHobbyTags);
+    }
+
+    public static List<MemberIntroductionProfileView> mapWithSameReligionTag(
+            List<MemberIntroductionProfileQueryResult> profileResults,
+            List<InterviewAnswerQueryResult> interviewResults
+    ) {
+        return map(profileResults, interviewResults, MemberIntroductionProfileViewMapper::toSameReligionTags);
+    }
+
+    private static List<MemberIntroductionProfileView> map(
+            List<MemberIntroductionProfileQueryResult> profileResults,
+            List<InterviewAnswerQueryResult> interviewResults,
+            Function<MemberIntroductionProfileQueryResult, List<String>> tagExtractor
+    ) {
+        Map<Long, String> interviewAnswerMap = getFirstInterviewAnswerMap(interviewResults);
+        return profileResults.stream()
+                .map(result -> new MemberIntroductionProfileView(
+                        result.memberId(),
+                        result.profileImageUrl(),
+                        tagExtractor.apply(result),
+                        interviewAnswerMap.get(result.memberId()),
+                        result.isIntroduced()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private static Map<Long, String> getFirstInterviewAnswerMap(List<InterviewAnswerQueryResult> interviewResults) {
+        return interviewResults.stream()
+                .collect(Collectors.toMap(
+                        InterviewAnswerQueryResult::memberId,
+                        InterviewAnswerQueryResult::content,
+                        (existing, replacement) -> existing
+                ));
+    }
+
+    private static List<String> toDefaultTags(MemberIntroductionProfileQueryResult view) {
+        List<String> tags = new ArrayList<>();
+        tags.addAll(view.hobbies());
+        tags.add(view.religion());
+        tags.add(view.mbti());
+        return tags;
+    }
+
+    private static List<String> toSameHobbyTags(MemberIntroductionProfileQueryResult view) {
+        List<String> tags = new ArrayList<>();
+        tags.add(view.religion());
+        tags.add(view.mbti());
+        return tags;
+    }
+
+    private static List<String> toSameReligionTags(MemberIntroductionProfileQueryResult view) {
+        List<String> tags = new ArrayList<>();
+        tags.addAll(view.hobbies());
+        tags.add(view.mbti());
+        return tags;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/intra/InterviewAnswerQueryResult.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/intra/InterviewAnswerQueryResult.java
@@ -1,0 +1,12 @@
+package atwoz.atwoz.member.query.introduction.intra;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record InterviewAnswerQueryResult(
+        long memberId,
+        String content
+) {
+    @QueryProjection
+    public InterviewAnswerQueryResult {
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepository.java
@@ -1,0 +1,177 @@
+package atwoz.atwoz.member.query.introduction.intra;
+
+import atwoz.atwoz.member.query.introduction.application.IntroductionSearchCondition;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static atwoz.atwoz.admin.command.domain.hobby.QHobby.hobby;
+import static atwoz.atwoz.interview.command.domain.answer.QInterviewAnswer.interviewAnswer;
+import static atwoz.atwoz.match.command.domain.match.QMatch.match;
+import static atwoz.atwoz.member.command.domain.introduction.QMemberIntroduction.memberIntroduction;
+import static atwoz.atwoz.member.command.domain.member.QMember.member;
+import static atwoz.atwoz.member.command.domain.profileImage.QProfileImage.profileImage;
+
+@Repository
+@RequiredArgsConstructor
+public class IntroductionQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    private static final Long LIMIT = 10L;
+
+    public Set<Long> findAllMatchRequestedMemberId(long memberId) {
+        return new HashSet<>(queryFactory
+                .select(match.requesterId)
+                .from(match)
+                .where(match.responderId.eq(memberId))
+                .fetch());
+    }
+
+    public Set<Long> findAllMatchRequestingMemberId(long memberId) {
+        return new HashSet<>(queryFactory
+                .select(match.responderId)
+                .from(match)
+                .where(match.requesterId.eq(memberId))
+                .fetch());
+    }
+
+    public Set<Long> findAllIntroducedMemberId(long memberId) {
+        return new HashSet<>(queryFactory
+                .select(memberIntroduction.introducedMemberId)
+                .from(memberIntroduction)
+                .where(memberIntroduction.memberId.eq(memberId))
+                .fetch());
+    }
+
+    public Set<Long> findAllIntroductionMemberId(IntroductionSearchCondition condition) {
+        JPAQuery<Long> query = queryFactory
+                .select(member.id)
+                .from(member)
+                .where(
+                        idsNotIn(condition.getExcludedMemberIds()),
+                        ageBetween(condition.getMinAge(), condition.getMaxAge()),
+                        regionEq(condition.getRegion()),
+                        religionEq(condition.getReligion()),
+                        smokingStatusEq(condition.getSmokingStatus()),
+                        drinkingStatusEq(condition.getDrinkingStatus()),
+                        gradeEq(condition.getMemberGrade()),
+                        createdAtGoe(condition.getJoinedAfter())
+                )
+                .orderBy(member.id.desc())
+                .limit(LIMIT);
+
+        applyHobbyIdsCondition(query, condition);
+        return new HashSet<>(query.fetch());
+    }
+
+    public List<MemberIntroductionProfileQueryResult> findAllMemberIntroductionProfileQueryResultByMemberIds(long memberId, Set<Long> memberIds) {
+        return new ArrayList<>(queryFactory
+                .from(member)
+                .leftJoin(hobby).on(hobby.id.in(member.profile.hobbyIds))
+                .leftJoin(memberIntroduction).on(memberIntroduction.memberId.eq(memberId))
+                .leftJoin(profileImage).on(profileImage.memberId.eq(member.id).and(profileImage.isPrimary.isTrue()))
+                .where(member.id.in(memberIds))
+                .orderBy(member.id.desc())
+                .transform(GroupBy.groupBy(member.id).as(
+                        new QMemberIntroductionProfileQueryResult(
+                                member.id,
+                                profileImage.imageUrl.value,
+                                GroupBy.list(hobby.name),
+                                member.profile.religion.stringValue(),
+                                member.profile.mbti.stringValue(),
+                                memberIntroduction.introducedMemberId.isNotNull()
+                        )
+                )).values());
+    }
+
+    public List<InterviewAnswerQueryResult> findAllInterviewAnswerInfoByMemberIds(Set<Long> memberIds) {
+        return queryFactory
+                .select(new QInterviewAnswerQueryResult(
+                        interviewAnswer.memberId,
+                        interviewAnswer.content
+                ))
+                .from(interviewAnswer)
+                .where(interviewAnswer.memberId.in(memberIds))
+                .orderBy(interviewAnswer.id.asc())
+                .fetch();
+    }
+
+    private BooleanExpression idsNotIn(Set<Long> id) {
+        if (id.isEmpty()) {
+            return null;
+        }
+        return member.id.notIn(id);
+    }
+
+    private BooleanExpression ageBetween(Integer minAge, Integer maxAge) {
+        if (minAge == null && maxAge == null) {
+            return null;
+        }
+        if (minAge == null) {
+            return member.profile.age.loe(maxAge);
+        }
+        if (maxAge == null) {
+            return member.profile.age.goe(minAge);
+        }
+        return member.profile.age.between(minAge, maxAge);
+    }
+
+    private BooleanExpression regionEq(String region) {
+        if (region == null) {
+            return null;
+        }
+        return member.profile.region.stringValue().eq(region);
+    }
+
+    private BooleanExpression religionEq(String religion) {
+        if (religion == null) {
+            return null;
+        }
+        return member.profile.religion.stringValue().eq(religion);
+    }
+
+    private BooleanExpression smokingStatusEq(String smokingStatus) {
+        if (smokingStatus == null) {
+            return null;
+        }
+        return member.profile.smokingStatus.stringValue().eq(smokingStatus);
+    }
+
+    private BooleanExpression drinkingStatusEq(String drinkingStatus) {
+        if (drinkingStatus == null) {
+            return null;
+        }
+        return member.profile.drinkingStatus.stringValue().eq(drinkingStatus);
+    }
+
+    private BooleanExpression gradeEq(String grade) {
+        if (grade == null) {
+            return null;
+        }
+        return member.grade.stringValue().eq(grade);
+    }
+
+    private BooleanExpression createdAtGoe(LocalDateTime createdAt) {
+        if (createdAt == null) {
+            return null;
+        }
+        return member.createdAt.goe(createdAt);
+    }
+
+    private void applyHobbyIdsCondition(JPAQuery<?> query, IntroductionSearchCondition condition) {
+        if (condition.getHobbyIds() != null && !condition.getHobbyIds().isEmpty()) {
+            NumberPath<Long> hobbyId = Expressions.numberPath(Long.class, "hobbyId");
+            query.join(member.profile.hobbyIds, hobbyId)
+                    .on(hobbyId.in(condition.getHobbyIds()))
+                    .distinct();
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepository.java
@@ -63,6 +63,7 @@ public class IntroductionQueryRepository {
                         smokingStatusEq(condition.getSmokingStatus()),
                         drinkingStatusEq(condition.getDrinkingStatus()),
                         gradeEq(condition.getMemberGrade()),
+                        genderEq(condition.getGender()),
                         createdAtGoe(condition.getJoinedAfter())
                 )
                 .orderBy(member.id.desc())
@@ -157,6 +158,13 @@ public class IntroductionQueryRepository {
             return null;
         }
         return member.grade.stringValue().eq(grade);
+    }
+
+    private BooleanExpression genderEq(String gender) {
+        if (gender == null) {
+            return null;
+        }
+        return member.profile.gender.stringValue().eq(gender);
     }
 
     private BooleanExpression createdAtGoe(LocalDateTime createdAt) {

--- a/src/main/java/atwoz/atwoz/member/query/introduction/intra/IntroductionRedisRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/intra/IntroductionRedisRepository.java
@@ -1,0 +1,49 @@
+package atwoz.atwoz.member.query.introduction.intra;
+
+import atwoz.atwoz.member.query.introduction.intra.exception.IntroductionMemberIdSerializationFailedException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Date;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class IntroductionRedisRepository {
+    private static final String PREFIX = "introduction:";
+
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveIntroductionMemberIds(String key, Set<Long> introductionMemberIds, Date expireAt) {
+        String fullKey = buildKey(key);
+        try {
+            String json = objectMapper.writeValueAsString(introductionMemberIds);
+            redisTemplate.opsForValue().set(fullKey, json);
+            redisTemplate.expireAt(fullKey, expireAt);
+        } catch (JsonProcessingException e) {
+            throw new IntroductionMemberIdSerializationFailedException(e);
+        }
+    }
+
+    public Set<Long> findIntroductionMemberIds(String key) {
+        String fullKey = buildKey(key);
+        try {
+            String json = redisTemplate.opsForValue().get(fullKey);
+            if (json == null) {
+                return Set.of();
+            }
+            return objectMapper.readValue(json, new TypeReference<Set<Long>>() {});
+        } catch (JsonProcessingException e) {
+            throw new IntroductionMemberIdSerializationFailedException(e);
+        }
+    }
+
+    private String buildKey(String key) {
+        return PREFIX + key;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/intra/MemberIntroductionProfileQueryResult.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/intra/MemberIntroductionProfileQueryResult.java
@@ -1,0 +1,18 @@
+package atwoz.atwoz.member.query.introduction.intra;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.util.List;
+
+public record MemberIntroductionProfileQueryResult(
+        long memberId,
+        String profileImageUrl,
+        List<String> hobbies,
+        String religion,
+        String mbti,
+        boolean isIntroduced
+) {
+    @QueryProjection
+    public MemberIntroductionProfileQueryResult {
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/intra/exception/IntroductionMemberIdSerializationFailedException.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/intra/exception/IntroductionMemberIdSerializationFailedException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.query.introduction.intra.exception;
+
+public class IntroductionMemberIdSerializationFailedException extends RuntimeException {
+    public IntroductionMemberIdSerializationFailedException(Exception e) {
+        super(e);
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcherTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcherTest.java
@@ -4,6 +4,7 @@ import atwoz.atwoz.member.command.application.introduction.exception.MemberIdeal
 import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
 import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
 import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
+import atwoz.atwoz.member.command.domain.member.Gender;
 import atwoz.atwoz.member.command.domain.member.Grade;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
@@ -93,7 +94,7 @@ class IntroductionMemberIdFetcherTest {
         Member member = mock(Member.class);
         when(memberCommandRepository.findById(memberId)).thenReturn(Optional.of(member));
 
-        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Grade.DIAMOND);
+        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Gender.MALE, Grade.DIAMOND);
         IntroductionMemberIdFetcher.IntroductionConditionSupplier<Grade> supplier =
                 (excluded, ideal, m, grade) -> dummyCondition;
 
@@ -136,7 +137,7 @@ class IntroductionMemberIdFetcherTest {
         when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(memberIdeal));
         when(memberCommandRepository.findById(memberId)).thenReturn(Optional.empty());
 
-        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Grade.DIAMOND);
+        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Gender.MALE, Grade.DIAMOND);
         IntroductionMemberIdFetcher.IntroductionConditionSupplier<Grade> supplier =
                 (excluded, ideal, m, grade) -> dummyCondition;
 
@@ -171,7 +172,7 @@ class IntroductionMemberIdFetcherTest {
         when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
 
         MemberIdeal memberIdeal = mock(MemberIdeal.class);
-        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Grade.DIAMOND);
+        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Gender.MALE, Grade.DIAMOND);
         IntroductionMemberIdFetcher.IntroductionConditionSupplier<Grade> supplier =
                 (excluded, ideal, m, grade) -> dummyCondition;
 

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcherTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcherTest.java
@@ -1,0 +1,182 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
+import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
+import atwoz.atwoz.member.command.domain.member.Grade;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import atwoz.atwoz.member.query.introduction.intra.IntroductionQueryRepository;
+import atwoz.atwoz.member.query.introduction.intra.IntroductionRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IntroductionMemberIdFetcherTest {
+
+    @InjectMocks
+    private IntroductionMemberIdFetcher introductionMemberIdFetcher;
+
+    @Mock
+    private IntroductionQueryRepository introductionQueryRepository;
+
+    @Mock
+    private IntroductionRedisRepository introductionRedisRepository;
+
+    @Mock
+    private MemberCommandRepository memberCommandRepository;
+
+    @Mock
+    private MemberIdealCommandRepository memberIdealCommandRepository;
+
+    @Test
+    @DisplayName("Redis에 저장된 값이 있을 때 fetch 메서드가 캐시된 값을 반환한다.")
+    void returnCachedIdsWhenRedisHasValue() {
+        // given
+        long memberId = 1L;
+        IntroductionCacheKeyPrefix introductionCacheKeyPrefix = IntroductionCacheKeyPrefix.DIAMOND;
+        Set<Long> cachedIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        String key = introductionCacheKeyPrefix.getPrefix() + memberId;
+        when(introductionRedisRepository.findIntroductionMemberIds(key))
+                .thenReturn(cachedIds);
+
+        // when
+        Set<Long> result = introductionMemberIdFetcher.fetch(
+                memberId,
+                introductionCacheKeyPrefix,
+                null,
+                (excludedMemberIds, memberIdeal, member, criteria) -> null);
+
+        // then
+        assertThat(result).isEqualTo(cachedIds);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 값이 없을 때 fetch 메서드가 DB 저장된 값을 반환한다.")
+    void returnDBValueWhenRedisHasNoValue() {
+        // given
+        long memberId = 1L;
+        IntroductionCacheKeyPrefix introductionCacheKeyPrefix = IntroductionCacheKeyPrefix.DIAMOND;
+        Set<Long> savedIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        String key = introductionCacheKeyPrefix.getPrefix() + memberId;
+        when(introductionRedisRepository.findIntroductionMemberIds(key))
+                .thenReturn(Set.of());
+
+        Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
+        when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
+        Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
+        when(introductionQueryRepository.findAllMatchRequestingMemberId(memberId)).thenReturn(matchedRequestingMemberIds);
+        Set<Long> introducedMemberIds = Set.of(memberId, 13L);
+        when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
+
+        Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
+        excludedMemberIds.addAll(matchedRequestedMemberIds);
+        excludedMemberIds.addAll(matchedRequestingMemberIds);
+        excludedMemberIds.addAll(introducedMemberIds);
+
+        MemberIdeal memberIdeal = mock(MemberIdeal.class);
+        when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(memberIdeal));
+        Member member = mock(Member.class);
+        when(memberCommandRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Grade.DIAMOND);
+        IntroductionMemberIdFetcher.IntroductionConditionSupplier<Grade> supplier =
+                (excluded, ideal, m, grade) -> dummyCondition;
+
+        when(introductionQueryRepository.findAllIntroductionMemberId(dummyCondition)).thenReturn(savedIds);
+
+        doNothing().when(introductionRedisRepository).saveIntroductionMemberIds(anyString(), eq(savedIds), any(Date.class));
+
+        // when
+        Set<Long> result = introductionMemberIdFetcher.fetch(memberId, IntroductionCacheKeyPrefix.DIAMOND, Grade.DIAMOND, supplier);
+
+        // then
+        assertThat(result).isEqualTo(savedIds);
+        verify(introductionRedisRepository).saveIntroductionMemberIds(eq(key), eq(savedIds), any(Date.class));
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 값이 없고 멤버가 없으면 예외를 던진다")
+    void throwExceptionWhenMemberNotFound() {
+        // given
+        long memberId = 1L;
+        IntroductionCacheKeyPrefix introductionCacheKeyPrefix = IntroductionCacheKeyPrefix.DIAMOND;
+        Set<Long> savedIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        String key = introductionCacheKeyPrefix.getPrefix() + memberId;
+        when(introductionRedisRepository.findIntroductionMemberIds(key))
+                .thenReturn(Set.of());
+
+        Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
+        when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
+        Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
+        when(introductionQueryRepository.findAllMatchRequestingMemberId(memberId)).thenReturn(matchedRequestingMemberIds);
+        Set<Long> introducedMemberIds = Set.of(memberId, 13L);
+        when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
+
+        Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
+        excludedMemberIds.addAll(matchedRequestedMemberIds);
+        excludedMemberIds.addAll(matchedRequestingMemberIds);
+        excludedMemberIds.addAll(introducedMemberIds);
+
+        MemberIdeal memberIdeal = mock(MemberIdeal.class);
+        when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(memberIdeal));
+        when(memberCommandRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Grade.DIAMOND);
+        IntroductionMemberIdFetcher.IntroductionConditionSupplier<Grade> supplier =
+                (excluded, ideal, m, grade) -> dummyCondition;
+
+        // when && then
+        assertThatThrownBy(() -> introductionMemberIdFetcher.fetch(memberId, IntroductionCacheKeyPrefix.DIAMOND, Grade.DIAMOND, supplier))
+                .isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 값이 없고 멤버 이상형이 없으면 예외를 던진다")
+    void throwExceptionWhenMemberIdealNotFound() {
+        // given
+        long memberId = 1L;
+        IntroductionCacheKeyPrefix introductionCacheKeyPrefix = IntroductionCacheKeyPrefix.DIAMOND;
+        Set<Long> savedIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        String key = introductionCacheKeyPrefix.getPrefix() + memberId;
+        when(introductionRedisRepository.findIntroductionMemberIds(key))
+                .thenReturn(Set.of());
+
+        Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
+        when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
+        Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
+        when(introductionQueryRepository.findAllMatchRequestingMemberId(memberId)).thenReturn(matchedRequestingMemberIds);
+        Set<Long> introducedMemberIds = Set.of(memberId, 13L);
+        when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
+
+        Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
+        excludedMemberIds.addAll(matchedRequestedMemberIds);
+        excludedMemberIds.addAll(matchedRequestingMemberIds);
+        excludedMemberIds.addAll(introducedMemberIds);
+
+        when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+
+        MemberIdeal memberIdeal = mock(MemberIdeal.class);
+        IntroductionSearchCondition dummyCondition = IntroductionSearchCondition.ofGrade(excludedMemberIds, memberIdeal, Grade.DIAMOND);
+        IntroductionMemberIdFetcher.IntroductionConditionSupplier<Grade> supplier =
+                (excluded, ideal, m, grade) -> dummyCondition;
+
+        // when && then
+        assertThatThrownBy(() -> introductionMemberIdFetcher.fetch(memberId, IntroductionCacheKeyPrefix.DIAMOND, Grade.DIAMOND, supplier))
+                .isInstanceOf(MemberIdealNotFoundException.class);
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionQueryServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionQueryServiceTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionQueryServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionQueryServiceTest.java
@@ -1,0 +1,185 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import atwoz.atwoz.member.command.domain.member.Grade;
+import atwoz.atwoz.member.command.domain.member.Region;
+import atwoz.atwoz.member.command.domain.member.Religion;
+import atwoz.atwoz.member.query.introduction.intra.InterviewAnswerQueryResult;
+import atwoz.atwoz.member.query.introduction.intra.IntroductionQueryRepository;
+import atwoz.atwoz.member.query.introduction.intra.MemberIntroductionProfileQueryResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IntroductionQueryServiceTest {
+
+    @InjectMocks
+    private IntroductionQueryService introductionQueryService;
+
+    @Mock
+    private IntroductionQueryRepository introductionQueryRepository;
+
+    @Mock
+    private IntroductionMemberIdFetcher introductionMemberIdFetcher;
+
+    @Test
+    @DisplayName("findDiamondGradeIntroductions 메서드 테스트")
+    void findDiamondGradeIntroductionsTest() {
+        // given
+        long memberId = 1L;
+        Set<Long> introductionMemberIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        when(introductionMemberIdFetcher.fetch(
+                eq(memberId),
+                eq(IntroductionCacheKeyPrefix.DIAMOND),
+                eq(Grade.DIAMOND),
+                ArgumentMatchers.<IntroductionMemberIdFetcher.IntroductionConditionSupplier<Grade>>any()
+        )).thenReturn(introductionMemberIds);
+        List<MemberIntroductionProfileQueryResult> memberIntroductionProfileQueryResults = List.of();
+        when(introductionQueryRepository.findAllMemberIntroductionProfileQueryResultByMemberIds(memberId, introductionMemberIds))
+                .thenReturn(memberIntroductionProfileQueryResults);
+        List<InterviewAnswerQueryResult> interviewAnswerQueryResults = List.of();
+        when(introductionQueryRepository.findAllInterviewAnswerInfoByMemberIds(introductionMemberIds))
+                .thenReturn(interviewAnswerQueryResults);
+        List<MemberIntroductionProfileView> expectedResult = List.of();
+
+        // when && then
+        try (MockedStatic<MemberIntroductionProfileViewMapper> mockedStatic = mockStatic(MemberIntroductionProfileViewMapper.class)) {
+            mockedStatic.when(() -> MemberIntroductionProfileViewMapper.mapWithDefaultTag(memberIntroductionProfileQueryResults, interviewAnswerQueryResults))
+                    .thenReturn(expectedResult);
+            List<MemberIntroductionProfileView> result = introductionQueryService.findDiamondGradeIntroductions(memberId);
+            assertThat(result).isEqualTo(expectedResult);
+        }
+    }
+
+    @Test
+    @DisplayName("findSameHobbyIntroductions 메서드 테스트")
+    void findSameHobbyIntroductionsTest() {
+        // given
+        long memberId = 1L;
+        Set<Long> introductionMemberIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        when(introductionMemberIdFetcher.fetch(
+                eq(memberId),
+                eq(IntroductionCacheKeyPrefix.SAME_HOBBY),
+                isNull(),
+                ArgumentMatchers.<IntroductionMemberIdFetcher.IntroductionConditionSupplier<Set>>any()
+        )).thenReturn(introductionMemberIds);
+        List<MemberIntroductionProfileQueryResult> memberIntroductionProfileQueryResults = List.of();
+        when(introductionQueryRepository.findAllMemberIntroductionProfileQueryResultByMemberIds(memberId, introductionMemberIds))
+                .thenReturn(memberIntroductionProfileQueryResults);
+        List<InterviewAnswerQueryResult> interviewAnswerQueryResults = List.of();
+        when(introductionQueryRepository.findAllInterviewAnswerInfoByMemberIds(introductionMemberIds))
+                .thenReturn(interviewAnswerQueryResults);
+        List<MemberIntroductionProfileView> expectedResult = List.of();
+
+        // when && then
+        try (MockedStatic<MemberIntroductionProfileViewMapper> mockedStatic = mockStatic(MemberIntroductionProfileViewMapper.class)) {
+            mockedStatic.when(() -> MemberIntroductionProfileViewMapper.mapWithSameHobbyTag(memberIntroductionProfileQueryResults, interviewAnswerQueryResults))
+                    .thenReturn(expectedResult);
+            List<MemberIntroductionProfileView> result = introductionQueryService.findSameHobbyIntroductions(memberId);
+            assertThat(result).isEqualTo(expectedResult);
+        }
+    }
+
+    @Test
+    @DisplayName("findSameReligionIntroductions 메서드 테스트")
+    void findSameReligionIntroductionsTest() {
+        // given
+        long memberId = 1L;
+        Set<Long> introductionMemberIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        when(introductionMemberIdFetcher.fetch(
+                eq(memberId),
+                eq(IntroductionCacheKeyPrefix.SAME_RELIGION),
+                isNull(),
+                ArgumentMatchers.<IntroductionMemberIdFetcher.IntroductionConditionSupplier<Religion>>any()
+        )).thenReturn(introductionMemberIds);
+        List<MemberIntroductionProfileQueryResult> memberIntroductionProfileQueryResults = List.of();
+        when(introductionQueryRepository.findAllMemberIntroductionProfileQueryResultByMemberIds(memberId, introductionMemberIds))
+                .thenReturn(memberIntroductionProfileQueryResults);
+        List<InterviewAnswerQueryResult> interviewAnswerQueryResults = List.of();
+        when(introductionQueryRepository.findAllInterviewAnswerInfoByMemberIds(introductionMemberIds))
+                .thenReturn(interviewAnswerQueryResults);
+        List<MemberIntroductionProfileView> expectedResult = List.of();
+
+        // when && then
+        try (MockedStatic<MemberIntroductionProfileViewMapper> mockedStatic = mockStatic(MemberIntroductionProfileViewMapper.class)) {
+            mockedStatic.when(() -> MemberIntroductionProfileViewMapper.mapWithSameReligionTag(memberIntroductionProfileQueryResults, interviewAnswerQueryResults))
+                    .thenReturn(expectedResult);
+            List<MemberIntroductionProfileView> result = introductionQueryService.findSameReligionIntroductions(memberId);
+            assertThat(result).isEqualTo(expectedResult);
+        }
+    }
+
+    @Test
+    @DisplayName("findSameRegionIntroductions 메서드 테스트")
+    void findSameRegionIntroductionsTest() {
+        // given
+        long memberId = 1L;
+        Set<Long> introductionMemberIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        when(introductionMemberIdFetcher.fetch(
+                eq(memberId),
+                eq(IntroductionCacheKeyPrefix.SAME_REGION),
+                isNull(),
+                ArgumentMatchers.<IntroductionMemberIdFetcher.IntroductionConditionSupplier<Region>>any()
+        )).thenReturn(introductionMemberIds);
+        List<MemberIntroductionProfileQueryResult> memberIntroductionProfileQueryResults = List.of();
+        when(introductionQueryRepository.findAllMemberIntroductionProfileQueryResultByMemberIds(memberId, introductionMemberIds))
+                .thenReturn(memberIntroductionProfileQueryResults);
+        List<InterviewAnswerQueryResult> interviewAnswerQueryResults = List.of();
+        when(introductionQueryRepository.findAllInterviewAnswerInfoByMemberIds(introductionMemberIds))
+                .thenReturn(interviewAnswerQueryResults);
+        List<MemberIntroductionProfileView> expectedResult = List.of();
+
+        // when && then
+        try (MockedStatic<MemberIntroductionProfileViewMapper> mockedStatic = mockStatic(MemberIntroductionProfileViewMapper.class)) {
+            mockedStatic.when(() -> MemberIntroductionProfileViewMapper.mapWithDefaultTag(memberIntroductionProfileQueryResults, interviewAnswerQueryResults))
+                    .thenReturn(expectedResult);
+            List<MemberIntroductionProfileView> result = introductionQueryService.findSameRegionIntroductions(memberId);
+            assertThat(result).isEqualTo(expectedResult);
+        }
+    }
+
+    @Test
+    @DisplayName("findRecentlyJoinedIntroductions 메서드 테스트")
+    void findRecentlyJoinedIntroductionsTest() {
+        // given
+        long memberId = 1L;
+        Set<Long> introductionMemberIds = Set.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        when(introductionMemberIdFetcher.fetch(
+                eq(memberId),
+                eq(IntroductionCacheKeyPrefix.RECENTLY_JOINED),
+                isNull(),
+                ArgumentMatchers.<IntroductionMemberIdFetcher.IntroductionConditionSupplier<LocalDateTime>>any()
+        )).thenReturn(introductionMemberIds);
+        List<MemberIntroductionProfileQueryResult> memberIntroductionProfileQueryResults = List.of();
+        when(introductionQueryRepository.findAllMemberIntroductionProfileQueryResultByMemberIds(memberId, introductionMemberIds))
+                .thenReturn(memberIntroductionProfileQueryResults);
+        List<InterviewAnswerQueryResult> interviewAnswerQueryResults = List.of();
+        when(introductionQueryRepository.findAllInterviewAnswerInfoByMemberIds(introductionMemberIds))
+                .thenReturn(interviewAnswerQueryResults);
+        List<MemberIntroductionProfileView> expectedResult = List.of();
+
+        // when && then
+        try (MockedStatic<MemberIntroductionProfileViewMapper> mockedStatic = mockStatic(MemberIntroductionProfileViewMapper.class)) {
+            mockedStatic.when(() -> MemberIntroductionProfileViewMapper.mapWithDefaultTag(memberIntroductionProfileQueryResults, interviewAnswerQueryResults))
+                    .thenReturn(expectedResult);
+            List<MemberIntroductionProfileView> result = introductionQueryService.findRecentlyJoinedIntroductions(memberId);
+            assertThat(result).isEqualTo(expectedResult);
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionSearchConditionTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionSearchConditionTest.java
@@ -1,0 +1,140 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.vo.AgeRange;
+import atwoz.atwoz.member.command.domain.member.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IntroductionSearchConditionTest {
+
+    private final Set<Long> excludedIds = Set.of(1L, 2L);
+    private final AgeRange ageRange = AgeRange.of(20, 30);
+    private final Set<Long> hobbyIds = Set.of(10L, 20L);
+    private final Region region = Region.SEOUL;
+    private final Religion religion = Religion.CHRISTIAN;
+    private final SmokingStatus smokingStatus = SmokingStatus.NONE;
+    private final DrinkingStatus drinkingStatus = DrinkingStatus.NONE;
+
+    MemberIdeal getMockedMemberIdeal() {
+        MemberIdeal ideal = mock(MemberIdeal.class);
+        when(ideal.getAgeRange()).thenReturn(ageRange);
+        when(ideal.getHobbyIds()).thenReturn(hobbyIds);
+        when(ideal.getRegion()).thenReturn(region);
+        when(ideal.getReligion()).thenReturn(religion);
+        when(ideal.getSmokingStatus()).thenReturn(smokingStatus);
+        when(ideal.getDrinkingStatus()).thenReturn(drinkingStatus);
+        return ideal;
+    }
+
+    void assertCommonFields(IntroductionSearchCondition condition) {
+        assertThat(condition.getExcludedMemberIds()).isEqualTo(excludedIds);
+        assertThat(condition.getMinAge()).isEqualTo(ageRange.getMinAge());
+        assertThat(condition.getMaxAge()).isEqualTo(ageRange.getMaxAge());
+        assertThat(condition.getSmokingStatus()).isEqualTo(smokingStatus.name());
+        assertThat(condition.getDrinkingStatus()).isEqualTo(drinkingStatus.name());
+    }
+
+    @Test
+    @DisplayName("ofGrade 메서드 테스트")
+    void ofGradeTest() {
+        // given
+        MemberIdeal ideal = getMockedMemberIdeal();
+        Grade grade = Grade.DIAMOND;
+
+        // when
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofGrade(excludedIds, ideal, grade);
+
+        // then
+        assertCommonFields(condition);
+        assertThat(condition.getHobbyIds()).isEqualTo(hobbyIds);
+        assertThat(condition.getRegion()).isEqualTo(region.name());
+        assertThat(condition.getReligion()).isEqualTo(religion.name());
+        assertThat(condition.getMemberGrade()).isEqualTo(grade.name());
+        assertThat(condition.getJoinedAfter()).isNull();
+    }
+
+    @Test
+    @DisplayName("ofHobbyIds 메서드 테스트")
+    void ofHobbyIdsTest() {
+        // given
+        MemberIdeal ideal = getMockedMemberIdeal();
+        Set<Long> memberHobbyIds = Set.of(30L, 40L);
+
+        // when
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofHobbyIds(excludedIds, ideal, memberHobbyIds);
+
+        // then
+        assertCommonFields(condition);
+        assertThat(condition.getHobbyIds()).isEqualTo(memberHobbyIds);
+        assertThat(condition.getRegion()).isEqualTo(region.name());
+        assertThat(condition.getReligion()).isEqualTo(religion.name());
+        assertThat(condition.getMemberGrade()).isNull();
+        assertThat(condition.getJoinedAfter()).isNull();
+    }
+
+    @Test
+    @DisplayName("ofReligion 메서드 테스트")
+    void ofReligionTest() {
+        // given
+        MemberIdeal ideal = getMockedMemberIdeal();
+        Religion memberReligion = Religion.NONE;
+
+        // when
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofReligion(excludedIds, ideal, memberReligion);
+
+        // then
+        assertCommonFields(condition);
+        assertThat(condition.getHobbyIds()).isEqualTo(hobbyIds);
+        assertThat(condition.getRegion()).isEqualTo(region.name());
+        assertThat(condition.getReligion()).isEqualTo(memberReligion.name());
+        assertThat(condition.getMemberGrade()).isNull();
+        assertThat(condition.getJoinedAfter()).isNull();
+    }
+
+    @Test
+    @DisplayName("ofRegion 메서드 테스트")
+    void ofRegionTest() {
+        // given
+        MemberIdeal ideal = getMockedMemberIdeal();
+        Region memberRegion = Region.DAEJEON;
+
+        // when
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofRegion(excludedIds, ideal, memberRegion);
+
+        // then
+        assertCommonFields(condition);
+        assertThat(condition.getHobbyIds()).isEqualTo(hobbyIds);
+        assertThat(condition.getRegion()).isEqualTo(memberRegion.name());
+        assertThat(condition.getReligion()).isEqualTo(religion.name());
+        assertThat(condition.getMemberGrade()).isNull();
+        assertThat(condition.getJoinedAfter()).isNull();
+    }
+
+    @Test
+    @DisplayName("ofJoinedAfter 메서드 테스트")
+    void ofJoinedAfterTest() {
+        // given
+        MemberIdeal ideal = getMockedMemberIdeal();
+        LocalDateTime joinedAfter = LocalDateTime.now();
+
+        // when
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofJoinDate(excludedIds, ideal, joinedAfter);
+
+        // then
+        assertCommonFields(condition);
+        assertThat(condition.getHobbyIds()).isEqualTo(hobbyIds);
+        assertThat(condition.getRegion()).isEqualTo(region.name());
+        assertThat(condition.getReligion()).isEqualTo(religion.name());
+        assertThat(condition.getMemberGrade()).isNull();
+        assertThat(condition.getJoinedAfter()).isEqualTo(joinedAfter);
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionSearchConditionTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionSearchConditionTest.java
@@ -23,6 +23,7 @@ class IntroductionSearchConditionTest {
     private final Religion religion = Religion.CHRISTIAN;
     private final SmokingStatus smokingStatus = SmokingStatus.NONE;
     private final DrinkingStatus drinkingStatus = DrinkingStatus.NONE;
+    private final Gender gender = Gender.MALE;
 
     MemberIdeal getMockedMemberIdeal() {
         MemberIdeal ideal = mock(MemberIdeal.class);
@@ -41,6 +42,7 @@ class IntroductionSearchConditionTest {
         assertThat(condition.getMaxAge()).isEqualTo(ageRange.getMaxAge());
         assertThat(condition.getSmokingStatus()).isEqualTo(smokingStatus.name());
         assertThat(condition.getDrinkingStatus()).isEqualTo(drinkingStatus.name());
+        assertThat(condition.getGender()).isEqualTo(gender.name());
     }
 
     @Test
@@ -51,7 +53,7 @@ class IntroductionSearchConditionTest {
         Grade grade = Grade.DIAMOND;
 
         // when
-        IntroductionSearchCondition condition = IntroductionSearchCondition.ofGrade(excludedIds, ideal, grade);
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofGrade(excludedIds, ideal, gender, grade);
 
         // then
         assertCommonFields(condition);
@@ -70,7 +72,7 @@ class IntroductionSearchConditionTest {
         Set<Long> memberHobbyIds = Set.of(30L, 40L);
 
         // when
-        IntroductionSearchCondition condition = IntroductionSearchCondition.ofHobbyIds(excludedIds, ideal, memberHobbyIds);
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofHobbyIds(excludedIds, ideal, gender, memberHobbyIds);
 
         // then
         assertCommonFields(condition);
@@ -89,7 +91,7 @@ class IntroductionSearchConditionTest {
         Religion memberReligion = Religion.NONE;
 
         // when
-        IntroductionSearchCondition condition = IntroductionSearchCondition.ofReligion(excludedIds, ideal, memberReligion);
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofReligion(excludedIds, ideal, gender, memberReligion);
 
         // then
         assertCommonFields(condition);
@@ -108,7 +110,7 @@ class IntroductionSearchConditionTest {
         Region memberRegion = Region.DAEJEON;
 
         // when
-        IntroductionSearchCondition condition = IntroductionSearchCondition.ofRegion(excludedIds, ideal, memberRegion);
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofRegion(excludedIds, ideal, gender, memberRegion);
 
         // then
         assertCommonFields(condition);
@@ -127,7 +129,7 @@ class IntroductionSearchConditionTest {
         LocalDateTime joinedAfter = LocalDateTime.now();
 
         // when
-        IntroductionSearchCondition condition = IntroductionSearchCondition.ofJoinDate(excludedIds, ideal, joinedAfter);
+        IntroductionSearchCondition condition = IntroductionSearchCondition.ofJoinDate(excludedIds, ideal, gender, joinedAfter);
 
         // then
         assertCommonFields(condition);

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/MemberIntroductionProfileViewMapperTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/MemberIntroductionProfileViewMapperTest.java
@@ -1,0 +1,112 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import atwoz.atwoz.member.query.introduction.intra.InterviewAnswerQueryResult;
+import atwoz.atwoz.member.query.introduction.intra.MemberIntroductionProfileQueryResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberIntroductionProfileViewMapperTest {
+    private final Long expectedMemberId = 1L;
+    private final String expectedProfileImageUrl = "imageUrl";
+    private final List<String> expectedHobbies = List.of("drawing", "cycling");
+    private final String expectedReligion = "Buddhist";
+    private final String expectedMbti = "INFJ";
+    private final String expectedInterviewAnswer = "Third Answer";
+    private final boolean expectedIsIntroduced = false;
+
+    @Test
+    @DisplayName("mapWithDefaultTag 메서드 테스트")
+    void mapWithDefaultTagTest() {
+        // given
+        List<String> expectedTags = new ArrayList<>(List.of());
+        expectedTags.addAll(expectedHobbies);
+        expectedTags.add(expectedReligion);
+        expectedTags.add(expectedMbti);
+
+        List<MemberIntroductionProfileQueryResult> profileResults = getProfileQueryResults();
+        List<InterviewAnswerQueryResult> interviewResults = getInterviewResults();
+
+        // when
+        List<MemberIntroductionProfileView> views =
+                MemberIntroductionProfileViewMapper.mapWithDefaultTag(profileResults, interviewResults);
+
+        // then
+        assertProfileView(views, expectedTags);
+    }
+
+    @Test
+    @DisplayName("mapWithSameHobbyTag 메서드 테스트")
+    void mapWithSameHobbyTagTest() {
+        // given
+        List<String> expectedTags = new ArrayList<>(List.of());
+        expectedTags.add(expectedReligion);
+        expectedTags.add(expectedMbti);
+
+        List<MemberIntroductionProfileQueryResult> profileResults = getProfileQueryResults();
+        List<InterviewAnswerQueryResult> interviewResults = getInterviewResults();
+
+        // when
+        List<MemberIntroductionProfileView> views =
+                MemberIntroductionProfileViewMapper.mapWithSameHobbyTag(profileResults, interviewResults);
+
+        // then
+        assertProfileView(views, expectedTags);
+    }
+
+    @Test
+    @DisplayName("mapWithSameReligionTag 메서드 테스트")
+    void mapWithSameReligionTagTest() {
+        // given
+        List<String> expectedTags = new ArrayList<>(List.of());
+        expectedTags.addAll(expectedHobbies);
+        expectedTags.add(expectedMbti);
+
+        List<MemberIntroductionProfileQueryResult> profileResults = getProfileQueryResults();
+        List<InterviewAnswerQueryResult> interviewResults = getInterviewResults();
+
+        // when
+        List<MemberIntroductionProfileView> views =
+                MemberIntroductionProfileViewMapper.mapWithSameReligionTag(profileResults, interviewResults);
+
+        // then
+        assertProfileView(views, expectedTags);
+    }
+
+    private List<MemberIntroductionProfileQueryResult> getProfileQueryResults() {
+        MemberIntroductionProfileQueryResult profileResult = new MemberIntroductionProfileQueryResult(
+                expectedMemberId,
+                expectedProfileImageUrl,
+                expectedHobbies,
+                expectedReligion,
+                expectedMbti,
+                expectedIsIntroduced
+        );
+
+        return List.of(profileResult);
+    }
+
+    private List<InterviewAnswerQueryResult> getInterviewResults() {
+        InterviewAnswerQueryResult interviewResult = new InterviewAnswerQueryResult(
+                expectedMemberId,
+                expectedInterviewAnswer
+        );
+
+        return List.of(interviewResult);
+    }
+
+    private void assertProfileView(List<MemberIntroductionProfileView> views, List<String> expectedTags) {
+        assertThat(views).hasSize(1);
+        MemberIntroductionProfileView view = views.get(0);
+        assertThat(view.memberId()).isEqualTo(expectedMemberId);
+        assertThat(view.profileImageUrl()).isEqualTo(expectedProfileImageUrl);
+        List<String> tags = view.tags();
+        assertThat(tags).containsExactlyElementsOf(expectedTags);
+        assertThat(view.interviewAnswerContent()).isEqualTo(expectedInterviewAnswer);
+        assertThat(view.isIntroduced()).isEqualTo(expectedIsIntroduced);
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepositoryTest.java
@@ -38,7 +38,7 @@ class IntroductionQueryRepositoryTest {
     @DisplayName("findAllIntroductionMemberId 메서드 테스트")
     class FindAllIntroductionMemberIdTest {
         @ParameterizedTest
-        @ValueSource(strings = {"excludedIds", "minAge", "maxAge", "hobbyIds", "religion", "region", "smokingStatus", "drinkingStatus", "memberGrade", "joinedAfter", "null"})
+        @ValueSource(strings = {"excludedIds", "minAge", "maxAge", "hobbyIds", "religion", "region", "smokingStatus", "drinkingStatus", "memberGrade", "gender", "joinedAfter", "null"})
         @DisplayName("search condition에 대한 검증")
         void findIntroductionMemberIdsWhenSuccess(String fieldName) {
             // given
@@ -60,6 +60,7 @@ class IntroductionQueryRepositoryTest {
                     .region(Region.DAEJEON)
                     .smokingStatus(SmokingStatus.DAILY)
                     .drinkingStatus(DrinkingStatus.SOCIAL)
+                    .gender(Gender.MALE)
                     .build();
             member1.updateProfile(profile1);
 
@@ -74,6 +75,7 @@ class IntroductionQueryRepositoryTest {
                     .region(Region.SEOUL)
                     .smokingStatus(SmokingStatus.NONE)
                     .drinkingStatus(DrinkingStatus.NONE)
+                    .gender(Gender.FEMALE)
                     .build();
             member2.updateProfile(profile2);
 
@@ -90,6 +92,7 @@ class IntroductionQueryRepositoryTest {
             when(condition.getSmokingStatus()).thenReturn(fieldName.equals("smokingStatus") ? member1.getProfile().getSmokingStatus().name() : null);
             when(condition.getDrinkingStatus()).thenReturn(fieldName.equals("drinkingStatus") ? member1.getProfile().getDrinkingStatus().name() : null);
             when(condition.getMemberGrade()).thenReturn(fieldName.equals("memberGrade") ? Grade.DIAMOND.name() : null);
+            when(condition.getGender()).thenReturn(fieldName.equals("gender")? member1.getProfile().getGender().name() : null);
             when(condition.getJoinedAfter()).thenReturn(fieldName.equals("joinedAfter") ? member2.getCreatedAt() : null);
 
             // when
@@ -114,6 +117,8 @@ class IntroductionQueryRepositoryTest {
                 assertThat(result).containsExactly(member1.getId());
             } else if (fieldName.equals("memberGrade")) {
                 assertThat(result).isEmpty();
+            } else if (fieldName.equals("gender")) {
+                assertThat(result).containsExactly(member1.getId());
             } else if (fieldName.equals("joinedAfter")) {
                 assertThat(result).containsExactly(member2.getId());
             } else {

--- a/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepositoryTest.java
@@ -1,0 +1,224 @@
+package atwoz.atwoz.member.query.introduction.intra;
+
+import atwoz.atwoz.QuerydslConfig;
+import atwoz.atwoz.admin.command.domain.hobby.Hobby;
+import atwoz.atwoz.member.command.domain.introduction.MemberIntroduction;
+import atwoz.atwoz.member.command.domain.member.*;
+import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
+import atwoz.atwoz.member.command.domain.profileImage.ProfileImage;
+import atwoz.atwoz.member.command.domain.profileImage.vo.ImageUrl;
+import atwoz.atwoz.member.query.introduction.application.IntroductionSearchCondition;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@DataJpaTest
+@Import({QuerydslConfig.class, IntroductionQueryRepository.class})
+class IntroductionQueryRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private IntroductionQueryRepository introductionQueryRepository;
+
+    @Nested
+    @DisplayName("findAllIntroductionMemberId 메서드 테스트")
+    class FindAllIntroductionMemberIdTest {
+        @ParameterizedTest
+        @ValueSource(strings = {"excludedIds", "minAge", "maxAge", "hobbyIds", "religion", "region", "smokingStatus", "drinkingStatus", "memberGrade", "joinedAfter", "null"})
+        @DisplayName("search condition에 대한 검증")
+        void findIntroductionMemberIdsWhenSuccess(String fieldName) {
+            // given
+            Hobby hobby1 = Hobby.from("취미1");
+            Hobby hobby2 = Hobby.from("취미2");
+            Hobby hobby3 = Hobby.from("취미3");
+            Hobby hobby4 = Hobby.from("취미4");
+            entityManager.persist(hobby1);
+            entityManager.persist(hobby2);
+            entityManager.persist(hobby3);
+            entityManager.persist(hobby4);
+            entityManager.flush();
+
+            Member member1 = Member.fromPhoneNumber("01011111111");
+            MemberProfile profile1 = MemberProfile.builder()
+                    .age(20)
+                    .hobbyIds(Set.of(hobby1.getId(), hobby2.getId()))
+                    .religion(Religion.BUDDHIST)
+                    .region(Region.DAEJEON)
+                    .smokingStatus(SmokingStatus.DAILY)
+                    .drinkingStatus(DrinkingStatus.SOCIAL)
+                    .build();
+            member1.updateProfile(profile1);
+
+            entityManager.persist(member1);
+            entityManager.flush();
+
+            Member member2 = Member.fromPhoneNumber("01022222222");
+            MemberProfile profile2 = MemberProfile.builder()
+                    .age(40)
+                    .hobbyIds(Set.of(hobby3.getId(), hobby4.getId()))
+                    .religion(Religion.NONE)
+                    .region(Region.SEOUL)
+                    .smokingStatus(SmokingStatus.NONE)
+                    .drinkingStatus(DrinkingStatus.NONE)
+                    .build();
+            member2.updateProfile(profile2);
+
+            entityManager.persist(member2);
+            entityManager.flush();
+
+            IntroductionSearchCondition condition = mock(IntroductionSearchCondition.class);
+            when(condition.getExcludedMemberIds()).thenReturn(fieldName.equals("excludedIds") ? Set.of(member2.getId()) : Set.of());
+            when(condition.getMinAge()).thenReturn(fieldName.equals("minAge") ? member1.getProfile().getAge() + 1 : null);
+            when(condition.getMaxAge()).thenReturn(fieldName.equals("maxAge") ? member2.getProfile().getAge() - 1 : null);
+            when(condition.getHobbyIds()).thenReturn(fieldName.equals("hobbyIds") ? member1.getProfile().getHobbyIds() : Set.of());
+            when(condition.getReligion()).thenReturn(fieldName.equals("religion") ? member1.getProfile().getReligion().name() : null);
+            when(condition.getRegion()).thenReturn(fieldName.equals("region") ? member1.getProfile().getRegion().name() : null);
+            when(condition.getSmokingStatus()).thenReturn(fieldName.equals("smokingStatus") ? member1.getProfile().getSmokingStatus().name() : null);
+            when(condition.getDrinkingStatus()).thenReturn(fieldName.equals("drinkingStatus") ? member1.getProfile().getDrinkingStatus().name() : null);
+            when(condition.getMemberGrade()).thenReturn(fieldName.equals("memberGrade") ? Grade.DIAMOND.name() : null);
+            when(condition.getJoinedAfter()).thenReturn(fieldName.equals("joinedAfter") ? member2.getCreatedAt() : null);
+
+            // when
+            Set<Long> result = introductionQueryRepository.findAllIntroductionMemberId(condition);
+
+            // then
+            if (fieldName.equals("excludedIds")) {
+                assertThat(result).containsExactly(member1.getId());
+            } else if (fieldName.equals("minAge")) {
+                assertThat(result).containsExactly(member2.getId());
+            } else if (fieldName.equals("maxAge")) {
+                assertThat(result).containsExactly(member1.getId());
+            } else if (fieldName.equals("hobbyIds")) {
+                assertThat(result).containsExactly(member1.getId());
+            } else if (fieldName.equals("religion")) {
+                assertThat(result).containsExactly(member1.getId());
+            } else if (fieldName.equals("region")) {
+                assertThat(result).containsExactly(member1.getId());
+            } else if (fieldName.equals("smokingStatus")) {
+                assertThat(result).containsExactly(member1.getId());
+            } else if (fieldName.equals("drinkingStatus")) {
+                assertThat(result).containsExactly(member1.getId());
+            } else if (fieldName.equals("memberGrade")) {
+                assertThat(result).isEmpty();
+            } else if (fieldName.equals("joinedAfter")) {
+                assertThat(result).containsExactly(member2.getId());
+            } else {
+                assertThat(result).containsExactlyInAnyOrder(member1.getId(), member2.getId());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllMemberIntroductionProfileQueryResultByMemberIds 메서드 테스트")
+    class FindAllMemberIntroductionProfileQueryResultByMemberIdsIdsTest {
+        @ParameterizedTest
+        @ValueSource(strings = {"introduced", "notIntroduced1", "notIntroduced2"})
+        @DisplayName("멤버 ID 목록에 해당하는 회원의 소개 프로필 리턴")
+        void findAllMemberIntroductionProfileQueryResultByMemberIdsWhenSuccess(String fieldName) {
+            // given
+            Hobby hobby1 = Hobby.from("취미1");
+            Hobby hobby2 = Hobby.from("취미2");
+            Hobby hobby3 = Hobby.from("취미3");
+            Hobby hobby4 = Hobby.from("취미4");
+            entityManager.persist(hobby1);
+            entityManager.persist(hobby2);
+            entityManager.persist(hobby3);
+            entityManager.persist(hobby4);
+            entityManager.flush();
+
+            Member me = Member.fromPhoneNumber("01011111111");
+            MemberProfile profile1 = MemberProfile.builder()
+                    .age(20)
+                    .hobbyIds(Set.of(hobby1.getId(), hobby2.getId()))
+                    .religion(Religion.BUDDHIST)
+                    .region(Region.DAEJEON)
+                    .smokingStatus(SmokingStatus.DAILY)
+                    .drinkingStatus(DrinkingStatus.SOCIAL)
+                    .build();
+            me.updateProfile(profile1);
+
+            entityManager.persist(me);
+            entityManager.flush();
+
+            Member introductionTargetMember = Member.fromPhoneNumber("01022222222");
+            MemberProfile introductionTargetMemberProfile = MemberProfile.builder()
+                    .age(40)
+                    .hobbyIds(Set.of(hobby3.getId(), hobby4.getId()))
+                    .religion(Religion.NONE)
+                    .region(Region.SEOUL)
+                    .smokingStatus(SmokingStatus.NONE)
+                    .drinkingStatus(DrinkingStatus.NONE)
+                    .mbti(Mbti.ISTP)
+                    .build();
+            introductionTargetMember.updateProfile(introductionTargetMemberProfile);
+
+            entityManager.persist(introductionTargetMember);
+            entityManager.flush();
+
+            ProfileImage primaryProfileImage = ProfileImage.builder()
+                    .memberId(introductionTargetMember.getId())
+                    .imageUrl(ImageUrl.from("https://example.com"))
+                    .isPrimary(true)
+                    .order(1)
+                    .build();
+
+            ProfileImage nonPrimaryProfileImage = ProfileImage.builder()
+                    .memberId(introductionTargetMember.getId())
+                    .imageUrl(ImageUrl.from("https://example2.com"))
+                    .isPrimary(false)
+                    .order(2)
+                    .build();
+
+            entityManager.persist(primaryProfileImage);
+            entityManager.persist(nonPrimaryProfileImage);
+
+            if (fieldName.equals("introduced")) {
+                MemberIntroduction memberIntroduction = MemberIntroduction.of(me.getId(), introductionTargetMember.getId());
+                entityManager.persist(memberIntroduction);
+                entityManager.flush();
+            }
+            if (fieldName.equals("notIntroduced1")) {
+                MemberIntroduction memberIntroduction = MemberIntroduction.of(introductionTargetMember.getId(), me.getId());
+                entityManager.persist(memberIntroduction);
+                entityManager.flush();
+            }
+            if (fieldName.equals("notIntroduced2")) {
+                // do nothing
+            }
+
+            // when
+            List<MemberIntroductionProfileQueryResult> result = introductionQueryRepository
+                    .findAllMemberIntroductionProfileQueryResultByMemberIds(
+                            me.getId(),
+                            Set.of(introductionTargetMember.getId()));
+
+            // then
+            assertThat(result).hasSize(1);
+            MemberIntroductionProfileQueryResult memberIntroductionProfileQueryResult = result.get(0);
+            assertThat(memberIntroductionProfileQueryResult.memberId()).isEqualTo(introductionTargetMember.getId());
+            assertThat(memberIntroductionProfileQueryResult.profileImageUrl()).isEqualTo(primaryProfileImage.getUrl());
+            assertThat(memberIntroductionProfileQueryResult.hobbies()).containsExactlyInAnyOrder(hobby3.getName(), hobby4.getName());
+            assertThat(memberIntroductionProfileQueryResult.religion()).isEqualTo(introductionTargetMember.getProfile().getReligion().name());
+            assertThat(memberIntroductionProfileQueryResult.mbti()).isEqualTo(introductionTargetMember.getProfile().getMbti().name());
+            if (fieldName.equals("introduced")) {
+                assertThat(memberIntroductionProfileQueryResult.isIntroduced()).isTrue();
+            } else {
+                assertThat(memberIntroductionProfileQueryResult.isIntroduced()).isFalse();
+            }
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionRedisRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionRedisRepositoryTest.java
@@ -1,0 +1,136 @@
+package atwoz.atwoz.member.query.introduction.intra;
+
+import atwoz.atwoz.member.query.introduction.intra.exception.IntroductionMemberIdSerializationFailedException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.Date;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IntroductionRedisRepositoryTest {
+
+    @InjectMocks
+    private IntroductionRedisRepository repository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOps;
+
+    @Mock
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Nested
+    @DisplayName("saveIntroductionMemberIds 메서드 테스트")
+    class SaveIntroductionMemberIdsTest {
+        @Test
+        @DisplayName("Redis에 올바르게 저장되고 만료 시간 설정")
+        void saveIntroductionMemberIdWhenSuccess() throws JsonProcessingException {
+            // given
+            String key = "testKey";
+            Set<Long> ids = Set.of(1L, 2L, 3L);
+            Date expireAt = new Date();
+            String json = "[1,2,3]";
+
+            when(mapper.writeValueAsString(ids)).thenReturn(json);
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+            // when
+            repository.saveIntroductionMemberIds(key, ids, expireAt);
+
+            // then
+            String fullKey = "introduction:" + key;
+            verify(valueOps).set(eq(fullKey), eq(json));
+            verify(redisTemplate).expireAt(eq(fullKey), eq(expireAt));
+        }
+
+        @Test
+        @DisplayName("JSON 직렬화 실패 시 예외 발생")
+        void throwExceptionWhenSerializationFailed() throws JsonProcessingException {
+            // given
+            String key = "testKey";
+            Set<Long> ids = Set.of(1L, 2L, 3L);
+            Date expireAt = new Date();
+
+            when(mapper.writeValueAsString(ids)).thenThrow(new JsonProcessingException("error") {});
+
+            // when & then
+            assertThatThrownBy(() -> repository.saveIntroductionMemberIds(key, ids, expireAt))
+                    .isInstanceOf(IntroductionMemberIdSerializationFailedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("findIntroductionMemberIds 메서드 테스트")
+    class FindIntroductionMemberIdsTest {
+        @Test
+        @DisplayName("Redis에 값이 없으면 빈 집합 반환")
+        void returnEmptySetWhenRedisHasNoValue() {
+            // given
+            String key = "testKey";
+            String fullKey = "introduction:" + key;
+
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.get(fullKey)).thenReturn(null);
+
+            // when
+            Set<Long> result = repository.findIntroductionMemberIds(key);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Redis에 저장된 JSON을 올바르게 역직렬화하여 반환")
+        void returnIntroductionMemberIdsWhenRedisHasValue() throws JsonProcessingException {
+            // given
+            String key = "testKey";
+            String fullKey = "introduction:" + key;
+            String json = "[1,2,3]";
+            Set<Long> ids = Set.of(1L, 2L, 3L);
+
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.get(fullKey)).thenReturn(json);
+            when(mapper.readValue(eq(json), any(TypeReference.class))).thenReturn(ids);
+
+            // when
+            Set<Long> result = repository.findIntroductionMemberIds(key);
+
+            // then
+            assertThat(result).isEqualTo(ids);
+        }
+
+        @Test
+        @DisplayName("Redis에 저장된 JSON 역직렬화 실패 시 예외 발생")
+        void throwExceptionWhenDeserializationFailed() throws JsonProcessingException {
+            // given
+            String key = "testKey";
+            String fullKey = "introduction:" + key;
+            String json = "[1,2,3]";
+
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.get(fullKey)).thenReturn(json);
+            when(mapper.readValue(eq(json), any(TypeReference.class))).thenThrow(new JsonProcessingException("error") {});
+
+            // when & then
+            assertThatThrownBy(() -> repository.findIntroductionMemberIds(key))
+                    .isInstanceOf(IntroductionMemberIdSerializationFailedException.class);
+        }
+    }
+}


### PR DESCRIPTION
### 관련 이슈
- closes #101 

<br>

### 작업 내용
- 멤버에 Grade 추가
- 멤버 이상형 entity 구현
- 멤버 소개 내역 entity 구현
- 소개받고 싶은 이성 목록 조회 (멤버 등급, 취미, 지역, 종교, 최근 가입자) 기능 구현

<br>

### 참고 자료
-

<br>

### 노트
- 소개받고 싶은 이성 기능의 요구사항
  - 멤버 이상형 필터 적용
  - 소개 타입에 따라 추가 필터 적용 (멤버 등급, 취미, 지역, 종교, 최근 가입자)
  - 00시 ~ 24시까지 기존에 조회한 10명을 그대로 노출
  - 다음날은 새로운 멤버 목록 제공
  - 전날 소개받은 이성은 제외
  - 전날 소개받고 싶은 이성 목록에 있었지만 소개받지 않은 대상은 포함 가능
  - 매칭 기록 있는 대상 제외
  - 최신순 정렬

- `00시 ~ 24시까지 기존에 조회한 10명을 그대로 노출` 을 위해서 redis에 10명 id list를 저장하고 00시에 expire 하도록 구현했어요
- key는 `introduction:소개타입:멤버아이디` 형식입니다

- 소개 타입에 따라 쿼리가 달라지는 부분이 적어서 하나의 쿼리를 구현하고 `IntroductionSearchCondition` 객체를 사용해서 필터를 각각 적용할 수 있도록 했어요

- `IntroductionMemberIdFetcher` 에 redis에 저장된 10명의 id list를 가져오거나, 없다면 조회해서 redis에 저장하고 리턴하는 역할을 분리했어요

- `IntroductionQueryService`는 `IntroductionMemberIdFetcher`으로 id list를 가져온 뒤 해당 id들의 데이터를 조회해서 리턴해주는 역할입니다.

- 소개받고 싶은 이성 기능이 조금 복잡해서 보다가 모호한 부분있으면 코멘트 남겨주시면 최대한 빨리 설명 추가 해둘게요!