### PR TITLE
셀프 소개 목록 조회 

### DIFF
--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionController.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionController.java
@@ -5,16 +5,16 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.community.command.application.selfintroduction.SelfIntroductionService;
-import atwoz.atwoz.community.presentation.selfintroduction.dto.SelfIntroductionSummaryResponse;
+import atwoz.atwoz.community.presentation.selfintroduction.dto.SelfIntroductionSearchRequest;
 import atwoz.atwoz.community.presentation.selfintroduction.dto.SelfIntroductionWriteRequest;
+import atwoz.atwoz.community.query.selfintroduction.SelfIntroductionQueryRepository;
 import atwoz.atwoz.community.query.selfintroduction.SelfIntroductionSearchCondition;
-import lombok.Getter;
+import atwoz.atwoz.community.query.selfintroduction.view.SelfIntroductionSummaryView;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/self-introduction")
@@ -22,6 +22,7 @@ import java.util.List;
 public class SelfIntroductionController {
 
     private final SelfIntroductionService selfIntroductionService;
+    private final SelfIntroductionQueryRepository selfIntroductionQueryRepository;
 
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> write(@RequestBody SelfIntroductionWriteRequest request, @AuthPrincipal AuthContext authContext) {
@@ -42,8 +43,8 @@ public class SelfIntroductionController {
     }
 
     @GetMapping
-    public ResponseEntity<BaseResponse<List<SelfIntroductionSummaryResponse>>> getIntroductions(@AuthPrincipal AuthContext authContext, @ModelAttribute SelfIntroductionSearchCondition searchCondition, Pageable pageable) {
-
-        return null;
+    public ResponseEntity<BaseResponse<Page<SelfIntroductionSummaryView>>> getIntroductions(@AuthPrincipal AuthContext authContext, @ModelAttribute SelfIntroductionSearchRequest searchRequest, Pageable pageable) {
+        SelfIntroductionSearchCondition searchCondition = SelfIntroductionMapper.toSelfIntroductionSearchCondition(searchRequest);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, selfIntroductionQueryRepository.findSelfIntroductions(searchCondition, pageable)));
     }
 }

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionController.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionController.java
@@ -5,10 +5,16 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.community.command.application.selfintroduction.SelfIntroductionService;
+import atwoz.atwoz.community.presentation.selfintroduction.dto.SelfIntroductionSummaryResponse;
 import atwoz.atwoz.community.presentation.selfintroduction.dto.SelfIntroductionWriteRequest;
+import atwoz.atwoz.community.query.selfintroduction.SelfIntroductionSearchCondition;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/self-introduction")
@@ -33,5 +39,11 @@ public class SelfIntroductionController {
     public ResponseEntity<BaseResponse> delete(@PathVariable Long id, @AuthPrincipal AuthContext authContext) {
         selfIntroductionService.delete(id, authContext.getId());
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<SelfIntroductionSummaryResponse>>> getIntroductions(@AuthPrincipal AuthContext authContext, @ModelAttribute SelfIntroductionSearchCondition searchCondition, Pageable pageable) {
+
+        return null;
     }
 }

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionMapper.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionMapper.java
@@ -1,0 +1,17 @@
+package atwoz.atwoz.community.presentation.selfintroduction;
+
+import atwoz.atwoz.community.presentation.selfintroduction.dto.SelfIntroductionSearchRequest;
+import atwoz.atwoz.community.query.selfintroduction.SelfIntroductionSearchCondition;
+import atwoz.atwoz.member.command.domain.member.Gender;
+import atwoz.atwoz.member.query.member.AgeConverter;
+
+public class SelfIntroductionMapper {
+    static SelfIntroductionSearchCondition toSelfIntroductionSearchCondition(SelfIntroductionSearchRequest selfIntroductionSearchRequest) {
+        return new SelfIntroductionSearchCondition(
+                selfIntroductionSearchRequest.preferredRegions(),
+                AgeConverter.toYearOfBirth(selfIntroductionSearchRequest.toAge()),
+                AgeConverter.toYearOfBirth(selfIntroductionSearchRequest.fromAge()),
+                Gender.from(selfIntroductionSearchRequest.gender())
+        );
+    }
+}

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchRequest.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchRequest.java
@@ -1,0 +1,13 @@
+package atwoz.atwoz.community.presentation.selfintroduction.dto;
+
+import atwoz.atwoz.member.command.domain.member.Region;
+
+import java.util.List;
+
+public record SelfIntroductionSearchRequest(
+        List<Region> preferredRegions,
+        Integer fromAge,
+        Integer toAge,
+        String gender
+) {
+}

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSummaryResponse.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSummaryResponse.java
@@ -4,6 +4,7 @@ public record SelfIntroductionSummaryResponse(
         Long id,
         String name,
         String profileUrl,
-        Integer age
+        Integer age,
+        String title
 ) {
 }

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSummaryResponse.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSummaryResponse.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.community.presentation.selfintroduction.dto;
+
+public record SelfIntroductionSummaryResponse(
+        Long id,
+        String name,
+        String profileUrl,
+        Integer age
+) {
+}

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionQueryRepository.java
@@ -1,0 +1,19 @@
+package atwoz.atwoz.community.query.selfintroduction;
+
+import atwoz.atwoz.community.query.selfintroduction.view.SelfIntroductionSummaryView;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SelfIntroductionQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public List<SelfIntroductionSummaryView> findSelfIntroductions() {
+
+        return null;
+    }
+}

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionQueryRepository.java
@@ -1,19 +1,91 @@
 package atwoz.atwoz.community.query.selfintroduction;
 
