### PR TITLE
이상형 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIdealService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIdealService.java
@@ -1,0 +1,50 @@
+package atwoz.atwoz.member.command.application.introduction;
+
+import atwoz.atwoz.admin.command.domain.hobby.HobbyCommandRepository;
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
+import atwoz.atwoz.member.command.domain.introduction.vo.AgeRange;
+import atwoz.atwoz.member.command.domain.member.DrinkingStatus;
+import atwoz.atwoz.member.command.domain.member.Region;
+import atwoz.atwoz.member.command.domain.member.Religion;
+import atwoz.atwoz.member.command.domain.member.SmokingStatus;
+import atwoz.atwoz.member.command.domain.member.exception.InvalidHobbyIdException;
+import atwoz.atwoz.member.presentation.introduction.dto.MemberIdealUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class MemberIdealService {
+    private final MemberIdealCommandRepository memberIdealCommandRepository;
+    private final HobbyCommandRepository hobbyCommandRepository;
+
+    @Transactional
+    public void update(MemberIdealUpdateRequest request, long memberId) {
+        validateHobbyIds(request.hobbyIds());
+        MemberIdeal memberIdeal = getMemberIdealByMemberId(memberId);
+        AgeRange ageRange = AgeRange.of(request.minAge(), request.maxAge());
+        Region region = Region.from(request.region());
+        Religion religion = Religion.from(request.religion());
+        SmokingStatus smokingStatus = SmokingStatus.from(request.smokingStatus());
+        DrinkingStatus drinkingStatus = DrinkingStatus.from(request.drinkingStatus());
+        memberIdeal.update(ageRange, request.hobbyIds(), region, religion, smokingStatus, drinkingStatus);
+    }
+
+    private MemberIdeal getMemberIdealByMemberId(long memberId) {
+        return memberIdealCommandRepository.findByMemberId(memberId).orElseThrow(MemberIdealNotFoundException::new);
+    }
+
+    private void validateHobbyIds(Set<Long> hobbyIds) {
+        if (hobbyIds == null || hobbyIds.isEmpty()) {
+            return;
+        }
+        if (hobbyCommandRepository.countAllByIdIsIn(hobbyIds) != hobbyIds.size()) {
+            throw new InvalidHobbyIdException();
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
@@ -6,6 +6,8 @@ import atwoz.atwoz.common.enums.Role;
 import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
 import atwoz.atwoz.member.command.application.member.exception.BannedMemberException;
 import atwoz.atwoz.member.command.application.member.exception.MemberLoginConflictException;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import java.time.Instant;
 public class MemberAuthService {
 
     private final MemberCommandRepository memberCommandRepository;
+    private final MemberIdealCommandRepository memberIdealCommandRepository;
     private final TokenProvider tokenProvider;
     private final TokenRepository tokenRepository;
 
@@ -47,7 +50,9 @@ public class MemberAuthService {
 
     private Member create(String phoneNumber) {
         try {
-            return memberCommandRepository.save(Member.fromPhoneNumber(phoneNumber));
+            Member member = memberCommandRepository.save(Member.fromPhoneNumber(phoneNumber));
+            MemberIdeal memberIdeal = memberIdealCommandRepository.save(MemberIdeal.from(member.getId()));
+            return member;
         } catch (DataIntegrityViolationException e) {
             throw new MemberLoginConflictException(phoneNumber);
         }

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
@@ -68,7 +68,7 @@ public class MemberIdeal extends BaseEntity {
     }
 
     public static MemberIdeal from(Long id) {
-        return new MemberIdeal(id, null, new HashSet<>(), null, null, null, null);
+        return new MemberIdeal(id, AgeRange.init(), new HashSet<>(), null, null, null, null);
     }
 
     public void update(

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
@@ -55,18 +55,6 @@ public class MemberIdeal extends BaseEntity {
     @Column(columnDefinition = "varchar(50)")
     private DrinkingStatus drinkingStatus;
 
-    public static MemberIdeal of(
-            Long memberId,
-            AgeRange ageRange,
-            Set<Long> hobbyIds,
-            Region region,
-            Religion religion,
-            SmokingStatus smokingStatus,
-            DrinkingStatus drinkingStatus
-    ) {
-        return new MemberIdeal(memberId, ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus);
-    }
-
     public static MemberIdeal from(Long id) {
         return new MemberIdeal(id, AgeRange.init(), new HashSet<>(), null, null, null, null);
     }

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
@@ -22,6 +22,7 @@ public class MemberIdeal extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private Long memberId;
 
     @Getter

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
@@ -71,6 +71,22 @@ public class MemberIdeal extends BaseEntity {
         return new MemberIdeal(id, null, new HashSet<>(), null, null, null, null);
     }
 
+    public void update(
+            AgeRange ageRange,
+            Set<Long> hobbyIds,
+            Region region,
+            Religion religion,
+            SmokingStatus smokingStatus,
+            DrinkingStatus drinkingStatus
+    ) {
+        this.ageRange = ageRange;
+        this.hobbyIds = hobbyIds;
+        this.region = region;
+        this.religion = religion;
+        this.smokingStatus = smokingStatus;
+        this.drinkingStatus = drinkingStatus;
+    }
+
     private MemberIdeal(
             Long memberId,
             AgeRange ageRange,

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
@@ -67,6 +67,10 @@ public class MemberIdeal extends BaseEntity {
         return new MemberIdeal(memberId, ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus);
     }
 
+    public static MemberIdeal from(Long id) {
+        return new MemberIdeal(id, null, new HashSet<>(), null, null, null, null);
+    }
+
     private MemberIdeal(
             Long memberId,
             AgeRange ageRange,

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
@@ -2,11 +2,13 @@ package atwoz.atwoz.member.command.domain.introduction.vo;
 
 import atwoz.atwoz.member.command.domain.introduction.exception.InvalidAgeRangeException;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 
 @Getter
 @Embeddable
+@EqualsAndHashCode
 public class AgeRange {
     private static final Integer MIN_VALUE = 20;
     private static final Integer MAX_VALUE = 47;

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
@@ -11,7 +11,7 @@ import lombok.NonNull;
 @EqualsAndHashCode
 public class AgeRange {
     private static final Integer MIN_VALUE = 20;
-    private static final Integer MAX_VALUE = 47;
+    private static final Integer MAX_VALUE = 46;
 
     private final Integer minAge;
     private final Integer maxAge;

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/vo/AgeRange.java
@@ -21,6 +21,10 @@ public class AgeRange {
         this.maxAge = MAX_VALUE;
     }
 
+    public static AgeRange init() {
+        return new AgeRange(MIN_VALUE, MAX_VALUE);
+    }
+
     public static AgeRange of(Integer minAge, Integer maxAge) {
         return new AgeRange(minAge, maxAge);
     }

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/DrinkingStatus.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/DrinkingStatus.java
@@ -18,7 +18,7 @@ public enum DrinkingStatus {
     }
 
     public static DrinkingStatus from(String value) {
-        if (value == null) return null;
+        if (value == null || value.isEmpty()) return null;
 
         try {
             return DrinkingStatus.valueOf(value.toUpperCase());

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Region.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Region.java
@@ -15,7 +15,7 @@ public enum Region {
     }
 
     public static Region from(String value) {
-        if (value == null) return null;
+        if (value == null || value.isEmpty()) return null;
 
         try {
             return Region.valueOf(value.toUpperCase());

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Religion.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Religion.java
@@ -18,7 +18,7 @@ public enum Religion {
     }
 
     public static Religion from(String value) {
-        if (value == null) return null;
+        if (value == null || value.isEmpty()) return null;
 
         try {
             return Religion.valueOf(value.toUpperCase());

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/SmokingStatus.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/SmokingStatus.java
@@ -18,7 +18,7 @@ public enum SmokingStatus {
     }
 
     public static SmokingStatus from(String value) {
-        if (value == null) return null;
+        if (value == null || value.isEmpty()) return null;
 
         try {
             return SmokingStatus.valueOf(value.toUpperCase());

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIdealController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIdealController.java
@@ -5,7 +5,10 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.member.command.application.introduction.MemberIdealService;
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
 import atwoz.atwoz.member.presentation.introduction.dto.MemberIdealUpdateRequest;
+import atwoz.atwoz.member.query.introduction.application.MemberIdealView;
+import atwoz.atwoz.member.query.introduction.intra.MemberIdealQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +18,15 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/member/ideal")
 public class MemberIdealController {
     private final MemberIdealService idealService;
+    private final MemberIdealQueryRepository memberIdealQueryRepository;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<MemberIdealView>> getMemberIdeal(@AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        MemberIdealView memberIdealView = memberIdealQueryRepository.findMemberIdealByMemberId(memberId)
+                .orElseThrow(MemberIdealNotFoundException::new);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, memberIdealView));
+    }
 
     @PatchMapping
     public ResponseEntity<BaseResponse<Void>> updateIdeal(@RequestBody MemberIdealUpdateRequest request, @AuthPrincipal AuthContext authContext) {

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIdealController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIdealController.java
@@ -9,6 +9,7 @@ import atwoz.atwoz.member.command.application.introduction.exception.MemberIdeal
 import atwoz.atwoz.member.presentation.introduction.dto.MemberIdealUpdateRequest;
 import atwoz.atwoz.member.query.introduction.application.MemberIdealView;
 import atwoz.atwoz.member.query.introduction.intra.MemberIdealQueryRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +30,7 @@ public class MemberIdealController {
     }
 
     @PatchMapping
-    public ResponseEntity<BaseResponse<Void>> updateIdeal(@RequestBody MemberIdealUpdateRequest request, @AuthPrincipal AuthContext authContext) {
+    public ResponseEntity<BaseResponse<Void>> updateIdeal(@Valid @RequestBody MemberIdealUpdateRequest request, @AuthPrincipal AuthContext authContext) {
         long memberId = authContext.getId();
         idealService.update(request, memberId);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIdealController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIdealController.java
@@ -1,0 +1,25 @@
+package atwoz.atwoz.member.presentation.introduction;
+
+import atwoz.atwoz.auth.presentation.AuthContext;
+import atwoz.atwoz.auth.presentation.AuthPrincipal;
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.member.command.application.introduction.MemberIdealService;
+import atwoz.atwoz.member.presentation.introduction.dto.MemberIdealUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member/ideal")
+public class MemberIdealController {
+    private final MemberIdealService idealService;
+
+    @PatchMapping
+    public ResponseEntity<BaseResponse<Void>> updateIdeal(@RequestBody MemberIdealUpdateRequest request, @AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        idealService.update(request, memberId);
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionController.java
@@ -8,9 +8,7 @@ import atwoz.atwoz.member.query.introduction.application.IntroductionQueryServic
 import atwoz.atwoz.member.query.introduction.application.MemberIntroductionProfileView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionExceptionHandler.java
@@ -3,6 +3,7 @@ package atwoz.atwoz.member.presentation.introduction;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
+import atwoz.atwoz.member.command.domain.introduction.exception.InvalidAgeRangeException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -18,5 +19,13 @@ public class MemberIntroductionExceptionHandler {
 
         return ResponseEntity.status(404)
                 .body(BaseResponse.from(StatusType.NOT_FOUND));
+    }
+
+    @ExceptionHandler(InvalidAgeRangeException.class)
+    public ResponseEntity<BaseResponse<Void>> handleInvalidAgeRangeException(InvalidAgeRangeException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.from(StatusType.BAD_REQUEST));
     }
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIdealUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIdealUpdateRequest.java
@@ -5,8 +5,8 @@ import java.util.Set;
 public record MemberIdealUpdateRequest(
         Integer minAge,
         Integer maxAge,
-        String religion,
         String region,
+        String religion,
         String smokingStatus,
         String drinkingStatus,
         Set<Long> hobbyIds

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIdealUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIdealUpdateRequest.java
@@ -1,0 +1,14 @@
+package atwoz.atwoz.member.presentation.introduction.dto;
+
+import java.util.Set;
+
+public record MemberIdealUpdateRequest(
+        Integer minAge,
+        Integer maxAge,
+        String religion,
+        String region,
+        String smokingStatus,
+        String drinkingStatus,
+        Set<Long> hobbyIds
+) {
+}

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIdealUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIdealUpdateRequest.java
@@ -1,14 +1,29 @@
 package atwoz.atwoz.member.presentation.introduction.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
 import java.util.Set;
 
 public record MemberIdealUpdateRequest(
+        @NotNull(message = "최소 나이를 입력해주세요.")
+        @Min(value = 20, message = "최소 나이는 20보다 작을 수 없습니다.")
+        @Max(value = 46, message = "최소 나이는 46보다 작을 수 없습니다.")
         Integer minAge,
+        @NotNull(message = "최대 나이를 입력해주세요.")
+        @Min(value = 20, message = "최대 나이는 20보다 작을 수 없습니다.")
+        @Max(value = 46, message = "최대 나이는 46보다 작을 수 없습니다.")
         Integer maxAge,
+        @NotNull(message = "지역을 입력해주세요.")
         String region,
+        @NotNull(message = "종교를 입력해주세요.")
         String religion,
+        @NotNull(message = "흡연 여부를 입력해주세요.")
         String smokingStatus,
+        @NotNull(message = "음주 여부를 입력해주세요.")
         String drinkingStatus,
+        @NotNull(message = "취미를 입력해주세요.")
         Set<Long> hobbyIds
 ) {
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberExceptionHandler.java
@@ -6,6 +6,7 @@ import atwoz.atwoz.member.command.application.member.exception.BannedMemberExcep
 import atwoz.atwoz.member.command.application.member.exception.KakaoIdAlreadyExistsException;
 import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
 import atwoz.atwoz.member.command.application.member.exception.PhoneNumberAlreadyExistsException;
+import atwoz.atwoz.member.command.domain.member.exception.InvalidHobbyIdException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -42,6 +43,14 @@ public class MemberExceptionHandler {
     @ExceptionHandler(KakaoIdAlreadyExistsException.class)
     public ResponseEntity<BaseResponse<Void>> handleKakaoIdAlreadyExistsException(KakaoIdAlreadyExistsException e) {
         log.warn("카카오 아이디 변경에 실패하였습니다. {}", e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.from(StatusType.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(InvalidHobbyIdException.class)
+    public ResponseEntity<BaseResponse<Void>> handleInvalidHobbyIdException(InvalidHobbyIdException e) {
+        log.warn("유효하지 않은 취미 아이디입니다. {}", e.getMessage());
 
         return ResponseEntity.badRequest()
                 .body(BaseResponse.from(StatusType.BAD_REQUEST));

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/MemberIdealView.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/MemberIdealView.java
@@ -1,0 +1,19 @@
+package atwoz.atwoz.member.query.introduction.application;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.util.List;
+
+public record MemberIdealView(
+        Integer minAge,
+        Integer maxAge,
+        List<String> hobbies,
+        String region,
+        String religion,
+        String smokingStatus,
+        String drinkingStatus
+) {
+    @QueryProjection
+    public MemberIdealView {
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/query/introduction/intra/MemberIdealQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/intra/MemberIdealQueryRepository.java
@@ -1,0 +1,42 @@
+package atwoz.atwoz.member.query.introduction.intra;
+
+import atwoz.atwoz.member.query.introduction.application.MemberIdealView;
+import atwoz.atwoz.member.query.introduction.application.QMemberIdealView;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static atwoz.atwoz.admin.command.domain.hobby.QHobby.hobby;
+import static atwoz.atwoz.member.command.domain.introduction.QMemberIdeal.memberIdeal;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberIdealQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<MemberIdealView> findMemberIdealByMemberId(long memberId) {
+        MemberIdealView memberIdealView = queryFactory
+                .from(memberIdeal)
+                .where(memberIdeal.memberId.eq(memberId))
+                .leftJoin(hobby).on(hobby.id.in(memberIdeal.hobbyIds))
+                .transform(
+                        groupBy(memberIdeal.memberId).as(
+                                new QMemberIdealView(
+                                        memberIdeal.ageRange.minAge,
+                                        memberIdeal.ageRange.maxAge,
+                                        list(hobby.name),
+                                        memberIdeal.region.stringValue(),
+                                        memberIdeal.religion.stringValue(),
+                                        memberIdeal.smokingStatus.stringValue(),
+                                        memberIdeal.drinkingStatus.stringValue()
+                                )
+                        )
+                ).get(memberId);
+
+        return Optional.ofNullable(memberIdealView);
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/command/application/introduction/MemberIdealServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/introduction/MemberIdealServiceTest.java
@@ -1,0 +1,106 @@
+package atwoz.atwoz.member.command.application.introduction;
+
+import atwoz.atwoz.admin.command.domain.hobby.HobbyCommandRepository;
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
+import atwoz.atwoz.member.command.domain.introduction.vo.AgeRange;
+import atwoz.atwoz.member.command.domain.member.DrinkingStatus;
+import atwoz.atwoz.member.command.domain.member.Region;
+import atwoz.atwoz.member.command.domain.member.Religion;
+import atwoz.atwoz.member.command.domain.member.SmokingStatus;
+import atwoz.atwoz.member.command.domain.member.exception.InvalidHobbyIdException;
+import atwoz.atwoz.member.presentation.introduction.dto.MemberIdealUpdateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberIdealServiceTest {
+
+    @InjectMocks
+    private MemberIdealService memberIdealService;
+
+    @Mock
+    private MemberIdealCommandRepository memberIdealCommandRepository;
+
+    @Mock
+    private HobbyCommandRepository hobbyCommandRepository;
+
+    private Set<Long> hobbyIds;
+    private AgeRange ageRange;
+    private Region region;
+    private Religion religion;
+    private SmokingStatus smokingStatus;
+    private DrinkingStatus drinkingStatus;
+    private MemberIdealUpdateRequest request;
+
+    @BeforeEach
+    void setUp() {
+        ageRange = AgeRange.of(20, 30);
+        region = Region.SEOUL;
+        religion = Religion.CHRISTIAN;
+        smokingStatus = SmokingStatus.VAPE;
+        drinkingStatus = DrinkingStatus.SOCIAL;
+        hobbyIds = Set.of(1L, 2L);
+        request =  new MemberIdealUpdateRequest(
+                ageRange.getMinAge(),
+                ageRange.getMaxAge(),
+                region.name(),
+                religion.name(),
+                smokingStatus.name(),
+                drinkingStatus.name(),
+                hobbyIds
+        );
+    }
+
+    @Test
+    @DisplayName("hobbyIds가 db에 존재하지 않는 경우 예외를 던진다.")
+    void throwExceptionWhenHobbyIdsIsNotExists() {
+        // given
+        long memberId = 1L;
+        when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(1L);
+
+        // when && then
+        assertThatThrownBy(() -> memberIdealService.update(request, memberId))
+                .isInstanceOf(InvalidHobbyIdException.class);
+    }
+
+    @Test
+    @DisplayName("memberIdeal이 존재하지 않는 경우 예외를 던진다.")
+    void throwExceptionWhenMemberIdealIsNotExists() {
+        // given
+        long memberId = 1L;
+        when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(((long) hobbyIds.size()));
+        when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+
+        // when && then
+        assertThatThrownBy(() -> memberIdealService.update(request, memberId))
+                .isInstanceOf(MemberIdealNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("memberIdeal이 존재하는 경우 memberIdeal을 업데이트한다.")
+    void updateMemberIdeal() {
+        long memberId = 1L;
+        when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(((long) hobbyIds.size()));
+        MemberIdeal memberIdeal = mock(MemberIdeal.class);
+        when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(memberIdeal));
+
+        // when
+        memberIdealService.update(request, memberId);
+
+        // then
+        verify(memberIdeal).update(ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus);
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
@@ -106,28 +106,30 @@ public class MemberAuthServiceTest {
         String phoneNumber = "01012345678";
         Instant fixedInstant = Instant.parse("2024-01-01T00:00:00Z");
 
-        MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class);
-        mockedInstant.when(Instant::now).thenReturn(fixedInstant);
+        try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class);
+             MockedStatic<MemberIdeal> mockedMemberIdeal = Mockito.mockStatic(MemberIdeal.class);
+        ) {
+            mockedInstant.when(Instant::now).thenReturn(fixedInstant);
 
-        Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.empty());
-        Mockito.when(jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
-                .thenReturn("accessToken");
-        Mockito.when(memberCommandRepository.save(Mockito.any())).thenReturn(member);
+            Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.empty());
+            Mockito.when(jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
+                    .thenReturn("accessToken");
+            Mockito.when(memberCommandRepository.save(Mockito.any())).thenReturn(member);
 
-        MockedStatic<MemberIdeal> mockedMemberIdeal = Mockito.mockStatic(MemberIdeal.class);
-        MemberIdeal memberIdeal = mock(MemberIdeal.class);
-        mockedMemberIdeal.when(() -> MemberIdeal.from(memberId)).thenReturn(memberIdeal);
-        Mockito.when(memberIdealCommandRepository.save(memberIdeal)).thenReturn(memberIdeal);
+            MemberIdeal memberIdeal = mock(MemberIdeal.class);
+            mockedMemberIdeal.when(() -> MemberIdeal.from(memberId)).thenReturn(memberIdeal);
+            Mockito.when(memberIdealCommandRepository.save(memberIdeal)).thenReturn(memberIdeal);
 
-        // When
-        MemberLoginServiceDto response = memberAuthService.login(phoneNumber);
+            // When
+            MemberLoginServiceDto response = memberAuthService.login(phoneNumber);
 
-        // Then
-        Assertions.assertThat(response.accessToken()).isNotNull();
-        Assertions.assertThat(response.accessToken()).isEqualTo("accessToken");
-        Assertions.assertThat(response.isProfileSettingNeeded()).isTrue();
+            // Then
+            Assertions.assertThat(response.accessToken()).isNotNull();
+            Assertions.assertThat(response.accessToken()).isEqualTo("accessToken");
+            Assertions.assertThat(response.isProfileSettingNeeded()).isTrue();
 
-        verify(memberIdealCommandRepository).save(memberIdeal);
+            verify(memberIdealCommandRepository).save(memberIdeal);
+        }
     }
 
     @Test

--- a/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
@@ -6,6 +6,8 @@ import atwoz.atwoz.common.enums.Role;
 import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
 import atwoz.atwoz.member.command.application.member.exception.BannedMemberException;
 import atwoz.atwoz.member.command.application.member.exception.MemberLoginConflictException;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
 import atwoz.atwoz.member.command.domain.member.ActivityStatus;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
@@ -25,13 +27,20 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.Instant;
 import java.util.Optional;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 @ExtendWith(MockitoExtension.class)
 public class MemberAuthServiceTest {
     private Member permanentStoppedMember;
     private Member member;
+    private Long memberId;
 
     @Mock
     private MemberCommandRepository memberCommandRepository;
+
+    @Mock
+    private MemberIdealCommandRepository memberIdealCommandRepository;
 
     @Mock
     private JwtProvider jwtProvider;
@@ -45,7 +54,8 @@ public class MemberAuthServiceTest {
     @BeforeEach
     void setUp() {
         member = Member.fromPhoneNumber("01012345678");
-        ReflectionTestUtils.setField(member, "id", 1L);
+        memberId = 1L;
+        ReflectionTestUtils.setField(member, "id", memberId);
         ReflectionTestUtils.setField(member, "activityStatus", ActivityStatus.ACTIVE);
 
         permanentStoppedMember = Member.fromPhoneNumber("01012345678");
@@ -96,22 +106,28 @@ public class MemberAuthServiceTest {
         String phoneNumber = "01012345678";
         Instant fixedInstant = Instant.parse("2024-01-01T00:00:00Z");
 
-        try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class)) {
-            mockedInstant.when(Instant::now).thenReturn(fixedInstant);
+        MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class);
+        mockedInstant.when(Instant::now).thenReturn(fixedInstant);
 
-            Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.empty());
-            Mockito.when(jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
-                    .thenReturn("accessToken");
-            Mockito.when(memberCommandRepository.save(Mockito.any())).thenReturn(member);
+        Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.empty());
+        Mockito.when(jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
+                .thenReturn("accessToken");
+        Mockito.when(memberCommandRepository.save(Mockito.any())).thenReturn(member);
 
-            // When
-            MemberLoginServiceDto response = memberAuthService.login(phoneNumber);
+        MockedStatic<MemberIdeal> mockedMemberIdeal = Mockito.mockStatic(MemberIdeal.class);
+        MemberIdeal memberIdeal = mock(MemberIdeal.class);
+        mockedMemberIdeal.when(() -> MemberIdeal.from(memberId)).thenReturn(memberIdeal);
+        Mockito.when(memberIdealCommandRepository.save(memberIdeal)).thenReturn(memberIdeal);
 
-            // Then
-            Assertions.assertThat(response.accessToken()).isNotNull();
-            Assertions.assertThat(response.accessToken()).isEqualTo("accessToken");
-            Assertions.assertThat(response.isProfileSettingNeeded()).isTrue();
-        }
+        // When
+        MemberLoginServiceDto response = memberAuthService.login(phoneNumber);
+
+        // Then
+        Assertions.assertThat(response.accessToken()).isNotNull();
+        Assertions.assertThat(response.accessToken()).isEqualTo("accessToken");
+        Assertions.assertThat(response.isProfileSettingNeeded()).isTrue();
+
+        verify(memberIdealCommandRepository).save(memberIdeal);
     }
 
     @Test

--- a/src/test/java/atwoz/atwoz/member/query/introduction/intra/MemberIdealQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/intra/MemberIdealQueryRepositoryTest.java
@@ -1,0 +1,78 @@
+package atwoz.atwoz.member.query.introduction.intra;
+
+
+import atwoz.atwoz.QuerydslConfig;
+import atwoz.atwoz.admin.command.domain.hobby.Hobby;
+import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
+import atwoz.atwoz.member.command.domain.introduction.vo.AgeRange;
+import atwoz.atwoz.member.command.domain.member.DrinkingStatus;
+import atwoz.atwoz.member.command.domain.member.Region;
+import atwoz.atwoz.member.command.domain.member.Religion;
+import atwoz.atwoz.member.command.domain.member.SmokingStatus;
+import atwoz.atwoz.member.query.introduction.application.MemberIdealView;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, MemberIdealQueryRepository.class})
+class MemberIdealQueryRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private MemberIdealQueryRepository memberIdealQueryRepository;
+
+    @Test
+    @DisplayName("memberIdeal이 존재하지 않는 경우 Optional.empty()를 반환한다.")
+    void returnOptionalEmptyWhenMemberIdealIsNotExists() {
+        // given
+        long memberId = 1L;
+
+        // when
+        var memberIdeal = memberIdealQueryRepository.findMemberIdealByMemberId(memberId);
+
+        // then
+        assertThat(memberIdeal).isEmpty();
+    }
+
+    @Test
+    @DisplayName("memberIdeal이 존재하는 경우 MemberIdealView를 반환한다.")
+    void returnMemberIdealViewWhenMemberIdealIsExists() {
+        // given
+        long memberId = 1L;
+        MemberIdeal memberIdeal = MemberIdeal.from(memberId);
+        AgeRange ageRange = AgeRange.of(20, 30);
+        Hobby hobby1 = Hobby.from("취미1");
+        Hobby hobby2 = Hobby.from("취미2");
+        entityManager.persist(hobby1);
+        entityManager.persist(hobby2);
+        Set<Long> hobbyIds = Set.of(hobby1.getId(), hobby2.getId());
+        Region region = Region.SEOUL;
+        Religion religion = Religion.CHRISTIAN;
+        SmokingStatus smokingStatus = SmokingStatus.NONE;
+        DrinkingStatus drinkingStatus = DrinkingStatus.NONE;
+        memberIdeal.update(ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus);
+        entityManager.persist(memberIdeal);
+        entityManager.flush();
+
+        // when
+        MemberIdealView memberIdealView = memberIdealQueryRepository.findMemberIdealByMemberId(memberId).get();
+
+        // then
+        assertThat(memberIdealView.minAge()).isEqualTo(ageRange.getMinAge());
+        assertThat(memberIdealView.maxAge()).isEqualTo(ageRange.getMaxAge());
+        assertThat(memberIdealView.hobbies()).containsExactlyInAnyOrder(hobby1.getName(), hobby2.getName());
+        assertThat(memberIdealView.region()).isEqualTo(region.name());
+        assertThat(memberIdealView.religion()).isEqualTo(religion.name());
+        assertThat(memberIdealView.smokingStatus()).isEqualTo(smokingStatus.name());
+        assertThat(memberIdealView.drinkingStatus()).isEqualTo(drinkingStatus.name());
+    }
+}


### PR DESCRIPTION
### 관련 이슈
- closes #121 

<br>

### 작업 내용
- 멤버 생성시 멤버 이상형 초기화
- 멤버 이상형 조회 API 구현
- 멤버 이상형 수정 API 구현

<br>

### 참고 자료
-

<br>

### 노트
- 멤버 이상형 수정시에 `지역, 종교, 흡연 여부, 음주 여부`에 대해서 상관없음을 사용하기 위해서 enum에 상관없음을 추가하는 대신 비어있는 String에 대해 null을 리턴하도록하여 상관없음에 대한 표시가 DB에 null으로 저장되는 것으로 구현했어요
