### PR TITLE
좋아요 보내기 500 에러 수정

### DIFF
--- a/src/main/java/atwoz/atwoz/like/command/application/InvalidLikeLevelException.java
+++ b/src/main/java/atwoz/atwoz/like/command/application/InvalidLikeLevelException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.like.command.application;
+
+public class InvalidLikeLevelException extends RuntimeException {
+    public InvalidLikeLevelException(String likeLevel) {
+        super("유효하지 않은 관심도 레벨입니다: " + likeLevel);
+    }
+}

--- a/src/main/java/atwoz/atwoz/like/command/application/LikeMapper.java
+++ b/src/main/java/atwoz/atwoz/like/command/application/LikeMapper.java
@@ -1,0 +1,22 @@
+package atwoz.atwoz.like.command.application;
+
+import atwoz.atwoz.like.command.domain.LikeLevel;
+import atwoz.atwoz.like.presentation.LikeLevelRequest;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public class LikeMapper {
+
+    public static LikeLevel toLikeLevel(LikeLevelRequest likeLevelRequest) {
+        try {
+            return switch (likeLevelRequest) {
+                case INTERESTED -> LikeLevel.INTERESTED;
+                case HIGHLY_INTERESTED -> LikeLevel.HIGHLY_INTERESTED;
+            };
+        } catch (IllegalArgumentException e) {
+            throw new InvalidLikeLevelException(likeLevelRequest.toString());
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/like/command/application/LikeSendService.java
+++ b/src/main/java/atwoz/atwoz/like/command/application/LikeSendService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static atwoz.atwoz.like.command.application.LikeMapper.toLikeLevel;
+
 @Service
 @RequiredArgsConstructor
 public class LikeSendService {
@@ -20,7 +22,7 @@ public class LikeSendService {
             throw new LikeAlreadyExistsException(senderId, receiverId);
         }
 
-        var like = Like.of(senderId, receiverId, request.likeLevel());
+        var like = Like.of(senderId, receiverId, toLikeLevel(request.likeLevel()));
         likeCommandRepository.save(like);
     }
 }

--- a/src/main/java/atwoz/atwoz/like/presentation/LikeExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/like/presentation/LikeExceptionHandler.java
@@ -24,7 +24,7 @@ public class LikeExceptionHandler {
     }
 
     @ExceptionHandler(InvalidLikeLevelException.class)
-    public ResponseEntity<BaseResponse<Void>> handleLInvalidLikeLevelException(InvalidLikeLevelException e) {
+    public ResponseEntity<BaseResponse<Void>> handleInvalidLikeLevelException(InvalidLikeLevelException e) {
         log.warn(e.getMessage());
 
         return ResponseEntity.badRequest().body(BaseResponse.from(StatusType.INVALID_ENUM_VALUE));

--- a/src/main/java/atwoz/atwoz/like/presentation/LikeExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/like/presentation/LikeExceptionHandler.java
@@ -2,6 +2,7 @@ package atwoz.atwoz.like.presentation;
 
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.like.command.application.InvalidLikeLevelException;
 import atwoz.atwoz.like.command.application.LikeAlreadyExistsException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
@@ -20,5 +21,12 @@ public class LikeExceptionHandler {
         log.warn(e.getMessage());
 
         return ResponseEntity.badRequest().body(BaseResponse.from(StatusType.INVALID_DUPLICATE_VALUE));
+    }
+
+    @ExceptionHandler(InvalidLikeLevelException.class)
+    public ResponseEntity<BaseResponse<Void>> handleLInvalidLikeLevelException(InvalidLikeLevelException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.badRequest().body(BaseResponse.from(StatusType.INVALID_ENUM_VALUE));
     }
 }

--- a/src/main/java/atwoz/atwoz/like/presentation/LikeLevelRequest.java
+++ b/src/main/java/atwoz/atwoz/like/presentation/LikeLevelRequest.java
@@ -1,0 +1,5 @@
+package atwoz.atwoz.like.presentation;
+
+public enum LikeLevelRequest {
+    INTERESTED, HIGHLY_INTERESTED
+}

--- a/src/main/java/atwoz/atwoz/like/presentation/LikeSendRequest.java
+++ b/src/main/java/atwoz/atwoz/like/presentation/LikeSendRequest.java
@@ -1,7 +1,6 @@
 package atwoz.atwoz.like.presentation;
 
-import atwoz.atwoz.like.command.domain.LikeLevel;
 import jakarta.validation.constraints.NotNull;
 
-public record LikeSendRequest(long receiverId, @NotNull LikeLevel likeLevel) {
+public record LikeSendRequest(long receiverId, @NotNull LikeLevelRequest likeLevel) {
 }

--- a/src/test/java/atwoz/atwoz/like/command/application/LikeSendServiceTest.java
+++ b/src/test/java/atwoz/atwoz/like/command/application/LikeSendServiceTest.java
@@ -2,7 +2,7 @@ package atwoz.atwoz.like.command.application;
 
 import atwoz.atwoz.like.command.domain.Like;
 import atwoz.atwoz.like.command.domain.LikeCommandRepository;
-import atwoz.atwoz.like.command.domain.LikeLevel;
+import atwoz.atwoz.like.presentation.LikeLevelRequest;
 import atwoz.atwoz.like.presentation.LikeSendRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ class LikeSendServiceTest {
         // given
         var senderId = 1L;
         var receiverId = 2L;
-        var likeLevel = LikeLevel.INTERESTED;
+        var likeLevel = LikeLevelRequest.INTERESTED;
         var request = new LikeSendRequest(receiverId, likeLevel);
 
         given(likeCommandRepository.existsBySenderIdAndReceiverId(senderId, receiverId)).willReturn(false);
@@ -49,7 +49,7 @@ class LikeSendServiceTest {
         // given
         var senderId = 1L;
         var receiverId = 2L;
-        var likeLevel = LikeLevel.INTERESTED;
+        var likeLevel = LikeLevelRequest.INTERESTED;
         var request = new LikeSendRequest(receiverId, likeLevel);
 
         given(likeCommandRepository.existsBySenderIdAndReceiverId(senderId, receiverId)).willReturn(true);


### PR DESCRIPTION
### 관련 이슈

- closes #172 

<br>

### 작업 내용
- 원인: 잘못된 값이 넘어와서 발생
- 조치: 잘못된 값이 넘어온 경우 500이 아닌 400 에러를 내려주도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - '관심도' 요청 값을 위한 새로운 enum(`INTERESTED`, `HIGHLY_INTERESTED`)이 추가되었습니다.
    - 잘못된 관심도 값 입력 시 400 Bad Request와 함께 명확한 오류 메시지를 제공합니다.

- **버그 수정**
    - 잘못된 관심도 값 처리 시 일관된 예외 처리와 사용자 응답을 제공합니다.

- **테스트**
    - 변경된 관심도 요청 타입에 맞춰 테스트 코드가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->