+import atwoz.atwoz.community.query.selfintroduction.view.QSelfIntroductionSummaryView;
 import atwoz.atwoz.community.query.selfintroduction.view.SelfIntroductionSummaryView;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
+
+import static atwoz.atwoz.community.command.domain.selfintroduction.QSelfIntroduction.selfIntroduction;
+import static atwoz.atwoz.member.command.domain.member.QMember.member;
+import static atwoz.atwoz.member.command.domain.profileImage.QProfileImage.profileImage;
 
 @Repository
 @RequiredArgsConstructor
 public class SelfIntroductionQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public List<SelfIntroductionSummaryView> findSelfIntroductions() {
+    public Page<SelfIntroductionSummaryView> findSelfIntroductions(SelfIntroductionSearchCondition searchCondition, Pageable pageable) {
 
-        return null;
+        BooleanExpression condition = getSearchCondition(searchCondition);
+
+        List<SelfIntroductionSummaryView> content = queryFactory
+                .select(
+                        new QSelfIntroductionSummaryView(selfIntroduction.id, member.profile.nickname.value, profileImage.imageUrl.value, member.profile.yearOfBirth.value, selfIntroduction.title)
+                )
+                .from(selfIntroduction)
+                .join(member).on(member.id.eq(selfIntroduction.memberId))
+                .join(profileImage).on(profileImage.memberId.eq(member.id).and(profileImage.isPrimary.eq(true)))
+                .where(condition)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(selfIntroduction.id.desc())
+                .fetch();
+
+        long totalCount = Optional.ofNullable(
+                queryFactory
+                        .select(selfIntroduction.count())
+                        .from(selfIntroduction)
+                        .join(member).on(member.id.eq(selfIntroduction.memberId))
+                        .join(profileImage).on(profileImage.memberId.eq(member.id).and(profileImage.isPrimary.eq(true)))
+                        .where(condition)
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(content, pageable, totalCount);
+    }
+
+    private BooleanExpression getSearchCondition(SelfIntroductionSearchCondition searchCondition) {
+        BooleanExpression condition = addYearOfBirthCondition(null, searchCondition);
+        condition = addGenderCondition(condition, searchCondition);
+        condition = addPreferredRegionCondition(condition, searchCondition);
+        return condition == null ? member.isNotNull() : condition;
+    }
+
+    private BooleanExpression addYearOfBirthCondition(BooleanExpression condition, SelfIntroductionSearchCondition searchCondition) {
+        if (searchCondition.fromYearOfBirth() != null && searchCondition.toYearOfBirth() != null) {
+            condition = (condition == null) ? member.profile.yearOfBirth.value.between(searchCondition.fromYearOfBirth(), searchCondition.toYearOfBirth())
+                    : condition.and(member.profile.yearOfBirth.value.between(searchCondition.fromYearOfBirth(), searchCondition.toYearOfBirth()));
+        } else if (searchCondition.fromYearOfBirth() != null) {
+            condition = (condition == null) ? member.profile.yearOfBirth.value.goe(searchCondition.fromYearOfBirth())
+                    : condition.and(member.profile.yearOfBirth.value.goe(searchCondition.fromYearOfBirth()));
+        } else if (searchCondition.toYearOfBirth() != null) {
+            condition = (condition == null) ? member.profile.yearOfBirth.value.loe(searchCondition.toYearOfBirth())
+                    : condition.and(member.profile.yearOfBirth.value.loe(searchCondition.toYearOfBirth()));
+        }
+        return condition;
+    }
+
+    private BooleanExpression addGenderCondition(BooleanExpression condition, SelfIntroductionSearchCondition searchCondition) {
+        if (searchCondition.gender() != null) {
+            condition = (condition == null) ? member.profile.gender.eq(searchCondition.gender())
+                    : condition.and(member.profile.gender.eq(searchCondition.gender()));
+        }
+        return condition;
+    }
+
+    private BooleanExpression addPreferredRegionCondition(BooleanExpression condition, SelfIntroductionSearchCondition searchCondition) {
+        if (searchCondition.preferredRegions() != null && !searchCondition.preferredRegions().isEmpty()) {
+            condition = (condition == null) ? member.profile.region.in(searchCondition.preferredRegions())
+                    : condition.and(member.profile.region.in(searchCondition.preferredRegions()));
+        }
+        return condition;
     }
 }

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionSearchCondition.java
@@ -1,0 +1,11 @@
+package atwoz.atwoz.community.query.selfintroduction;
+
+import java.util.List;
+
+public record SelfIntroductionSearchCondition(
+        List<String> preferredRegions,
+        Integer fromAge,
+        Integer toAge,
+        Boolean onlyAnotherGender
+) {
+}

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionSearchCondition.java
@@ -1,11 +1,14 @@
 package atwoz.atwoz.community.query.selfintroduction;
 
+import atwoz.atwoz.member.command.domain.member.Gender;
+import atwoz.atwoz.member.command.domain.member.Region;
+
 import java.util.List;
 
 public record SelfIntroductionSearchCondition(
-        List<String> preferredRegions,
-        Integer fromAge,
-        Integer toAge,
-        Boolean onlyAnotherGender
+        List<Region> preferredRegions,
+        Integer fromYearOfBirth,
+        Integer toYearOfBirth,
+        Gender gender
 ) {
 }

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/SelfIntroductionSummaryView.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/SelfIntroductionSummaryView.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.community.query.selfintroduction.view;
+
+public record SelfIntroductionSummaryView(
+        Long id,
+        String name,
+        String profileUrl,
+        Integer yearOfBirth
+) {
+}

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/SelfIntroductionSummaryView.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/SelfIntroductionSummaryView.java
@@ -1,9 +1,15 @@
 package atwoz.atwoz.community.query.selfintroduction.view;
 
+import com.querydsl.core.annotations.QueryProjection;
+
 public record SelfIntroductionSummaryView(
         Long id,
-        String name,
+        String nickname,
         String profileUrl,
-        Integer yearOfBirth
+        Integer yearOfBirth,
+        String title
 ) {
+    @QueryProjection
+    public SelfIntroductionSummaryView {
+    }
 }

--- a/src/main/java/atwoz/atwoz/member/query/member/AgeConverter.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/AgeConverter.java
@@ -4,12 +4,6 @@ import java.util.Calendar;
 
 public class AgeConverter {
     public static Integer toAge(Integer yearOfBirth) {
-
-        int current = Calendar.getInstance().get(Calendar.YEAR);
-        int age = current - yearOfBirth + 1;
-        System.out.println("current : " + current);
-        System.out.println("age : " + age);
-        System.out.println("year : " + (current - age - 1));
         return yearOfBirth == null ? null : Calendar.getInstance().get(Calendar.YEAR) - yearOfBirth + 1;
     }
 

--- a/src/main/java/atwoz/atwoz/member/query/member/AgeConverter.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/AgeConverter.java
@@ -4,7 +4,13 @@ import java.util.Calendar;
 
 public class AgeConverter {
     public static Integer toAge(Integer yearOfBirth) {
-        return yearOfBirth == null ? null : yearOfBirth - Calendar.getInstance().get(Calendar.YEAR) + 1;
+
+        int current = Calendar.getInstance().get(Calendar.YEAR);
+        int age = current - yearOfBirth + 1;
+        System.out.println("current : " + current);
+        System.out.println("age : " + age);
+        System.out.println("year : " + (current - age - 1));
+        return yearOfBirth == null ? null : Calendar.getInstance().get(Calendar.YEAR) - yearOfBirth + 1;
     }
 
     public static Integer toYearOfBirth(Integer age) {

--- a/src/main/java/atwoz/atwoz/member/query/member/view/OtherMemberProfileView.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/view/OtherMemberProfileView.java
@@ -33,7 +33,7 @@ public record OtherMemberProfileView(
             String contactType,
             String contact
     ) {
-        this(new BasicMemberInfo(id, nickname, profileImageUrl, AgeConverter.toAge(yearOfBirth), gender, height, job, hobbies, mbti, region, smokingStatus, drinkingStatus, highestEducation, religion, like),
+        this(new BasicMemberInfo(id, nickname, profileImageUrl, yearOfBirth, gender, height, job, hobbies, mbti, region, smokingStatus, drinkingStatus, highestEducation, religion, like),
                 matchId == null ? null : new MatchInfo(matchId, requesterId, responderId, requestMessage, responseMessage, matchStatus, contactType, contact));
     }
 }

--- a/src/test/java/atwoz/atwoz/community/query/SelfIntroductionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/community/query/SelfIntroductionQueryRepositoryTest.java
@@ -1,0 +1,284 @@
+package atwoz.atwoz.community.query;
+
+import atwoz.atwoz.common.config.QueryDslConfig;
+import atwoz.atwoz.common.event.Events;
+import atwoz.atwoz.community.command.domain.selfintroduction.SelfIntroduction;
+import atwoz.atwoz.community.query.selfintroduction.SelfIntroductionQueryRepository;
+import atwoz.atwoz.community.query.selfintroduction.SelfIntroductionSearchCondition;
+import atwoz.atwoz.community.query.selfintroduction.view.SelfIntroductionSummaryView;
+import atwoz.atwoz.member.command.domain.member.Gender;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.Region;
+import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
+import atwoz.atwoz.member.command.domain.profileImage.ProfileImage;
+import atwoz.atwoz.member.command.domain.profileImage.vo.ImageUrl;
+import atwoz.atwoz.member.query.member.AgeConverter;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, SelfIntroductionQueryRepository.class})
+public class SelfIntroductionQueryRepositoryTest {
+
+    @Autowired
+    private SelfIntroductionQueryRepository selfIntroductionQueryRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Nested
+    @DisplayName("셀프 소개 페이지네이션 테스트")
+    class selfIntroductionPaginationTest {
+
+        static MockedStatic<Events> mockedEvents;
+
+        Member maleMember;
+        String maleMemberProfileImageUrl = "imageUrl1";
+
+        Member femaleMember;
+        String femaleMemberProfileImageUrl = "imageUrl2";
+
+        List<SelfIntroduction> selfIntroductions = new ArrayList<>();
+
+        @BeforeEach
+        void setUp() {
+            mockedEvents = Mockito.mockStatic(Events.class);
+            mockedEvents.when(() -> Events.raise(Mockito.any()))
+                    .thenAnswer(invocation -> null);
+
+            maleMember = Member.fromPhoneNumber("01012345678");
+            femaleMember = Member.fromPhoneNumber("01012345679");
+
+            MemberProfile maleMemberProfile = MemberProfile.builder()
+                    .gender(Gender.MALE)
+                    .region(Region.SEOUL)
+                    .yearOfBirth(AgeConverter.toYearOfBirth(25))
+                    .build();
+
+            MemberProfile femaleMemberProfile = MemberProfile.builder()
+                    .gender(Gender.FEMALE)
+                    .region(Region.DAEJEON)
+                    .yearOfBirth(AgeConverter.toYearOfBirth(35))
+                    .build();
+
+            maleMember.updateProfile(maleMemberProfile);
+            femaleMember.updateProfile(femaleMemberProfile);
+
+            entityManager.persist(maleMember);
+            entityManager.persist(femaleMember);
+            entityManager.flush();
+
+            // 프로필 이미지 설정.
+            ProfileImage maleMemberProfileImage = ProfileImage.builder()
+                    .isPrimary(true)
+                    .order(1)
+                    .imageUrl(ImageUrl.from(maleMemberProfileImageUrl))
+                    .memberId(maleMember.getId())
+                    .build();
+
+            ProfileImage femaleMemberProfileImage = ProfileImage.builder()
+                    .isPrimary(true)
+                    .imageUrl(ImageUrl.from(femaleMemberProfileImageUrl))
+                    .memberId(femaleMember.getId())
+                    .build();
+
+            entityManager.persist(maleMemberProfileImage);
+            entityManager.persist(femaleMemberProfileImage);
+            entityManager.flush();
+
+            // 셀프 소개 글 작성.
+            // 남자 6개, 여자 6개
+            for (int i = 0; i < 6; i++) {
+                SelfIntroduction maleSelfIntroduction = SelfIntroduction.write(maleMember.getId(), "제목" + i, "내용은 30자 이상 이어야 합니다. 30자 채우기용 30자 채우기용 " + i);
+                SelfIntroduction femaleSelfIntroduction = SelfIntroduction.write(femaleMember.getId(), "제목" + i, "내용은 30자 이상 이어야 합니다. 30자 채우기용 30자 채우기용 " + i);
+
+                selfIntroductions.add(maleSelfIntroduction);
+                selfIntroductions.add(femaleSelfIntroduction);
+
+                entityManager.persist(maleSelfIntroduction);
+                entityManager.persist(femaleSelfIntroduction);
+            }
+            entityManager.flush();
+
+            selfIntroductions.sort((s1, s2) -> (int)(s2.getId() - s1.getId()));
+        }
+
+        @AfterEach
+        void tearDown() {
+            mockedEvents.close();
+        }
+
+        @Test
+        @DisplayName("검색 조건이 없는 경우, 모든 글을 불러온다.")
+        void getAllSelfIntroductions() {
+            // Given
+            SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
+                    null, null, null, null
+            );
+
+            // When
+            Page<SelfIntroductionSummaryView> selfIntroductionPage = selfIntroductionQueryRepository
+                    .findSelfIntroductions(searchCondition, PageRequest.of(0, 20));
+
+            // Then
+            Assertions.assertThat(selfIntroductionPage).isNotNull();
+            Assertions.assertThat(selfIntroductionPage.getTotalElements()).isEqualTo(selfIntroductions.size());
+        }
+
+        @Test
+        @DisplayName("검색 조건 중 성별에 남성을 명시한 경우, 남성의 글을 불러온다.")
+        void getSelfIntroductionsByGender() {
+            // Given
+            SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
+                    null, null, null, Gender.MALE
+            );
+            List<SelfIntroduction> maleSelfIntroduction = selfIntroductions.stream().filter(s -> s.getMemberId() == maleMember.getId()).toList();
+
+
+            // When
+            Page<SelfIntroductionSummaryView> selfIntroductionPage = selfIntroductionQueryRepository
+                    .findSelfIntroductions(searchCondition, PageRequest.of(0, 20));
+
+
+            // Then
+            Assertions.assertThat(selfIntroductionPage).isNotNull();
+            Assertions.assertThat(selfIntroductionPage.getTotalElements()).isEqualTo(maleSelfIntroduction.size());
+
+            for (int i = 0; i < selfIntroductionPage.getTotalElements(); i++) {
+                SelfIntroductionSummaryView view = selfIntroductionPage.getContent().get(i);
+                SelfIntroduction selfIntroduction = maleSelfIntroduction.get(i);
+
+                Assertions.assertThat(view.id()).isEqualTo(selfIntroduction.getId());
+                Assertions.assertThat(view.title()).isEqualTo(selfIntroduction.getTitle());
+                Assertions.assertThat(view.nickname()).isEqualTo(maleMember.getProfile().getNickname());
+                Assertions.assertThat(view.profileUrl()).isEqualTo(maleMemberProfileImageUrl);
+                Assertions.assertThat(view.yearOfBirth()).isEqualTo(maleMember.getProfile().getYearOfBirth().getValue());
+            }
+        }
+
+        @Test
+        @DisplayName("검색 조건 중 최대 연도를 명시한 경우, 해당 연도 이하의 멤버가 작성한 글을 불러온다.")
+        void getSelfIntroductionsByStartAgeCondition() {
+            // Given
+            int toYearOfBirth = maleMember.getProfile().getYearOfBirth().getValue() + 1;
+            SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
+                    null, null, toYearOfBirth, null
+            );
+
+            // When
+            Page<SelfIntroductionSummaryView> selfIntroductionPage = selfIntroductionQueryRepository
+                    .findSelfIntroductions(searchCondition, PageRequest.of(0, 20));
+
+            // Then
+            Assertions.assertThat(selfIntroductionPage).isNotNull();
+            for (int i = 0; i < selfIntroductionPage.getTotalElements(); i++) {
+                SelfIntroductionSummaryView view = selfIntroductionPage.getContent().get(i);
+                Assertions.assertThat(view.yearOfBirth()).isLessThanOrEqualTo(toYearOfBirth);
+            }
+        }
+
+        @Test
+        @DisplayName("검색 조건 중 최소 연도를 명시한 경우, 해당 연도 이상의 멤버가 작성한 글을 불러온다.")
+        void getSelfIntroductionsByEndAgeCondition() {
+            // Given
+            int fromYearOfBirth = femaleMember.getProfile().getYearOfBirth().getValue() - 1;
+            SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
+                    null, fromYearOfBirth, null, null
+            );
+
+
+            // When
+            Page<SelfIntroductionSummaryView> selfIntroductionPage = selfIntroductionQueryRepository
+                    .findSelfIntroductions(searchCondition, PageRequest.of(0, 20));
+
+            // Then
+            Assertions.assertThat(selfIntroductionPage).isNotNull();
+            for (int i = 0; i < selfIntroductionPage.getTotalElements(); i++) {
+                SelfIntroductionSummaryView view = selfIntroductionPage.getContent().get(i);
+                Assertions.assertThat(view.yearOfBirth()).isGreaterThanOrEqualTo(fromYearOfBirth);
+            }
+        }
+
+        @Test
+        @DisplayName("검색 조건 중 최소/최대 연도를 명시한 경우, 해당 연도 사이의 멤버가 작성한 글을 불러온다.")
+        void getSelfIntroductionsByYearRangeCondition() {
+            // Given
+            int toYearOfBirth = maleMember.getProfile().getYearOfBirth().getValue();
+            int fromYearOfBirth = femaleMember.getProfile().getYearOfBirth().getValue();
+
+            SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
+                    null, fromYearOfBirth, toYearOfBirth, null
+            );
+
+            // When
+            Page<SelfIntroductionSummaryView> selfIntroductionPage = selfIntroductionQueryRepository
+                    .findSelfIntroductions(searchCondition, PageRequest.of(0, 20));
+
+            // Then
+            Assertions.assertThat(selfIntroductionPage).isNotNull();
+            for (int i = 0; i < selfIntroductionPage.getTotalElements(); i++) {
+                SelfIntroductionSummaryView view = selfIntroductionPage.getContent().get(i);
+                Assertions.assertThat(view.yearOfBirth()).isBetween(fromYearOfBirth, toYearOfBirth);
+            }
+        }
+
+        @Test
+        @DisplayName("검색 조건 중 지역을 명시한 경우, 해당 지역 출신의 멤벅 작성한 글을 불러온다.")
+        void getSelfIntroductionByRegionCondition() {
+            // Given
+            Region region = maleMember.getProfile().getRegion();
+            SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
+                    List.of(region), null, null, null
+            );
+
+            List<SelfIntroduction> maleSelfIntroduction = selfIntroductions.stream().filter(s -> s.getMemberId() == maleMember.getId()).toList();
+
+            // When
+            Page<SelfIntroductionSummaryView> selfIntroductionPage = selfIntroductionQueryRepository
+                    .findSelfIntroductions(searchCondition, PageRequest.of(0, 20));
+
+            // Then
+            Assertions.assertThat(selfIntroductionPage).isNotNull();
+            for (int i = 0; i < selfIntroductionPage.getTotalElements(); i++) {
+                SelfIntroductionSummaryView view = selfIntroductionPage.getContent().get(i);
+                SelfIntroduction selfIntroduction = maleSelfIntroduction.get(i);
+
+                Assertions.assertThat(view.id()).isEqualTo(selfIntroduction.getId());
+            }
+        }
+
+        @Test
+        @DisplayName("모든 조건을 설정해 글을 조회합니다.")
+        void findSelfIntroductions() {
+            // Given
+            SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
+                    List.of(Region.DAEJEON, Region.SEOUL), femaleMember.getProfile().getYearOfBirth().getValue(), maleMember.getProfile().getYearOfBirth().getValue(), maleMember.getProfile().getGender()
+            );
+            List<SelfIntroduction> maleSelfIntroduction = selfIntroductions.stream().filter(s -> s.getMemberId() == maleMember.getId()).toList();
+
+            // When
+            Page<SelfIntroductionSummaryView> selfIntroductionPage = selfIntroductionQueryRepository
+                    .findSelfIntroductions(searchCondition, PageRequest.of(0, 20));
+
+            // Then
+            Assertions.assertThat(selfIntroductionPage).isNotNull();
+            for (int i = 0; i < selfIntroductionPage.getTotalElements(); i++) {
+                SelfIntroductionSummaryView view = selfIntroductionPage.getContent().get(i);
+                SelfIntroduction selfIntroduction = maleSelfIntroduction.get(i);
+
+                Assertions.assertThat(view.id()).isEqualTo(selfIntroduction.getId());
+            }
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/community/query/SelfIntroductionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/community/query/SelfIntroductionQueryRepositoryTest.java
@@ -111,7 +111,7 @@ public class SelfIntroductionQueryRepositoryTest {
             }
             entityManager.flush();
 
