### PR TITLE
Pagination indicator 추가

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,7 +27,7 @@ public class ScreeningController {
     @GetMapping
     public ResponseEntity<BaseResponse<Page<ScreeningView>>> getScreenings(
         @Valid @ModelAttribute ScreeningSearchCondition condition,
-        Pageable pageable
+        @PageableDefault(size = 100) Pageable pageable
     ) {
         return ResponseEntity.ok(BaseResponse.of(OK, screeningQueryRepository.findScreenings(condition, pageable)));
     }

--- a/src/main/java/atwoz/atwoz/admin/query/ScreeningQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/admin/query/ScreeningQueryRepository.java
@@ -40,6 +40,7 @@ public class ScreeningQueryRepository {
                 startDateGoe(condition.startDate()),
                 loeEndDate(condition.endDate())
             )
+            .orderBy(screening.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();

--- a/src/main/java/atwoz/atwoz/like/presentation/LikeController.java
+++ b/src/main/java/atwoz/atwoz/like/presentation/LikeController.java
@@ -5,13 +5,10 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.like.command.application.LikeSendService;
 import atwoz.atwoz.like.query.LikeQueryService;
-import atwoz.atwoz.like.query.LikeView;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static atwoz.atwoz.common.enums.StatusType.OK;
 
@@ -33,7 +30,7 @@ public class LikeController {
     }
 
     @GetMapping("/sent")
-    public ResponseEntity<BaseResponse<List<LikeView>>> getSentLikes(
+    public ResponseEntity<BaseResponse<LikeViews>> getSentLikes(
         @ModelAttribute LikeListRequest request,
         @AuthPrincipal AuthContext authContext
     ) {
@@ -42,7 +39,7 @@ public class LikeController {
     }
 
     @GetMapping("/received")
-    public ResponseEntity<BaseResponse<List<LikeView>>> getReceivedLikes(
+    public ResponseEntity<BaseResponse<LikeViews>> getReceivedLikes(
         @ModelAttribute LikeListRequest request,
         @AuthPrincipal AuthContext authContext
     ) {

--- a/src/main/java/atwoz/atwoz/like/presentation/LikeViews.java
+++ b/src/main/java/atwoz/atwoz/like/presentation/LikeViews.java
@@ -1,0 +1,8 @@
+package atwoz.atwoz.like.presentation;
+
+import atwoz.atwoz.like.query.LikeView;
+
+import java.util.List;
+
+public record LikeViews(List<LikeView> likes, boolean hasMore) {
+}

--- a/src/main/java/atwoz/atwoz/like/query/LikeQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/like/query/LikeQueryRepository.java
@@ -15,7 +15,7 @@ import static atwoz.atwoz.member.command.domain.profileImage.QProfileImage.profi
 @Repository
 @RequiredArgsConstructor
 public class LikeQueryRepository {
-    private static final int PAGE_SIZE = 12;
+    private static final int PAGE_SIZE = 13;
     private final JPAQueryFactory queryFactory;
 
     public List<RawLikeView> findSentLikes(long senderId, Long lastLikeId) {

--- a/src/main/java/atwoz/atwoz/like/query/LikeQueryService.java
+++ b/src/main/java/atwoz/atwoz/like/query/LikeQueryService.java
@@ -1,10 +1,10 @@
 package atwoz.atwoz.like.query;
 
+import atwoz.atwoz.like.presentation.LikeViews;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -12,27 +12,31 @@ public class LikeQueryService {
     private static final int CLIENT_PAGE_SIZE = 12;
     private final LikeQueryRepository likeQueryRepository;
 
-    public List<LikeView> findSentLikes(long senderId, Long lastLikeId) {
-        List<RawLikeView> likes = likeQueryRepository.findSentLikes(senderId, lastLikeId);
-        boolean hasMore = likes.size() > CLIENT_PAGE_SIZE;
+    public LikeViews findSentLikes(long senderId, Long lastLikeId) {
+        var rawLikes = likeQueryRepository.findSentLikes(senderId, lastLikeId);
+        boolean hasMore = rawLikes.size() > CLIENT_PAGE_SIZE;
 
-        return likes.stream()
+        var likes = rawLikes.stream()
             .limit(CLIENT_PAGE_SIZE)
-            .map(raw -> toLikeView(raw, hasMore))
+            .map(this::toLikeView)
             .toList();
+
+        return new LikeViews(likes, hasMore);
     }
 
-    public List<LikeView> findReceivedLikes(long receiverId, Long lastLikeId) {
-        List<RawLikeView> likes = likeQueryRepository.findReceivedLikes(receiverId, lastLikeId);
-        boolean hasMore = likes.size() > CLIENT_PAGE_SIZE;
+    public LikeViews findReceivedLikes(long receiverId, Long lastLikeId) {
+        var rawLikes = likeQueryRepository.findReceivedLikes(receiverId, lastLikeId);
+        boolean hasMore = rawLikes.size() > CLIENT_PAGE_SIZE;
 
-        return likes.stream()
+        var likes = rawLikes.stream()
             .limit(CLIENT_PAGE_SIZE)
-            .map(raw -> toLikeView(raw, hasMore))
+            .map(this::toLikeView)
             .toList();
+
+        return new LikeViews(likes, hasMore);
     }
 
-    private LikeView toLikeView(RawLikeView raw, boolean hasMore) {
+    private LikeView toLikeView(RawLikeView raw) {
         return new LikeView(
             raw.likeId(),
             raw.opponentId(),
@@ -41,8 +45,7 @@ public class LikeQueryService {
             raw.city(),
             LocalDate.now().getYear() - raw.yearOfBirth(),
             raw.isMutualLike(),
-            raw.createdAt(),
-            hasMore
+            raw.createdAt()
         );
     }
 }

--- a/src/main/java/atwoz/atwoz/like/query/LikeQueryService.java
+++ b/src/main/java/atwoz/atwoz/like/query/LikeQueryService.java
@@ -9,21 +9,30 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class LikeQueryService {
+    private static final int CLIENT_PAGE_SIZE = 12;
     private final LikeQueryRepository likeQueryRepository;
 
     public List<LikeView> findSentLikes(long senderId, Long lastLikeId) {
-        return likeQueryRepository.findSentLikes(senderId, lastLikeId).stream()
-            .map(this::toLikeView)
+        List<RawLikeView> likes = likeQueryRepository.findSentLikes(senderId, lastLikeId);
+        boolean hasMore = likes.size() > CLIENT_PAGE_SIZE;
+
+        return likes.stream()
+            .limit(CLIENT_PAGE_SIZE)
+            .map(raw -> toLikeView(raw, hasMore))
             .toList();
     }
 
     public List<LikeView> findReceivedLikes(long receiverId, Long lastLikeId) {
-        return likeQueryRepository.findReceivedLikes(receiverId, lastLikeId).stream()
-            .map(this::toLikeView)
+        List<RawLikeView> likes = likeQueryRepository.findReceivedLikes(receiverId, lastLikeId);
+        boolean hasMore = likes.size() > CLIENT_PAGE_SIZE;
+
+        return likes.stream()
+            .limit(CLIENT_PAGE_SIZE)
+            .map(raw -> toLikeView(raw, hasMore))
             .toList();
     }
 
-    private LikeView toLikeView(RawLikeView raw) {
+    private LikeView toLikeView(RawLikeView raw, boolean hasMore) {
         return new LikeView(
             raw.likeId(),
             raw.opponentId(),
@@ -32,7 +41,8 @@ public class LikeQueryService {
             raw.city(),
             LocalDate.now().getYear() - raw.yearOfBirth(),
             raw.isMutualLike(),
-            raw.createdAt()
+            raw.createdAt(),
+            hasMore
         );
     }
 }

--- a/src/main/java/atwoz/atwoz/like/query/LikeView.java
+++ b/src/main/java/atwoz/atwoz/like/query/LikeView.java
@@ -10,6 +10,7 @@ public record LikeView(
     String city,
     int age,
     boolean isMutualLike,
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    boolean hasMore
 ) {
 }

--- a/src/main/java/atwoz/atwoz/like/query/LikeView.java
+++ b/src/main/java/atwoz/atwoz/like/query/LikeView.java
@@ -10,7 +10,6 @@ public record LikeView(
     String city,
     int age,
     boolean isMutualLike,
-    LocalDateTime createdAt,
-    boolean hasMore
+    LocalDateTime createdAt
 ) {
 }

--- a/src/test/java/atwoz/atwoz/like/query/LikeQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/like/query/LikeQueryRepositoryTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import({QueryDslConfig.class, LikeQueryRepository.class})
 class LikeQueryRepositoryTest {
     private static final int NUMBER_OF_PEOPLE = 30;
-    private static final int PAGE_SIZE = 12;
+    private static final int PAGE_SIZE = 13;
 
     @Autowired
     private LikeQueryRepository likeQueryRepository;

--- a/src/test/java/atwoz/atwoz/like/query/LikeQueryServiceTest.java
+++ b/src/test/java/atwoz/atwoz/like/query/LikeQueryServiceTest.java
@@ -1,0 +1,187 @@
+package atwoz.atwoz.like.query;
+
+import atwoz.atwoz.like.presentation.LikeViews;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class LikeQueryServiceTest {
+
+    private static final int CLIENT_PAGE_SIZE = 12;
+
+    @InjectMocks
+    private LikeQueryService likeQueryService;
+    @Mock
+    private LikeQueryRepository likeQueryRepository;
+
+    private List<RawLikeView> createRawLikes(int count) {
+        return IntStream.range(0, count)
+            .mapToObj(i -> new RawLikeView(
+                i + 1L,
+                i + 100L,
+                "https://example.com/image" + i,
+                "nickname" + i,
+                "SEOUL",
+                1990 + i,
+                i % 2 == 0,
+                LocalDateTime.now()
+            ))
+            .toList();
+    }
+
+    @Nested
+    @DisplayName("보낸 좋아요 목록 조회")
+    class FindSentLikes {
+
+        @Test
+        @DisplayName("데이터가 없는 경우 빈 목록을 반환한다")
+        void returnsEmptyListWhenNoData() {
+            // given
+            long senderId = 1L;
+            Long lastLikeId = null;
+            given(likeQueryRepository.findSentLikes(senderId, lastLikeId)).willReturn(List.of());
+
+            // when
+            LikeViews result = likeQueryService.findSentLikes(senderId, lastLikeId);
+
+            // then
+            assertThat(result.likes()).isEmpty();
+            assertThat(result.hasMore()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CLIENT_PAGE_SIZE보다 적은 데이터가 있는 경우 모든 데이터를 반환한다")
+        void returnsAllDataWhenLessThanPageSize() {
+            // given
+            long senderId = 1L;
+            Long lastLikeId = null;
+            List<RawLikeView> rawLikes = createRawLikes(CLIENT_PAGE_SIZE - 1);
+            given(likeQueryRepository.findSentLikes(senderId, lastLikeId)).willReturn(rawLikes);
+
+            // when
+            LikeViews result = likeQueryService.findSentLikes(senderId, lastLikeId);
+
+            // then
+            assertThat(result.likes()).hasSize(CLIENT_PAGE_SIZE - 1);
+            assertThat(result.hasMore()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CLIENT_PAGE_SIZE와 같은 수의 데이터가 있는 경우 hasMore는 false이다")
+        void returnsExactPageSizeData() {
+            // given
+            long senderId = 1L;
+            Long lastLikeId = null;
+            List<RawLikeView> rawLikes = createRawLikes(CLIENT_PAGE_SIZE);
+            given(likeQueryRepository.findSentLikes(senderId, lastLikeId)).willReturn(rawLikes);
+
+            // when
+            LikeViews result = likeQueryService.findSentLikes(senderId, lastLikeId);
+
+            // then
+            assertThat(result.likes()).hasSize(CLIENT_PAGE_SIZE);
+            assertThat(result.hasMore()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CLIENT_PAGE_SIZE보다 많은 데이터가 있는 경우 페이지 크기만큼만 반환한고, hasMore는 true이다")
+        void returnsLimitedDataWhenMoreThanPageSize() {
+            // given
+            long senderId = 1L;
+            Long lastLikeId = null;
+            List<RawLikeView> rawLikes = createRawLikes(CLIENT_PAGE_SIZE + 1);
+            given(likeQueryRepository.findSentLikes(senderId, lastLikeId)).willReturn(rawLikes);
+
+            // when
+            LikeViews result = likeQueryService.findSentLikes(senderId, lastLikeId);
+
+            // then
+            assertThat(result.likes()).hasSize(CLIENT_PAGE_SIZE);
+            assertThat(result.hasMore()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("받은 좋아요 목록 조회")
+    class FindReceivedLikes {
+
+        @Test
+        @DisplayName("데이터가 없는 경우 빈 목록을 반환한다")
+        void returnsEmptyListWhenNoData() {
+            // given
+            long receiverId = 1L;
+            Long lastLikeId = null;
+            given(likeQueryRepository.findReceivedLikes(receiverId, lastLikeId)).willReturn(List.of());
+
+            // when
+            LikeViews result = likeQueryService.findReceivedLikes(receiverId, lastLikeId);
+
+            // then
+            assertThat(result.likes()).isEmpty();
+            assertThat(result.hasMore()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CLIENT_PAGE_SIZE보다 적은 데이터가 있는 경우 모든 데이터를 반환한다")
+        void returnsAllDataWhenLessThanPageSize() {
+            // given
+            long receiverId = 1L;
+            Long lastLikeId = null;
+            List<RawLikeView> rawLikes = createRawLikes(CLIENT_PAGE_SIZE - 1);
+            given(likeQueryRepository.findReceivedLikes(receiverId, lastLikeId)).willReturn(rawLikes);
+
+            // when
+            LikeViews result = likeQueryService.findReceivedLikes(receiverId, lastLikeId);
+
+            // then
+            assertThat(result.likes()).hasSize(CLIENT_PAGE_SIZE - 1);
+            assertThat(result.hasMore()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CLIENT_PAGE_SIZE와 같은 수의 데이터가 있는 경우 hasMore는 false이다")
+        void returnsExactPageSizeData() {
+            // given
+            long receiverId = 1L;
+            Long lastLikeId = null;
+            List<RawLikeView> rawLikes = createRawLikes(CLIENT_PAGE_SIZE);
+            given(likeQueryRepository.findReceivedLikes(receiverId, lastLikeId)).willReturn(rawLikes);
+
+            // when
+            LikeViews result = likeQueryService.findReceivedLikes(receiverId, lastLikeId);
+
+            // then
+            assertThat(result.likes()).hasSize(CLIENT_PAGE_SIZE);
+            assertThat(result.hasMore()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CLIENT_PAGE_SIZE보다 많은 데이터가 있는 경우 페이지 크기만큼만 반환하고, hasMore는 true이다")
+        void returnsLimitedDataWhenMoreThanPageSize() {
+            // given
+            long receiverId = 1L;
+            Long lastLikeId = null;
+            List<RawLikeView> rawLikes = createRawLikes(CLIENT_PAGE_SIZE + 1);
+            given(likeQueryRepository.findReceivedLikes(receiverId, lastLikeId)).willReturn(rawLikes);
+
+            // when
+            LikeViews result = likeQueryService.findReceivedLikes(receiverId, lastLikeId);
+
+            // then
+            assertThat(result.likes()).hasSize(CLIENT_PAGE_SIZE);
+            assertThat(result.hasMore()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
### 관련 이슈

- closes #176

<br>

### 작업 내용
- LikeView에 hasMore 필드 추가
- findLikes 메서드에 hasMore 계산 로직 추가
- PAGE_SIZE 값을 13으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 좋아요 목록 API에서 좋아요 항목 리스트와 추가 데이터 존재 여부(hasMore)를 함께 반환하는 새로운 구조가 도입되었습니다.

- **기능 개선**
    - 좋아요 관련 API 응답이 단순 리스트에서 LikeViews 객체로 변경되어, 추가 데이터의 존재 여부를 확인할 수 있습니다.
    - 관리자의 심사 목록 조회 시 기본 페이지 크기가 100으로 설정되었습니다.
    - 심사 목록이 생성일 기준 내림차순으로 정렬됩니다.

- **버그 수정**
    - 좋아요 목록 조회 시 최대 반환 개수가 12개에서 13개로 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->