### PR TITLE
상대방 프로필 조회 쿼리 계층 수정

### DIFF
--- a/src/main/java/atwoz/atwoz/interview/command/domain/question/InterviewQuestion.java
+++ b/src/main/java/atwoz/atwoz/interview/command/domain/question/InterviewQuestion.java
@@ -14,6 +14,7 @@ import lombok.NonNull;
 public class InterviewQuestion extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
     private Long id;
 
     @Getter
@@ -21,6 +22,7 @@ public class InterviewQuestion extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)")
+    @Getter
     private InterviewCategory category;
 
     @Getter

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberController.java
@@ -6,14 +6,18 @@ import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.member.command.application.member.MemberContactService;
 import atwoz.atwoz.member.command.application.member.MemberProfileService;
+import atwoz.atwoz.member.presentation.member.dto.MemberProfileResponse;
 import atwoz.atwoz.member.presentation.member.dto.MemberProfileUpdateRequest;
 import atwoz.atwoz.member.query.member.MemberQueryRepository;
+import atwoz.atwoz.member.query.member.view.InterviewResultView;
 import atwoz.atwoz.member.query.member.view.MemberContactView;
 import atwoz.atwoz.member.query.member.view.MemberProfileView;
 import atwoz.atwoz.member.query.member.view.OtherMemberProfileView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/member")
@@ -40,14 +44,16 @@ public class MemberController {
     }
 
     @GetMapping("/{memberId}")
-    public ResponseEntity<BaseResponse<OtherMemberProfileView>> getOtherProfile(@AuthPrincipal AuthContext authContext, @PathVariable Long memberId) {
-        OtherMemberProfileView response = memberQueryRepository.findOtherProfileByMemberId(authContext.getId(), memberId).orElse(null);
+    public ResponseEntity<BaseResponse<MemberProfileResponse>> getOtherProfile(@AuthPrincipal AuthContext authContext, @PathVariable Long memberId) {
+        OtherMemberProfileView profileView = memberQueryRepository.findOtherProfileByMemberId(authContext.getId(), memberId).orElse(null);
+        List<InterviewResultView> interviewResultView = memberQueryRepository.findInterviewsByMemberId(memberId);
 
-        if (response == null) {
+        if (profileView == null) {
             return ResponseEntity.status(404)
                     .body(BaseResponse.from(StatusType.NOT_FOUND));
         }
-        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, response));
+
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, new MemberProfileResponse(profileView, interviewResultView)));
     }
 
     @PostMapping("/profile/dormant")

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberController.java
@@ -46,14 +46,14 @@ public class MemberController {
     @GetMapping("/{memberId}")
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getOtherProfile(@AuthPrincipal AuthContext authContext, @PathVariable Long memberId) {
         OtherMemberProfileView profileView = memberQueryRepository.findOtherProfileByMemberId(authContext.getId(), memberId).orElse(null);
-        List<InterviewResultView> interviewResultView = memberQueryRepository.findInterviewsByMemberId(memberId);
+        List<InterviewResultView> interviewResultViews = memberQueryRepository.findInterviewsByMemberId(memberId);
 
         if (profileView == null) {
             return ResponseEntity.status(404)
                     .body(BaseResponse.from(StatusType.NOT_FOUND));
         }
 
-        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, new MemberProfileResponse(profileView, interviewResultView)));
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, new MemberProfileResponse(profileView, interviewResultViews)));
     }
 
     @PostMapping("/profile/dormant")

