### PR TITLE
소개받고 싶은 이성 소개받기 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/heart/command/domain/hearttransaction/vo/TransactionType.java
+++ b/src/main/java/atwoz/atwoz/heart/command/domain/hearttransaction/vo/TransactionType.java
@@ -7,10 +7,12 @@ public enum TransactionType {
     DATING_EXAM,
     PROFILE_EXCHANGE,
     SELF_INTRODUCTION,
+    INTRODUCTION,
     PURCHASE;
 
     public boolean isUsingType() {
-        return this == MESSAGE || this == DATING_EXAM || this == PROFILE_EXCHANGE || this == SELF_INTRODUCTION;
+        return this == MESSAGE || this == DATING_EXAM || this == PROFILE_EXCHANGE || this == SELF_INTRODUCTION ||
+                this == INTRODUCTION;
     }
 
     public boolean isGainingType() {

--- a/src/main/java/atwoz/atwoz/heart/command/infra/heartusagepolicy/HeartUsageEventHandler.java
+++ b/src/main/java/atwoz/atwoz/heart/command/infra/heartusagepolicy/HeartUsageEventHandler.java
@@ -3,6 +3,7 @@ package atwoz.atwoz.heart.command.infra.heartusagepolicy;
 import atwoz.atwoz.heart.command.application.heartusagepolicy.HeartUsagePolicyService;
 import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
 import atwoz.atwoz.match.command.domain.match.event.MatchRequestedEvent;
+import atwoz.atwoz.member.command.domain.introduction.event.MemberIntroducedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -15,5 +16,10 @@ public class HeartUsageEventHandler {
     @EventListener(value = MatchRequestedEvent.class)
     public void handle(MatchRequestedEvent event) {
         heartUsageService.useHeart(event.getRequesterId(), TransactionType.MESSAGE);
+    }
+
+    @EventListener(value = MemberIntroducedEvent.class)
+    public void handle(MemberIntroducedEvent event) {
+        heartUsageService.useHeart(event.getMemberId(), TransactionType.INTRODUCTION);
     }
 }

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIdealService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIdealService.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.member.command.application.introduction;
 
 import atwoz.atwoz.admin.command.domain.hobby.HobbyCommandRepository;
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealAlreadyExistsException;
 import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
 import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
 import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
@@ -22,6 +23,15 @@ import java.util.Set;
 public class MemberIdealService {
     private final MemberIdealCommandRepository memberIdealCommandRepository;
     private final HobbyCommandRepository hobbyCommandRepository;
+
+    @Transactional
+    public void init(long memberId) {
+        if (memberIdealCommandRepository.existsByMemberId(memberId)) {
+            throw new MemberIdealAlreadyExistsException(memberId);
+        }
+        MemberIdeal memberIdeal = MemberIdeal.from(memberId);
+        memberIdealCommandRepository.save(memberIdeal);
+    }
 
     @Transactional
     public void update(MemberIdealUpdateRequest request, long memberId) {

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIdealService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIdealService.java
@@ -29,7 +29,7 @@ public class MemberIdealService {
         if (memberIdealCommandRepository.existsByMemberId(memberId)) {
             throw new MemberIdealAlreadyExistsException(memberId);
         }
-        MemberIdeal memberIdeal = MemberIdeal.from(memberId);
+        MemberIdeal memberIdeal = MemberIdeal.init(memberId);
         memberIdealCommandRepository.save(memberIdeal);
     }
 

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionService.java
@@ -1,8 +1,12 @@
 package atwoz.atwoz.member.command.application.introduction;
 
+import atwoz.atwoz.member.command.application.introduction.exception.IntroducedMemberNotActiveException;
+import atwoz.atwoz.member.command.application.introduction.exception.IntroducedMemberNotFoundException;
 import atwoz.atwoz.member.command.application.introduction.exception.MemberIntroductionAlreadyExistsException;
 import atwoz.atwoz.member.command.domain.introduction.MemberIntroduction;
 import atwoz.atwoz.member.command.domain.introduction.MemberIntroductionCommandRepository;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,14 +14,24 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class MemberIntroductionService {
+    private final MemberCommandRepository memberCommandRepository;
     private final MemberIntroductionCommandRepository memberIntroductionCommandRepository;
 
     @Transactional
     public void create(long memberId, long introducedMemberId) {
+        validateIntroduction(memberId, introducedMemberId);
+        MemberIntroduction memberIntroduction = MemberIntroduction.of(memberId, introducedMemberId);
+        memberIntroductionCommandRepository.save(memberIntroduction);
+    }
+
+    private void validateIntroduction(long memberId, long introducedMemberId) {
+        Member introductionMember = memberCommandRepository.findById(introducedMemberId)
+                .orElseThrow(IntroducedMemberNotFoundException::new);
+        if (!introductionMember.isActive()) {
+            throw new IntroducedMemberNotActiveException();
+        }
         if (memberIntroductionCommandRepository.existsByMemberIdAndIntroducedMemberId(memberId, introducedMemberId)) {
             throw new MemberIntroductionAlreadyExistsException();
         }
-        MemberIntroduction memberIntroduction = MemberIntroduction.of(memberId, introducedMemberId);
-        memberIntroductionCommandRepository.save(memberIntroduction);
     }
 }

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionService.java
@@ -1,0 +1,23 @@
+package atwoz.atwoz.member.command.application.introduction;
+
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIntroductionAlreadyExistsException;
+import atwoz.atwoz.member.command.domain.introduction.MemberIntroduction;
+import atwoz.atwoz.member.command.domain.introduction.MemberIntroductionCommandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberIntroductionService {
+    private final MemberIntroductionCommandRepository memberIntroductionCommandRepository;
+
+    @Transactional
+    public void create(long memberId, long introducedMemberId) {
+        if (memberIntroductionCommandRepository.existsByMemberIdAndIntroducedMemberId(memberId, introducedMemberId)) {
+            throw new MemberIntroductionAlreadyExistsException();
+        }
+        MemberIntroduction memberIntroduction = MemberIntroduction.of(memberId, introducedMemberId);
+        memberIntroductionCommandRepository.save(memberIntroduction);
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/IntroducedMemberNotActiveException.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/IntroducedMemberNotActiveException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.command.application.introduction.exception;
+
+public class IntroducedMemberNotActiveException extends RuntimeException {
+    public IntroducedMemberNotActiveException() {
+        super("소개된 멤버가 Active 상태가 아닙니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/IntroducedMemberNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/IntroducedMemberNotFoundException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.command.application.introduction.exception;
+
+public class IntroducedMemberNotFoundException extends RuntimeException {
+    public IntroducedMemberNotFoundException() {
+        super("소개된 멤버가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/MemberIdealAlreadyExistsException.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/MemberIdealAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.command.application.introduction.exception;
+
+public class MemberIdealAlreadyExistsException extends RuntimeException {
+    public MemberIdealAlreadyExistsException(long memberId) {
+        super("멤버(id: " + memberId + ")의 Ideal이 이미 생성되어 있습니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/MemberIntroductionAlreadyExistsException.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/exception/MemberIntroductionAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.command.application.introduction.exception;
+
+public class MemberIntroductionAlreadyExistsException extends RuntimeException {
+    public MemberIntroductionAlreadyExistsException() {
+        super("이미 소개된 회원입니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
@@ -6,8 +6,6 @@ import atwoz.atwoz.common.enums.Role;
 import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
 import atwoz.atwoz.member.command.application.member.exception.BannedMemberException;
 import atwoz.atwoz.member.command.application.member.exception.MemberLoginConflictException;
-import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
-import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +20,6 @@ import java.time.Instant;
 public class MemberAuthService {
 
     private final MemberCommandRepository memberCommandRepository;
-    private final MemberIdealCommandRepository memberIdealCommandRepository;
     private final TokenProvider tokenProvider;
     private final TokenRepository tokenRepository;
 
@@ -50,9 +47,7 @@ public class MemberAuthService {
 
     private Member create(String phoneNumber) {
         try {
-            Member member = memberCommandRepository.save(Member.fromPhoneNumber(phoneNumber));
-            MemberIdeal memberIdeal = memberIdealCommandRepository.save(MemberIdeal.from(member.getId()));
-            return member;
+            return memberCommandRepository.save(Member.fromPhoneNumber(phoneNumber));
         } catch (DataIntegrityViolationException e) {
             throw new MemberLoginConflictException(phoneNumber);
         }

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
@@ -55,8 +55,8 @@ public class MemberIdeal extends BaseEntity {
     @Column(columnDefinition = "varchar(50)")
     private DrinkingStatus drinkingStatus;
 
-    public static MemberIdeal from(Long id) {
-        return new MemberIdeal(id, AgeRange.init(), new HashSet<>(), null, null, null, null);
+    public static MemberIdeal from(Long memberId) {
+        return new MemberIdeal(memberId, AgeRange.init(), new HashSet<>(), null, null, null, null);
     }
 
     public void update(

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdeal.java
@@ -10,6 +10,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -22,6 +23,7 @@ public class MemberIdeal extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Getter
     @Column(unique = true)
     private Long memberId;
 
@@ -55,7 +57,7 @@ public class MemberIdeal extends BaseEntity {
     @Column(columnDefinition = "varchar(50)")
     private DrinkingStatus drinkingStatus;
 
-    public static MemberIdeal from(Long memberId) {
+    public static MemberIdeal init(Long memberId) {
         return new MemberIdeal(memberId, AgeRange.init(), new HashSet<>(), null, null, null, null);
     }
 
@@ -67,8 +69,8 @@ public class MemberIdeal extends BaseEntity {
             SmokingStatus smokingStatus,
             DrinkingStatus drinkingStatus
     ) {
-        this.ageRange = ageRange;
-        this.hobbyIds = hobbyIds;
+        setAgeRange(ageRange);
+        setHobbyIds(hobbyIds);
         this.region = region;
         this.religion = religion;
         this.smokingStatus = smokingStatus;
@@ -84,12 +86,24 @@ public class MemberIdeal extends BaseEntity {
             SmokingStatus smokingStatus,
             DrinkingStatus drinkingStatus
     ) {
-        this.memberId = memberId;
-        this.ageRange = ageRange;
-        this.hobbyIds = hobbyIds;
+        setMemberId(memberId);
+        setAgeRange(ageRange);
+        setHobbyIds(hobbyIds);
         this.region = region;
         this.religion = religion;
         this.smokingStatus = smokingStatus;
         this.drinkingStatus = drinkingStatus;
+    }
+
+    private void setMemberId(@NonNull Long memberId) {
+        this.memberId = memberId;
+    }
+
+    private void setAgeRange(@NonNull AgeRange ageRange) {
+        this.ageRange = ageRange;
+    }
+
+    private void setHobbyIds(@NonNull Set<Long> hobbyIds) {
+        this.hobbyIds = hobbyIds;
     }
 }

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdealCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIdealCommandRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface MemberIdealCommandRepository extends JpaRepository<MemberIdeal, Long> {
     Optional<MemberIdeal> findByMemberId(Long memberId);
+
+    boolean existsByMemberId(long memberId);
 }

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIntroduction.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIntroduction.java
@@ -1,8 +1,11 @@
 package atwoz.atwoz.member.command.domain.introduction;
 
 import atwoz.atwoz.common.entity.BaseEntity;
+import atwoz.atwoz.common.event.Events;
+import atwoz.atwoz.member.command.domain.introduction.event.MemberIntroducedEvent;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
@@ -14,12 +17,16 @@ public class MemberIntroduction extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Getter
     private Long memberId;
 
+    @Getter
     private Long introducedMemberId;
 
     public static MemberIntroduction of(Long memberId, Long introducedMemberId) {
-        return new MemberIntroduction(memberId, introducedMemberId);
+        MemberIntroduction memberIntroduction = new MemberIntroduction(memberId, introducedMemberId);
+        Events.raise(MemberIntroducedEvent.of(memberId));
+        return memberIntroduction;
     }
 
     private MemberIntroduction(@NonNull Long memberId, @NonNull Long introducedMemberId) {

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIntroductionCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/MemberIntroductionCommandRepository.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.command.domain.introduction;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberIntroductionCommandRepository extends JpaRepository<MemberIntroduction, Long> {
+    boolean existsByMemberIdAndIntroducedMemberId(long memberId, long introducedMemberId);
+}

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/event/MemberIntroducedEvent.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/event/MemberIntroducedEvent.java
@@ -1,0 +1,16 @@
+package atwoz.atwoz.member.command.domain.introduction.event;
+
+import atwoz.atwoz.common.event.Event;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberIntroducedEvent extends Event {
+    private final Long memberId;
+
+    public static MemberIntroducedEvent of(Long memberId) {
+        return new MemberIntroducedEvent(memberId);
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/infra/introduction/IdealEventHandler.java
+++ b/src/main/java/atwoz/atwoz/member/command/infra/introduction/IdealEventHandler.java
@@ -1,0 +1,27 @@
+package atwoz.atwoz.member.command.infra.introduction;
+
+import atwoz.atwoz.member.command.application.introduction.MemberIdealService;
+import atwoz.atwoz.notification.command.infra.notificationsetting.MemberRegisteredEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class IdealEventHandler {
+    private final MemberIdealService memberIdealService;
+
+    @Async
+    @TransactionalEventListener(value = MemberRegisteredEvent.class, phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(MemberRegisteredEvent event) {
+        try {
+            memberIdealService.init(event.getMemberId());
+        } catch (Exception e) {
+            log.error("Member(memberId: {})의 Ideal 생성 중 예외가 발생합니다.", event.getMemberId(), e);
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionController.java
@@ -4,8 +4,11 @@ import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.member.command.application.introduction.MemberIntroductionService;
+import atwoz.atwoz.member.presentation.introduction.dto.MemberIntroductionCreateRequest;
 import atwoz.atwoz.member.query.introduction.application.IntroductionQueryService;
 import atwoz.atwoz.member.query.introduction.application.MemberIntroductionProfileView;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +20,7 @@ import java.util.List;
 @RequestMapping("/member/introduction")
 public class MemberIntroductionController {
     private final IntroductionQueryService introductionQueryService;
+    private final MemberIntroductionService memberintroductionService;
 
     @GetMapping("/grade")
     public ResponseEntity<BaseResponse<List<MemberIntroductionProfileView>>> findDiamondGradeIntroductions(@AuthPrincipal AuthContext authContext) {
@@ -51,5 +55,12 @@ public class MemberIntroductionController {
         long memberId = authContext.getId();
         List<MemberIntroductionProfileView> introductionProfileViews = introductionQueryService.findRecentlyJoinedIntroductions(memberId);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, introductionProfileViews));
+    }
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> create(@Valid @RequestBody MemberIntroductionCreateRequest request, @AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        memberintroductionService.create(memberId, request.introducedMemberId());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionExceptionHandler.java
@@ -2,6 +2,8 @@ package atwoz.atwoz.member.presentation.introduction;
 
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.member.command.application.introduction.exception.IntroducedMemberNotActiveException;
+import atwoz.atwoz.member.command.application.introduction.exception.IntroducedMemberNotFoundException;
 import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
 import atwoz.atwoz.member.command.domain.introduction.exception.InvalidAgeRangeException;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +25,22 @@ public class MemberIntroductionExceptionHandler {
 
     @ExceptionHandler(InvalidAgeRangeException.class)
     public ResponseEntity<BaseResponse<Void>> handleInvalidAgeRangeException(InvalidAgeRangeException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.from(StatusType.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(IntroducedMemberNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleIntroducedMemberNotFoundException(IntroducedMemberNotFoundException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(404)
+                .body(BaseResponse.from(StatusType.NOT_FOUND));
+    }
+
+    @ExceptionHandler(IntroducedMemberNotActiveException.class)
+    public ResponseEntity<BaseResponse<Void>> handleIntroducedMemberNotActiveException(IntroducedMemberNotActiveException e) {
         log.warn(e.getMessage());
 
         return ResponseEntity.badRequest()

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIntroductionCreateRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIntroductionCreateRequest.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.member.presentation.introduction.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MemberIntroductionCreateRequest(
+        @NotNull(message = "introducedMemberId는 필수입니다.")
+        Long introducedMemberId
+) {
+}

--- a/src/test/java/atwoz/atwoz/member/command/application/introduction/MemberIdealServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/introduction/MemberIdealServiceTest.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.member.command.application.introduction;
 
 import atwoz.atwoz.admin.command.domain.hobby.HobbyCommandRepository;
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealAlreadyExistsException;
 import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
 import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
 import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
@@ -13,10 +14,12 @@ import atwoz.atwoz.member.command.domain.member.exception.InvalidHobbyIdExceptio
 import atwoz.atwoz.member.presentation.introduction.dto.MemberIdealUpdateRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -37,70 +40,109 @@ class MemberIdealServiceTest {
     @Mock
     private HobbyCommandRepository hobbyCommandRepository;
 
-    private Set<Long> hobbyIds;
-    private AgeRange ageRange;
-    private Region region;
-    private Religion religion;
-    private SmokingStatus smokingStatus;
-    private DrinkingStatus drinkingStatus;
-    private MemberIdealUpdateRequest request;
+    @Nested
+    @DisplayName("update 메서드 테스트")
+    class UpdateTest {
+        private Set<Long> hobbyIds;
+        private AgeRange ageRange;
+        private Region region;
+        private Religion religion;
+        private SmokingStatus smokingStatus;
+        private DrinkingStatus drinkingStatus;
+        private MemberIdealUpdateRequest request;
 
-    @BeforeEach
-    void setUp() {
-        ageRange = AgeRange.of(20, 30);
-        region = Region.SEOUL;
-        religion = Religion.CHRISTIAN;
-        smokingStatus = SmokingStatus.VAPE;
-        drinkingStatus = DrinkingStatus.SOCIAL;
-        hobbyIds = Set.of(1L, 2L);
-        request =  new MemberIdealUpdateRequest(
-                ageRange.getMinAge(),
-                ageRange.getMaxAge(),
-                region.name(),
-                religion.name(),
-                smokingStatus.name(),
-                drinkingStatus.name(),
-                hobbyIds
-        );
+        @BeforeEach
+        void setUp() {
+            ageRange = AgeRange.of(20, 30);
+            region = Region.SEOUL;
+            religion = Religion.CHRISTIAN;
+            smokingStatus = SmokingStatus.VAPE;
+            drinkingStatus = DrinkingStatus.SOCIAL;
+            hobbyIds = Set.of(1L, 2L);
+            request = new MemberIdealUpdateRequest(
+                    ageRange.getMinAge(),
+                    ageRange.getMaxAge(),
+                    region.name(),
+                    religion.name(),
+                    smokingStatus.name(),
+                    drinkingStatus.name(),
+                    hobbyIds
+            );
+        }
+
+        @Test
+        @DisplayName("hobbyIds가 db에 존재하지 않는 경우 예외를 던진다.")
+        void throwExceptionWhenHobbyIdsIsNotExists() {
+            // given
+            long memberId = 1L;
+            when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(1L);
+
+            // when && then
+            assertThatThrownBy(() -> memberIdealService.update(request, memberId))
+                    .isInstanceOf(InvalidHobbyIdException.class);
+        }
+
+        @Test
+        @DisplayName("memberIdeal이 존재하지 않는 경우 예외를 던진다.")
+        void throwExceptionWhenMemberIdealIsNotExists() {
+            // given
+            long memberId = 1L;
+            when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(((long) hobbyIds.size()));
+            when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+
+            // when && then
+            assertThatThrownBy(() -> memberIdealService.update(request, memberId))
+                    .isInstanceOf(MemberIdealNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("memberIdeal이 존재하는 경우 memberIdeal을 업데이트한다.")
+        void updateMemberIdeal() {
+            long memberId = 1L;
+            when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(((long) hobbyIds.size()));
+            MemberIdeal memberIdeal = mock(MemberIdeal.class);
+            when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(memberIdeal));
+
+            // when
+            memberIdealService.update(request, memberId);
+
+            // then
+            verify(memberIdeal).update(ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus);
+        }
     }
 
-    @Test
-    @DisplayName("hobbyIds가 db에 존재하지 않는 경우 예외를 던진다.")
-    void throwExceptionWhenHobbyIdsIsNotExists() {
-        // given
-        long memberId = 1L;
-        when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(1L);
+    @Nested
+    @DisplayName("init 메서드 테스트")
+    class InitTest {
+        @Test
+        @DisplayName("memberIdeal이 이미 존재하는 경우 예외를 던진다.")
+        void throwExceptionWhenMemberIdealIsAlreadyExists() {
+            // given
+            long memberId = 1L;
+            when(memberIdealCommandRepository.existsByMemberId(memberId)).thenReturn(true);
 
-        // when && then
-        assertThatThrownBy(() -> memberIdealService.update(request, memberId))
-                .isInstanceOf(InvalidHobbyIdException.class);
-    }
+            // when && then
+            assertThatThrownBy(() -> memberIdealService.init(memberId))
+                    .isInstanceOf(MemberIdealAlreadyExistsException.class);
+        }
 
-    @Test
-    @DisplayName("memberIdeal이 존재하지 않는 경우 예외를 던진다.")
-    void throwExceptionWhenMemberIdealIsNotExists() {
-        // given
-        long memberId = 1L;
-        when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(((long) hobbyIds.size()));
-        when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+        @Test
+        @DisplayName("memberIdeal이 존재하지 않는 경우 memberIdeal을 생성한다.")
+        void createMemberIdeal() {
+            // given
+            long memberId = 1L;
+            when(memberIdealCommandRepository.existsByMemberId(memberId)).thenReturn(false);
 
-        // when && then
-        assertThatThrownBy(() -> memberIdealService.update(request, memberId))
-                .isInstanceOf(MemberIdealNotFoundException.class);
-    }
+            try(MockedStatic<MemberIdeal> memberIdealMock = mockStatic(MemberIdeal.class)) {
+                MemberIdeal memberIdeal = mock(MemberIdeal.class);
+                memberIdealMock.when(() -> MemberIdeal.init(memberId)).thenReturn(memberIdeal);
 
-    @Test
-    @DisplayName("memberIdeal이 존재하는 경우 memberIdeal을 업데이트한다.")
-    void updateMemberIdeal() {
-        long memberId = 1L;
-        when(hobbyCommandRepository.countAllByIdIsIn(hobbyIds)).thenReturn(((long) hobbyIds.size()));
-        MemberIdeal memberIdeal = mock(MemberIdeal.class);
-        when(memberIdealCommandRepository.findByMemberId(memberId)).thenReturn(Optional.of(memberIdeal));
+                // when
+                memberIdealService.init(memberId);
 
-        // when
-        memberIdealService.update(request, memberId);
-
-        // then
-        verify(memberIdeal).update(ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus);
+                // then
+                verify(memberIdealCommandRepository).save(memberIdeal);
+            }
+        }
     }
 }

--- a/src/test/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionServiceTest.java
@@ -1,0 +1,60 @@
+package atwoz.atwoz.member.command.application.introduction;
+
+
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIntroductionAlreadyExistsException;
+import atwoz.atwoz.member.command.domain.introduction.MemberIntroduction;
+import atwoz.atwoz.member.command.domain.introduction.MemberIntroductionCommandRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberIntroductionServiceTest {
+
+    @InjectMocks
+    private MemberIntroductionService memberIntroductionService;
+
+    @Mock
+    private MemberIntroductionCommandRepository memberIntroductionCommandRepository;
+
+    @Test
+    @DisplayName("이미 소개받은 멤버라면 예외를 던진다")
+    void throwsExceptionWhenMemberAlreadyIntroduced() {
+        // given
+        long memberId = 1L;
+        long introducedMemberId = 2L;
+
+        when(memberIntroductionCommandRepository.existsByMemberIdAndIntroducedMemberId(memberId, introducedMemberId)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> memberIntroductionService.create(memberId, introducedMemberId))
+                .isInstanceOf(MemberIntroductionAlreadyExistsException.class);
+    }
+
+    @Test
+    @DisplayName("소개받은 멤버가 아니라면 소개를 생성한다")
+    void createIntroduction() {
+        // given
+        long memberId = 1L;
+        long introducedMemberId = 2L;
+
+        when(memberIntroductionCommandRepository.existsByMemberIdAndIntroducedMemberId(memberId, introducedMemberId)).thenReturn(false);
+
+        // when
+        try (MockedStatic<MemberIntroduction> memberIntroductionMock = mockStatic(MemberIntroduction.class)) {
+            MemberIntroduction memberIntroduction = mock(MemberIntroduction.class);
+            memberIntroductionMock.when(() -> MemberIntroduction.of(memberId, introducedMemberId)).thenReturn(memberIntroduction);
+            memberIntroductionService.create(memberId, introducedMemberId);
+
+            // then
+            verify(memberIntroductionCommandRepository).save(memberIntroduction);
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
@@ -6,8 +6,6 @@ import atwoz.atwoz.common.enums.Role;
 import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
 import atwoz.atwoz.member.command.application.member.exception.BannedMemberException;
 import atwoz.atwoz.member.command.application.member.exception.MemberLoginConflictException;
-import atwoz.atwoz.member.command.domain.introduction.MemberIdeal;
-import atwoz.atwoz.member.command.domain.introduction.MemberIdealCommandRepository;
 import atwoz.atwoz.member.command.domain.member.ActivityStatus;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
@@ -27,9 +25,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.Instant;
 import java.util.Optional;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 public class MemberAuthServiceTest {
     private Member permanentStoppedMember;
@@ -38,9 +33,6 @@ public class MemberAuthServiceTest {
 
     @Mock
     private MemberCommandRepository memberCommandRepository;
-
-    @Mock
-    private MemberIdealCommandRepository memberIdealCommandRepository;
 
     @Mock
     private JwtProvider jwtProvider;
@@ -106,19 +98,13 @@ public class MemberAuthServiceTest {
         String phoneNumber = "01012345678";
         Instant fixedInstant = Instant.parse("2024-01-01T00:00:00Z");
 
-        try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class);
-             MockedStatic<MemberIdeal> mockedMemberIdeal = Mockito.mockStatic(MemberIdeal.class);
-        ) {
+        try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class);) {
             mockedInstant.when(Instant::now).thenReturn(fixedInstant);
 
             Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.empty());
             Mockito.when(jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
                     .thenReturn("accessToken");
             Mockito.when(memberCommandRepository.save(Mockito.any())).thenReturn(member);
-
-            MemberIdeal memberIdeal = mock(MemberIdeal.class);
-            mockedMemberIdeal.when(() -> MemberIdeal.from(memberId)).thenReturn(memberIdeal);
-            Mockito.when(memberIdealCommandRepository.save(memberIdeal)).thenReturn(memberIdeal);
 
             // When
             MemberLoginServiceDto response = memberAuthService.login(phoneNumber);
@@ -127,8 +113,6 @@ public class MemberAuthServiceTest {
             Assertions.assertThat(response.accessToken()).isNotNull();
             Assertions.assertThat(response.accessToken()).isEqualTo("accessToken");
             Assertions.assertThat(response.isProfileSettingNeeded()).isTrue();
-
-            verify(memberIdealCommandRepository).save(memberIdeal);
         }
     }
 

--- a/src/test/java/atwoz/atwoz/member/command/domain/introduction/MemberIdealTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/domain/introduction/MemberIdealTest.java
@@ -1,0 +1,132 @@
+package atwoz.atwoz.member.command.domain.introduction;
+
+import atwoz.atwoz.member.command.domain.introduction.vo.AgeRange;
+import atwoz.atwoz.member.command.domain.member.DrinkingStatus;
+import atwoz.atwoz.member.command.domain.member.Region;
+import atwoz.atwoz.member.command.domain.member.Religion;
+import atwoz.atwoz.member.command.domain.member.SmokingStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberIdealTest {
+
+    @Nested
+    @DisplayName("init 메서드 테스트")
+    class InitTest {
+
+        @Test
+        @DisplayName("memberId가 null이면 예외를 던진다.")
+        void throwsExceptionWhenMemberIdIsNull() {
+            // given
+            Long memberId = null;
+
+            // when, then
+            assertThatThrownBy(() -> MemberIdeal.init(null))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("정상적으로 MemberIdeal 객체를 생성한다.")
+        void createsMemberIdealObject() {
+            // given
+            Long memberId = 1L;
+
+            // when
+            MemberIdeal memberIdeal = MemberIdeal.init(memberId);
+
+            // then
+            assertThat(memberIdeal.getMemberId()).isEqualTo(memberId);
+            assertThat(memberIdeal.getAgeRange()).isEqualTo(AgeRange.init());
+            assertThat(memberIdeal.getHobbyIds()).isEmpty();
+            assertThat(memberIdeal.getRegion()).isNull();
+            assertThat(memberIdeal.getReligion()).isNull();
+            assertThat(memberIdeal.getSmokingStatus()).isNull();
+            assertThat(memberIdeal.getDrinkingStatus()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("update 메서드 테스트")
+    class UpdateTest {
+
+        private Set<Long> hobbyIds;
+        private AgeRange ageRange;
+        private Region region;
+        private Religion religion;
+        private SmokingStatus smokingStatus;
+        private DrinkingStatus drinkingStatus;
+
+        @BeforeEach
+        void setUp() {
+            ageRange = AgeRange.of(20, 30);
+            region = Region.SEOUL;
+            religion = Religion.CHRISTIAN;
+            smokingStatus = SmokingStatus.VAPE;
+            drinkingStatus = DrinkingStatus.SOCIAL;
+            hobbyIds = Set.of(1L, 2L);
+        }
+
+        @Test
+        @DisplayName("ageRange가 null이면 예외를 던진다.")
+        void throwsExceptionWhenAgeRangeIsNull() {
+            // given
+            MemberIdeal memberIdeal = MemberIdeal.init(1L);
+            ageRange = null;
+
+            // when, then
+            assertThatThrownBy(() -> memberIdeal.update(ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("hobbyIds가 null이면 예외를 던진다.")
+        void throwsExceptionWhenHobbyIdsIsNull() {
+            // given
+            MemberIdeal memberIdeal = MemberIdeal.init(1L);
+            hobbyIds = null;
+
+            // when, then
+            assertThatThrownBy(() -> memberIdeal.update(ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"region", "religion", "smokingStatus", "drinkingStatus", "none"})
+        @DisplayName("ageRange, hobbyIds외의 다른 파라미터가 null이면 update한다.")
+        void updatesMemberIdeal(String nullParameter) {
+            // given
+            MemberIdeal memberIdeal = MemberIdeal.init(1L);
+            if (nullParameter.equals("region")) {
+                region = null;
+            } else if (nullParameter.equals("religion")) {
+                religion = null;
+            } else if (nullParameter.equals("smokingStatus")) {
+                smokingStatus = null;
+            } else if (nullParameter.equals("drinkingStatus")) {
+                drinkingStatus = null;
+            } else if (nullParameter.equals("none")) {
+                // do nothing
+            }
+
+            // when
+            memberIdeal.update(ageRange, hobbyIds, region, religion, smokingStatus, drinkingStatus);
+
+            // then
+            assertThat(memberIdeal.getAgeRange()).isEqualTo(ageRange);
+            assertThat(memberIdeal.getHobbyIds()).isEqualTo(hobbyIds);
+            assertThat(memberIdeal.getRegion()).isEqualTo(region);
+            assertThat(memberIdeal.getReligion()).isEqualTo(religion);
+            assertThat(memberIdeal.getSmokingStatus()).isEqualTo(smokingStatus);
+            assertThat(memberIdeal.getDrinkingStatus()).isEqualTo(drinkingStatus);
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/command/domain/introduction/MemberIntroductionTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/domain/introduction/MemberIntroductionTest.java
@@ -1,0 +1,54 @@
+package atwoz.atwoz.member.command.domain.introduction;
+
+
+import atwoz.atwoz.common.event.Events;
+import atwoz.atwoz.member.command.domain.introduction.event.MemberIntroducedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class MemberIntroductionTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"memberId", "introducedMemberId"})
+    @DisplayName("null 값을 가지고 생성하면 예외를 던진다.")
+    void throwsExceptionWhenNullValue(String nullParam) {
+        // given
+        Long memberId = nullParam.equals("memberId") ? null : 1L;
+        Long introducedMemberId = nullParam.equals("introducedMemberId") ? null : 2L;
+
+        // when & then
+        assertThatThrownBy(() -> MemberIntroduction.of(memberId, introducedMemberId))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("of 메서드를 호출하면 MemberIntroducedEvent를 발행하고 MemberIntroduction을 생성한다.")
+    void createIntroduction() {
+        // given
+        long memberId = 1L;
+        long introducedMemberId = 2L;
+
+
+        try (MockedStatic<Events> eventsMock = mockStatic(Events.class);
+             MockedStatic<MemberIntroducedEvent> memberIntroducedEventMock = mockStatic(MemberIntroducedEvent.class)
+        ) {
+            MemberIntroducedEvent memberIntroducedEvent = mock(MemberIntroducedEvent.class);
+            memberIntroducedEventMock.when(() -> MemberIntroducedEvent.of(memberId)).thenReturn(memberIntroducedEvent);
+
+            // when
+            MemberIntroduction memberIntroduction = MemberIntroduction.of(memberId, introducedMemberId);
+
+            // then
+            eventsMock.verify(() -> Events.raise(memberIntroducedEvent));
+            assertThat(memberIntroduction.getMemberId()).isEqualTo(memberId);
+            assertThat(memberIntroduction.getIntroducedMemberId()).isEqualTo(introducedMemberId);
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepositoryTest.java
@@ -2,6 +2,7 @@ package atwoz.atwoz.member.query.introduction.intra;
 
 import atwoz.atwoz.QuerydslConfig;
 import atwoz.atwoz.admin.command.domain.hobby.Hobby;
+import atwoz.atwoz.common.event.Events;
 import atwoz.atwoz.member.command.domain.introduction.MemberIntroduction;
 import atwoz.atwoz.member.command.domain.member.*;
 import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
@@ -11,6 +12,8 @@ import atwoz.atwoz.member.query.introduction.application.IntroductionSearchCondi
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -131,6 +134,20 @@ class IntroductionQueryRepositoryTest {
     @Nested
     @DisplayName("findAllMemberIntroductionProfileQueryResultByMemberIds 메서드 테스트")
     class FindAllMemberIntroductionProfileQueryResultByMemberIdsIdsTest {
+        private static MockedStatic<Events> mockedEvents;
+
+        @BeforeEach
+        void setUp() {
+            mockedEvents = Mockito.mockStatic(Events.class);
+            mockedEvents.when(() -> Events.raise(Mockito.any()))
+                    .thenAnswer(invocation -> null);
+        }
+
+        @AfterEach
+        void tearDown() {
+            mockedEvents.close();
+        }
+
         @ParameterizedTest
         @ValueSource(strings = {"introduced", "notIntroduced1", "notIntroduced2"})
         @DisplayName("멤버 ID 목록에 해당하는 회원의 소개 프로필 리턴")

--- a/src/test/java/atwoz/atwoz/member/query/introduction/intra/MemberIdealQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/intra/MemberIdealQueryRepositoryTest.java
@@ -48,7 +48,7 @@ class MemberIdealQueryRepositoryTest {
     void returnMemberIdealViewWhenMemberIdealIsExists() {
         // given
         long memberId = 1L;
-        MemberIdeal memberIdeal = MemberIdeal.from(memberId);
+        MemberIdeal memberIdeal = MemberIdeal.init(memberId);
         AgeRange ageRange = AgeRange.of(20, 30);
         Hobby hobby1 = Hobby.from("취미1");
         Hobby hobby2 = Hobby.from("취미2");


### PR DESCRIPTION
### 관련 이슈
- closes #125 

<br>

### 작업 내용
- 소개받기 API 구현
- 소개받기 이벤트 발행 시 하트 소모 처리하는 핸들러 구현
- 멤버 회원가입 이벤트 발행 시 멤버 이상형 초기화 하는 핸들러 구현

<br>

### 참고 자료
-

<br>

### 노트
- https://github.com/atwoz-dev/atwoz_server/pull/123#discussion_r2003161471
  - 이번 PR에서 멤버 이상형 초기화 분리 작업 포함해서 진행했어요!