-            selfIntroductions.sort((s1, s2) -> (int)(s2.getId() - s1.getId()));
+            selfIntroductions.sort((s1, s2) -> (int) (s2.getId() - s1.getId()));
         }
 
         @AfterEach

--- a/src/test/java/atwoz/atwoz/member/query/member/MemberQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/member/MemberQueryRepositoryTest.java
@@ -410,7 +410,7 @@ public class MemberQueryRepositoryTest {
         private void assertionsBasicInfo(BasicMemberInfo basicMemberInfo, MemberProfile otherMemberProfile) {
             Assertions.assertThat(basicMemberInfo.nickname()).isEqualTo(otherMemberProfile.getNickname().getValue());
             Assertions.assertThat(basicMemberInfo.profileImageUrl()).isEqualTo(profileImageUrl);
-            Assertions.assertThat(basicMemberInfo.yearOfBirth()).isEqualTo(AgeConverter.toAge(otherMemberProfile.getYearOfBirth().getValue()));
+            Assertions.assertThat(basicMemberInfo.yearOfBirth()).isEqualTo(otherMemberProfile.getYearOfBirth().getValue());
             Assertions.assertThat(basicMemberInfo.gender()).isEqualTo(otherMemberProfile.getGender().toString());
             Assertions.assertThat(basicMemberInfo.height()).isEqualTo(otherMemberProfile.getHeight());
             Assertions.assertThat(basicMemberInfo.job()).isEqualTo(jobName);


### PR DESCRIPTION
### 관련 이슈
- closes #117

<br>

### 작업 내용
- 페이지네이션 구현
- 테스트 코드 작성

<br>

### 참고 자료
- 호윤님이 이전에 작성하셨던 페이지네이션(`Screening`)에 맞춰서 기능을 구현하려고 하였습니다 (오프셋 기반 페이지네이션)!

<br>

### 노트
- 해당 검색 조건에도 출생 연도가 있어서, 클라이언트에게 받은 나이를 포함한 검색 조건()을 출생 연도를 포함한 검색 조건()으로 변경하기 위해 중간에 Mapper 를 사용하였습니다.

```sql
select
        si1_0.id,
        m1_0.nickname,
        pi1_0.url,
        m1_0.year_of_birth,
        si1_0.title 
    from
        self_introductions si1_0 
    join
        members m1_0 
            on m1_0.id=si1_0.member_id 
    join
        profile_images pi1_0 
            on pi1_0.member_id=m1_0.id 
            and pi1_0.is_primary=? 
    where
        m1_0.year_of_birth between ? and ? 
        and m1_0.gender=? 
        and m1_0.region in (?, ?) 
    order by
        si1_0.id desc 
    offset
        ? rows 
    fetch
        first ? rows only
```

 모든 조건을 활용하였을 때 위와 같은 쿼리가 발생하게 되는데, 만약 데이터가 많아지면 Join을 하는 상황에서 성능 저하가 발생할 것 같다는 생각이 들더라고요! 
* 인덱스를 활용하더라도, 검색 조건(where)에 부합하는 인덱스가 존재하지 않아서 풀스캔을 통해 데이터를 읽어오는 상황이 지속적으로 발생.

따라서, 
* members 의 year_of_birth, gender, region 인덱스 추가

* self_introductions(member_id, id) 인덱스 추가

* profile_images(member_id, is_primary, url) 인덱스 추가

이후 작업에서는 이렇게 인덱스를 추가해볼려고 하는데 어떻게 생각하실지 궁금합니다!!