--- a/src/main/java/atwoz/atwoz/member/presentation/member/dto/MemberProfileResponse.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/dto/MemberProfileResponse.java
@@ -1,0 +1,18 @@
+package atwoz.atwoz.member.presentation.member.dto;
+
+import atwoz.atwoz.member.query.member.view.BasicMemberInfo;
+import atwoz.atwoz.member.query.member.view.InterviewResultView;
+import atwoz.atwoz.member.query.member.view.MatchInfo;
+import atwoz.atwoz.member.query.member.view.OtherMemberProfileView;
+
+import java.util.List;
+
+public record MemberProfileResponse(
+        BasicMemberInfo basicMemberInfo,
+        MatchInfo matchInfo,
+        List<InterviewResultView> interviews
+) {
+    public MemberProfileResponse(OtherMemberProfileView otherMemberProfileView, List<InterviewResultView> interviews) {
+        this(otherMemberProfileView.basicMemberInfo(), otherMemberProfileView.matchInfo(), interviews);
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/member/MemberQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/MemberQueryRepository.java
@@ -121,7 +121,9 @@ public class MemberQueryRepository {
                 .innerJoin(interviewAnswer).on(getInterviewAnswerJoinCondition(memberId))
                 .select(
                         new QInterviewResultView(interviewQuestion.content, interviewQuestion.category.stringValue(), interviewAnswer.content)
-                ).fetch();
+                )
+                .where(interviewQuestion.isPublic.eq(true))
+                .fetch();
     }
 
     private BooleanExpression getMatchJoinCondition(Long memberId, Long otherMemberId) {

--- a/src/main/java/atwoz/atwoz/member/query/member/MemberQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/MemberQueryRepository.java
@@ -8,10 +8,13 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static atwoz.atwoz.admin.command.domain.hobby.QHobby.hobby;
 import static atwoz.atwoz.admin.command.domain.job.QJob.job;
+import static atwoz.atwoz.interview.command.domain.answer.QInterviewAnswer.interviewAnswer;
+import static atwoz.atwoz.interview.command.domain.question.QInterviewQuestion.interviewQuestion;
 import static atwoz.atwoz.match.command.domain.match.QMatch.match;
 import static atwoz.atwoz.member.command.domain.member.QMember.member;
 import static atwoz.atwoz.member.command.domain.profileImage.QProfileImage.profileImage;
@@ -112,10 +115,23 @@ public class MemberQueryRepository {
         return Optional.ofNullable(otherMemberProfileView);
     }
 
+    public List<InterviewResultView> findInterviewsByMemberId(Long memberId) {
+        return queryFactory
+                .from(interviewQuestion)
+                .innerJoin(interviewAnswer).on(getAnswerJoinCondition(memberId))
+                .select(
+                        new QInterviewResultView(interviewQuestion.content, interviewQuestion.category.stringValue(), interviewAnswer.content)
+                ).fetch();
+    }
+
     private BooleanExpression getMatchJoinCondition(Long memberId, Long otherMemberId) {
         return (match.requesterId.eq(memberId).and(match.responderId.eq(otherMemberId))
                 .or(match.requesterId.eq(otherMemberId).and(match.responderId.eq(memberId))))
                 .and(match.status.notIn(MatchStatus.REJECT_CHECKED, MatchStatus.EXPIRED));
+    }
+
+    private BooleanExpression getAnswerJoinCondition(Long memberId) {
+        return interviewQuestion.id.eq(interviewAnswer.id).and(interviewAnswer.memberId.eq(memberId));
     }
 
 

--- a/src/main/java/atwoz/atwoz/member/query/member/MemberQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/MemberQueryRepository.java
@@ -118,7 +118,7 @@ public class MemberQueryRepository {
     public List<InterviewResultView> findInterviewsByMemberId(Long memberId) {
         return queryFactory
                 .from(interviewQuestion)
-                .innerJoin(interviewAnswer).on(getAnswerJoinCondition(memberId))
+                .innerJoin(interviewAnswer).on(getInterviewAnswerJoinCondition(memberId))
                 .select(
                         new QInterviewResultView(interviewQuestion.content, interviewQuestion.category.stringValue(), interviewAnswer.content)
                 ).fetch();
@@ -130,9 +130,7 @@ public class MemberQueryRepository {
                 .and(match.status.notIn(MatchStatus.REJECT_CHECKED, MatchStatus.EXPIRED));
     }
 
-    private BooleanExpression getAnswerJoinCondition(Long memberId) {
+    private BooleanExpression getInterviewAnswerJoinCondition(Long memberId) {
         return interviewQuestion.id.eq(interviewAnswer.id).and(interviewAnswer.memberId.eq(memberId));
     }
-
-
 }

--- a/src/main/java/atwoz/atwoz/member/query/member/view/BasicMemberInfo.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/view/BasicMemberInfo.java
@@ -3,6 +3,7 @@ package atwoz.atwoz.member.query.member.view;
 import java.util.List;
 
 public record BasicMemberInfo(
+        Long id,
         String nickname,
         String profileImageUrl,
         Integer age,

--- a/src/main/java/atwoz/atwoz/member/query/member/view/InterviewResultView.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/view/InterviewResultView.java
@@ -1,0 +1,16 @@
+package atwoz.atwoz.member.query.member.view;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record InterviewResultView(
+        String content,
+        String category,
+        String answer
+) {
+    @QueryProjection
+    public InterviewResultView(String content, String category, String answer) {
+        this.content = content;
+        this.category = category;
+        this.answer = answer;
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/member/view/OtherMemberProfileView.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/view/OtherMemberProfileView.java
@@ -5,7 +5,6 @@ import com.querydsl.core.annotations.QueryProjection;
 import java.util.List;
 
 public record OtherMemberProfileView(
-        Long id,
         BasicMemberInfo basicMemberInfo,
         MatchInfo matchInfo
 ) {
@@ -32,7 +31,7 @@ public record OtherMemberProfileView(
             String contactType,
             String contact
     ) {
-        this(id, new BasicMemberInfo(nickname, profileImageUrl, age, gender, height, job, hobbies, mbti, region, smokingStatus, drinkingStatus, highestEducation, religion),
+        this(new BasicMemberInfo(id, nickname, profileImageUrl, age, gender, height, job, hobbies, mbti, region, smokingStatus, drinkingStatus, highestEducation, religion),
                 new MatchInfo(matchId, requesterId, responderId, requestMessage, responseMessage, matchStatus, contactType, contact));
     }
 }


### PR DESCRIPTION
### 관련 이슈
- closes #120 

<br>

### 작업 내용
- 프로필 조회시, 인터뷰 내역도 함께 불러올 수 있도록 하였습니다. (셀프 소개로 착각했었습니다 ㅠ.ㅠ)
- 인터뷰 DTO 및 테스트 코드 작성.

<br>

### 참고 자료
-

<br>

### 노트
- 저번 PR에서 인호님께서 Query 내에서도 Service 계층에서 여러 쿼리를 조합하여, 처리를 하셔서 해당 패턴으로 작업을 할까 고민하다가, 제 방식은 아직 단순 쿼리 뿐이여서 컨트롤러에서 두 개의 쿼리 결과를 조합하여 바로 전송하는 방식으로 구현하였습니다. (쿼리를 조합한 것은 단순 View 라고 생각하지 않아서, Response 로 반환하도록 하였습니다.!)

`View1 + View2 (Repository) => Response (Controller)`

- 통일성을 위해서 여러 쿼리를 따로 전송하는 경우에는 Service 계층에서 처리하여 Mapper 로 처리하는게 좋을까요?
