### PR TITLE
어드민 하트 지급 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/command/application/temp/AdminTempService.java
+++ b/src/main/java/atwoz/atwoz/admin/command/application/temp/AdminTempService.java
@@ -1,0 +1,31 @@
+package atwoz.atwoz.admin.command.application.temp;
+
+import atwoz.atwoz.admin.presentation.temp.dto.GrantMissionHeartRequest;
+import atwoz.atwoz.heart.command.domain.hearttransaction.HeartTransaction;
+import atwoz.atwoz.heart.command.domain.hearttransaction.HeartTransactionCommandRepository;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartAmount;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
+import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminTempService {
+
+    private final MemberCommandRepository memberCommandRepository;
+    private final HeartTransactionCommandRepository heartTransactionCommandRepository;
+
+    @Transactional
+    public void grantMissionHeart(GrantMissionHeartRequest request) {
+        Member member   = memberCommandRepository.findById(request.memberId())
+                .orElseThrow(MemberNotFoundException::new);
+        HeartAmount heartAmount = HeartAmount.from(request.heartAmount());
+        member.gainMissionHeart(heartAmount);
+        HeartTransaction heartTransaction = HeartTransaction.of(member.getId(), TransactionType.MISSION, heartAmount, member.getHeartBalance());
+        heartTransactionCommandRepository.save(heartTransaction);
+    }
+}

--- a/src/main/java/atwoz/atwoz/admin/presentation/temp/AdminHeartController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/temp/AdminHeartController.java
@@ -1,0 +1,27 @@
+package atwoz.atwoz.admin.presentation.temp;
+
+import atwoz.atwoz.admin.command.application.temp.AdminTempService;
+import atwoz.atwoz.admin.presentation.temp.dto.GrantMissionHeartRequest;
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminHeartController {
+
+    private final AdminTempService adminTempService;
+
+    @PatchMapping("/mission-heart")
+    public ResponseEntity<BaseResponse<Void>> grantMissionHeart(@Valid @RequestBody GrantMissionHeartRequest request) {
+        adminTempService.grantMissionHeart(request);
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+}

--- a/src/main/java/atwoz/atwoz/admin/presentation/temp/dto/GrantMissionHeartRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/temp/dto/GrantMissionHeartRequest.java
@@ -1,0 +1,12 @@
+package atwoz.atwoz.admin.presentation.temp.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.NonNull;
+
+public record GrantMissionHeartRequest(
+        @NonNull
+        Long memberId,
+        @Min(value = 1, message = "하트 지급은 최소 1개 이상으로 설정")
+        Long heartAmount
+) {
+}

--- a/src/test/java/atwoz/atwoz/admin/command/application/temp/AdminTempServiceTest.java
+++ b/src/test/java/atwoz/atwoz/admin/command/application/temp/AdminTempServiceTest.java
@@ -1,0 +1,82 @@
+package atwoz.atwoz.admin.command.application.temp;
+
+import atwoz.atwoz.admin.presentation.temp.dto.GrantMissionHeartRequest;
+import atwoz.atwoz.heart.command.domain.hearttransaction.HeartTransaction;
+import atwoz.atwoz.heart.command.domain.hearttransaction.HeartTransactionCommandRepository;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartAmount;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartBalance;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
+import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminTempServiceTest {
+
+    @InjectMocks
+    private AdminTempService adminTempService;
+
+    @Mock
+    private MemberCommandRepository memberCommandRepository;
+
+    @Mock
+    private HeartTransactionCommandRepository heartTransactionCommandRepository;
+
+    @Test
+    @DisplayName("회원이 존재하지 않으면 예외를 던진다.")
+    void grantMissionHeart() {
+        // given
+        GrantMissionHeartRequest request = new GrantMissionHeartRequest(1L, 100L);
+        when(memberCommandRepository.findById(request.memberId())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminTempService.grantMissionHeart(request))
+                .isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("회원이 존재하면 미션 하트를 부여한다.")
+    void grantMissionHeart_Success() {
+        // given
+        GrantMissionHeartRequest request = new GrantMissionHeartRequest(1L, 100L);
+        Member member = mock(Member.class);
+        when(memberCommandRepository.findById(request.memberId())).thenReturn(Optional.of(member));
+        when(member.getId()).thenReturn(request.memberId());
+        HeartBalance heartBalance = mock(HeartBalance.class);
+        when(member.getHeartBalance()).thenReturn(heartBalance);
+
+        // when
+        try (MockedStatic<HeartAmount> heartAmountMockedStatic = mockStatic(HeartAmount.class);
+             MockedStatic<HeartTransaction> heartTransactionMockedStatic = mockStatic(HeartTransaction.class)
+        ) {
+            HeartAmount heartAmount = mock(HeartAmount.class);
+            heartAmountMockedStatic.when(() -> HeartAmount.from(request.heartAmount())).thenReturn(heartAmount);
+
+            HeartTransaction heartTransaction = mock(HeartTransaction.class);
+            heartTransactionMockedStatic.when(() -> HeartTransaction.of(
+                    request.memberId(),
+                    TransactionType.MISSION,
+                    heartAmount,
+                    heartBalance
+            )).thenReturn(heartTransaction);
+
+            adminTempService.grantMissionHeart(request);
+
+            // then
+            verify(member).gainMissionHeart(heartAmount);
+            verify(heartTransactionCommandRepository).save(heartTransaction);
+        }
+    }
+}


### PR DESCRIPTION
### 관련 이슈
- closes #132 

<br>

### 작업 내용
- 앱스토어 결제 테스트 관련된 등록 일정이 연기되어 `임시로 사용할 어드민에서 멤버에게 미션 하트를 지급하는 기능`을 구현

<br>

### 참고 자료
-

<br>

### 노트
- 임시로 사용하고 앱스토어 결제 등록 이후에는 삭제될 기능이라 temp 패키지에 간략하게 구현하였습니다
