### PR TITLE
인앱 결제 product CRUD api 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
+++ b/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
@@ -1,11 +1,13 @@
 package atwoz.atwoz.payment.command.application.heartpurchaseoption;
 
+import atwoz.atwoz.heart.command.application.heartusagepolicy.exception.HeartUsagePolicyNotFoundException;
 import atwoz.atwoz.payment.command.application.heartpurchaseoption.exception.HeartPurchaseOptionAlreadyExistsException;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseAmount;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOption;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOptionCommandRepository;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.Price;
 import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOptionCreateRequest;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,12 +16,19 @@ import org.springframework.stereotype.Service;
 public class HeartPurchaseOptionService {
     private final HeartPurchaseOptionCommandRepository heartPurchaseOptionCommandRepository;
 
+    @Transactional
     public void create(HeartPurchaseOptionCreateRequest request) {
-        validateHeartPurchaseOption(request);
+        validateCreateRequest(request);
         createHeartPurchaseOption(request);
     }
 
-    private void validateHeartPurchaseOption(HeartPurchaseOptionCreateRequest request) {
+    @Transactional
+    public void delete(Long id) {
+        validateDeleteRequest(id);
+        heartPurchaseOptionCommandRepository.deleteById(id);
+    }
+
+    private void validateCreateRequest(HeartPurchaseOptionCreateRequest request) {
         if (heartPurchaseOptionCommandRepository.existsByProductId(request.productId())) {
             throw new HeartPurchaseOptionAlreadyExistsException(request.productId());
         }
@@ -35,5 +44,11 @@ public class HeartPurchaseOptionService {
             request.name()
         );
         heartPurchaseOptionCommandRepository.save(heartPurchaseOption);
+    }
+
+    private void validateDeleteRequest(Long id) {
+        if (!heartPurchaseOptionCommandRepository.existsById(id)) {
+            throw new HeartUsagePolicyNotFoundException();
+        }
     }
 }

--- a/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
+++ b/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
@@ -1,0 +1,27 @@
+package atwoz.atwoz.payment.command.application.heartpurchaseoption;
+
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseAmount;
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOption;
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOptionCommandRepository;
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.Price;
+import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOptionCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HeartPurchaseOptionService {
+    private final HeartPurchaseOptionCommandRepository heartPurchaseOptionCommandRepository;
+
+    public void create(HeartPurchaseOptionCreateRequest request) {
+        HeartPurchaseAmount heartAmount = HeartPurchaseAmount.from(request.heartAmount());
+        Price price = Price.from(request.price());
+        HeartPurchaseOption heartPurchaseOption = HeartPurchaseOption.of(
+            heartAmount,
+            price,
+            request.productId(),
+            request.name()
+        );
+        heartPurchaseOptionCommandRepository.save(heartPurchaseOption);
+    }
+}

--- a/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
+++ b/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
@@ -47,8 +47,11 @@ public class HeartPurchaseOptionService {
     }
 
     private void validateDeleteRequest(Long id) {
-        if (!heartPurchaseOptionCommandRepository.existsById(id)) {
-            throw new HeartPurchaseOptionNotFoundException("해당 하트 구매 옵션이 존재하지 않습니다. id: " + id);
+        final HeartPurchaseOption heartPurchaseOption = heartPurchaseOptionCommandRepository.findById(id).orElseThrow(
+            () -> new HeartPurchaseOptionNotFoundException("해당 id의 하트 구매 옵션이 존재하지 않습니다." + id)
+        );
+        if (heartPurchaseOption.isDeleted()) {
+            throw new HeartPurchaseOptionNotFoundException("이미 삭제된 하트 구매 옵션입니다." + id);
         }
     }
 }

--- a/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
+++ b/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.payment.command.application.heartpurchaseoption;
 
+import atwoz.atwoz.payment.command.application.heartpurchaseoption.exception.HeartPurchaseOptionAlreadyExistsException;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseAmount;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOption;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOptionCommandRepository;
@@ -14,6 +15,17 @@ public class HeartPurchaseOptionService {
     private final HeartPurchaseOptionCommandRepository heartPurchaseOptionCommandRepository;
 
     public void create(HeartPurchaseOptionCreateRequest request) {
+        validateHeartPurchaseOption(request);
+        createHeartPurchaseOption(request);
+    }
+
+    private void validateHeartPurchaseOption(HeartPurchaseOptionCreateRequest request) {
+        if (heartPurchaseOptionCommandRepository.existsByProductId(request.productId())) {
+            throw new HeartPurchaseOptionAlreadyExistsException(request.productId());
+        }
+    }
+
+    private void createHeartPurchaseOption(HeartPurchaseOptionCreateRequest request) {
         HeartPurchaseAmount heartAmount = HeartPurchaseAmount.from(request.heartAmount());
         Price price = Price.from(request.price());
         HeartPurchaseOption heartPurchaseOption = HeartPurchaseOption.of(

--- a/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
+++ b/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
@@ -29,7 +29,7 @@ public class HeartPurchaseOptionService {
     }
 
     private void validateCreateRequest(HeartPurchaseOptionCreateRequest request) {
-        if (heartPurchaseOptionCommandRepository.existsByProductId(request.productId())) {
+        if (heartPurchaseOptionCommandRepository.existsByProductIdAndDeletedAtIsNull(request.productId())) {
             throw new HeartPurchaseOptionAlreadyExistsException(request.productId());
         }
     }

--- a/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
+++ b/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionService.java
@@ -1,7 +1,7 @@
 package atwoz.atwoz.payment.command.application.heartpurchaseoption;
 
-import atwoz.atwoz.heart.command.application.heartusagepolicy.exception.HeartUsagePolicyNotFoundException;
 import atwoz.atwoz.payment.command.application.heartpurchaseoption.exception.HeartPurchaseOptionAlreadyExistsException;
+import atwoz.atwoz.payment.command.application.order.exception.HeartPurchaseOptionNotFoundException;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseAmount;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOption;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOptionCommandRepository;
@@ -48,7 +48,7 @@ public class HeartPurchaseOptionService {
 
     private void validateDeleteRequest(Long id) {
         if (!heartPurchaseOptionCommandRepository.existsById(id)) {
-            throw new HeartUsagePolicyNotFoundException();
+            throw new HeartPurchaseOptionNotFoundException("해당 하트 구매 옵션이 존재하지 않습니다. id: " + id);
         }
     }
 }

--- a/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/exception/HeartPurchaseOptionAlreadyExistsException.java
+++ b/src/main/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/exception/HeartPurchaseOptionAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.payment.command.application.heartpurchaseoption.exception;
+
+public class HeartPurchaseOptionAlreadyExistsException extends RuntimeException {
+    public HeartPurchaseOptionAlreadyExistsException(String productId) {
+        super("이미 존재하는 상품입니다. productId=" + productId);
+    }
+}

--- a/src/main/java/atwoz/atwoz/payment/command/application/order/OrderService.java
+++ b/src/main/java/atwoz/atwoz/payment/command/application/order/OrderService.java
@@ -37,7 +37,8 @@ public class OrderService {
     }
 
     private void purchaseHeart(Long memberId, String productId, Integer quantity) {
-        HeartPurchaseOption heartPurchaseOption = heartPurchaseOptionCommandRepository.findByProductId(productId)
+        HeartPurchaseOption heartPurchaseOption = heartPurchaseOptionCommandRepository.findByProductIdAndDeletedAtIsNull(
+                productId)
             .orElseThrow(
                 () -> new HeartPurchaseOptionNotFoundException("하트 구매 옵션이 존재하지 않습니다. product id:" + productId));
         heartPurchaseOption.purchase(memberId, quantity);

--- a/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOption.java
+++ b/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOption.java
@@ -9,10 +9,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Table(name = "heart_purchase_options")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE heart_purchase_options SET deleted_at = now() WHERE id = ?")
 public class HeartPurchaseOption extends SoftDeleteBaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOption.java
+++ b/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOption.java
@@ -29,14 +29,15 @@ public class HeartPurchaseOption extends SoftDeleteBaseEntity {
 
     private String productId;
 
-    private HeartPurchaseOption(HeartPurchaseAmount amount, Price price, String name) {
+    private HeartPurchaseOption(HeartPurchaseAmount amount, Price price, String productId, String name) {
         setAmount(amount);
         setPrice(price);
+        setProductId(productId);
         setName(name);
     }
 
-    public static HeartPurchaseOption of(HeartPurchaseAmount amount, Price price, String name) {
-        return new HeartPurchaseOption(amount, price, name);
+    public static HeartPurchaseOption of(HeartPurchaseAmount amount, Price price, String productId, String name) {
+        return new HeartPurchaseOption(amount, price, productId, name);
     }
 
     public Long getHeartAmount() {
@@ -54,6 +55,13 @@ public class HeartPurchaseOption extends SoftDeleteBaseEntity {
 
     private void setPrice(@NonNull Price price) {
         this.price = price;
+    }
+
+    private void setProductId(@NonNull String productId) {
+        if (productId.isBlank()) {
+            throw new InvalidHeartPurchaseOptionException("productId 값이 비어있습니다.");
+        }
+        this.productId = productId;
     }
 
     private void setName(@NonNull String name) {

--- a/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOption.java
+++ b/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOption.java
@@ -25,10 +25,13 @@ public class HeartPurchaseOption extends SoftDeleteBaseEntity {
     private HeartPurchaseAmount amount;
 
     @Embedded
+    @Getter
     private Price price;
 
+    @Getter
     private String name;
 
+    @Getter
     private String productId;
 
     private HeartPurchaseOption(HeartPurchaseAmount amount, Price price, String productId, String name) {

--- a/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOptionCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOptionCommandRepository.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.payment.command.domain.heartpurchaseoption;
 
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,6 @@ public interface HeartPurchaseOptionCommandRepository extends JpaRepository<Hear
     Optional<HeartPurchaseOption> findById(Long id);
 
     Optional<HeartPurchaseOption> findByProductId(String productId);
+
+    boolean existsByProductId(@NotBlank(message = "상품 ID를 입력해주세요.") String s);
 }

--- a/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOptionCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOptionCommandRepository.java
@@ -1,7 +1,5 @@
 package atwoz.atwoz.payment.command.domain.heartpurchaseoption;
 
-
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -11,5 +9,5 @@ public interface HeartPurchaseOptionCommandRepository extends JpaRepository<Hear
 
     Optional<HeartPurchaseOption> findByProductId(String productId);
 
-    boolean existsByProductId(@NotBlank(message = "상품 ID를 입력해주세요.") String s);
+    boolean existsByProductId(String productId);
 }

--- a/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOptionCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOptionCommandRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 public interface HeartPurchaseOptionCommandRepository extends JpaRepository<HeartPurchaseOption, Long> {
     Optional<HeartPurchaseOption> findById(Long id);
 
-    Optional<HeartPurchaseOption> findByProductId(String productId);
+    Optional<HeartPurchaseOption> findByProductIdAndDeletedAtIsNull(String productId);
 
-    boolean existsByProductId(String productId);
+    boolean existsByProductIdAndDeletedAtIsNull(String productId);
 }

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
@@ -4,8 +4,14 @@ import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.payment.command.application.heartpurchaseoption.HeartPurchaseOptionService;
 import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOptionCreateRequest;
+import atwoz.atwoz.payment.query.heartpurchaseoption.HeartPurchaseOptionQueryRepository;
+import atwoz.atwoz.payment.query.heartpurchaseoption.condition.HeartPurchaseOptionSearchCondition;
+import atwoz.atwoz.payment.query.heartpurchaseoption.view.HeartPurchaseOptionView;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/admin/heartpurchaseoption")
 public class AdminHeartPurchaseOptionController {
     private final HeartPurchaseOptionService heartPurchaseOptionService;
+    private final HeartPurchaseOptionQueryRepository heartPurchaseOptionQueryRepository;
 
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> create(@Valid @RequestBody HeartPurchaseOptionCreateRequest request) {
@@ -26,5 +33,13 @@ public class AdminHeartPurchaseOptionController {
     public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long id) {
         heartPurchaseOptionService.delete(id);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<Page<HeartPurchaseOptionView>>> getPage(
+        @ModelAttribute HeartPurchaseOptionSearchCondition condition,
+        @PageableDefault(size = 100) Pageable pageable) {
+        Page<HeartPurchaseOptionView> page = heartPurchaseOptionQueryRepository.findPage(condition, pageable);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, page));
     }
 }

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/heartpurchaseoption")
+@RequestMapping("/admin/heart-purchase-options")
 public class AdminHeartPurchaseOptionController {
     private final HeartPurchaseOptionService heartPurchaseOptionService;
     private final HeartPurchaseOptionQueryRepository heartPurchaseOptionQueryRepository;

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
@@ -1,9 +1,12 @@
 package atwoz.atwoz.payment.presentation.heartpurchaseoption;
 
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.payment.command.application.heartpurchaseoption.HeartPurchaseOptionService;
 import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOptionCreateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +19,8 @@ public class AdminHeartPurchaseOptionController {
     private final HeartPurchaseOptionService heartPurchaseOptionService;
 
     @PostMapping
-    public void create(@Valid @RequestBody HeartPurchaseOptionCreateRequest request) {
+    public ResponseEntity<BaseResponse<Void>> create(@Valid @RequestBody HeartPurchaseOptionCreateRequest request) {
         heartPurchaseOptionService.create(request);
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
@@ -7,10 +7,7 @@ import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOpt
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +18,13 @@ public class AdminHeartPurchaseOptionController {
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> create(@Valid @RequestBody HeartPurchaseOptionCreateRequest request) {
         heartPurchaseOptionService.create(request);
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long id) {
+        heartPurchaseOptionService.delete(id);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
@@ -1,0 +1,22 @@
+package atwoz.atwoz.payment.presentation.heartpurchaseoption;
+
+import atwoz.atwoz.payment.command.application.heartpurchaseoption.HeartPurchaseOptionService;
+import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOptionCreateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/heartpurchaseoption")
+public class AdminHeartPurchaseOptionController {
+    private final HeartPurchaseOptionService heartPurchaseOptionService;
+
+    @PostMapping
+    public void create(@Valid @RequestBody HeartPurchaseOptionCreateRequest request) {
+        heartPurchaseOptionService.create(request);
+    }
+}

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/HeartPurchaseOptionExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/HeartPurchaseOptionExceptionHandler.java
@@ -1,0 +1,26 @@
+package atwoz.atwoz.payment.presentation.heartpurchaseoption;
+
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.payment.command.application.heartpurchaseoption.exception.HeartPurchaseOptionAlreadyExistsException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class HeartPurchaseOptionExceptionHandler {
+
+    @ExceptionHandler(HeartPurchaseOptionAlreadyExistsException.class)
+    public ResponseEntity<BaseResponse<Void>> handleHeartPurchaseOptionAlreadyExistsException(
+        HeartPurchaseOptionAlreadyExistsException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.badRequest()
+            .body(BaseResponse.from(StatusType.INVALID_DUPLICATE_VALUE));
+    }
+}

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/HeartPurchaseOptionExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/HeartPurchaseOptionExceptionHandler.java
@@ -3,6 +3,7 @@ package atwoz.atwoz.payment.presentation.heartpurchaseoption;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.payment.command.application.heartpurchaseoption.exception.HeartPurchaseOptionAlreadyExistsException;
+import atwoz.atwoz.payment.command.application.order.exception.HeartPurchaseOptionNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -22,5 +23,14 @@ public class HeartPurchaseOptionExceptionHandler {
 
         return ResponseEntity.badRequest()
             .body(BaseResponse.from(StatusType.INVALID_DUPLICATE_VALUE));
+    }
+
+    @ExceptionHandler(HeartPurchaseOptionNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleHeartPurchaseOptionNotFoundException(
+        HeartPurchaseOptionNotFoundException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(404)
+            .body(BaseResponse.from(StatusType.NOT_FOUND));
     }
 }

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/dto/HeartPurchaseOptionCreateRequest.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/dto/HeartPurchaseOptionCreateRequest.java
@@ -1,0 +1,16 @@
+package atwoz.atwoz.payment.presentation.heartpurchaseoption.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record HeartPurchaseOptionCreateRequest(
+    @Min(value = 1, message = "최소 1 이상의 하트 수량을 입력해주세요.")
+    Long heartAmount,
+    @Min(value = 1, message = "최소 1 이상의 가격을 입력해주세요.")
+    Long price,
+    @NotBlank(message = "상품 ID를 입력해주세요.")
+    String productId,
+    @NotBlank(message = "상품 이름을 입력해주세요.")
+    String name
+) {
+}

--- a/src/main/java/atwoz/atwoz/payment/query/heartpurchaseoption/HeartPurchaseOptionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/payment/query/heartpurchaseoption/HeartPurchaseOptionQueryRepository.java
@@ -1,0 +1,79 @@
+package atwoz.atwoz.payment.query.heartpurchaseoption;
+
+import atwoz.atwoz.payment.query.heartpurchaseoption.condition.HeartPurchaseOptionSearchCondition;
+import atwoz.atwoz.payment.query.heartpurchaseoption.view.HeartPurchaseOptionView;
+import atwoz.atwoz.payment.query.heartpurchaseoption.view.QHeartPurchaseOptionView;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static atwoz.atwoz.payment.command.domain.heartpurchaseoption.QHeartPurchaseOption.heartPurchaseOption;
+
+@Repository
+@RequiredArgsConstructor
+public class HeartPurchaseOptionQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public Page<HeartPurchaseOptionView> findPage(HeartPurchaseOptionSearchCondition condition, Pageable pageable) {
+        List<HeartPurchaseOptionView> views = queryFactory
+            .select(new QHeartPurchaseOptionView(
+                heartPurchaseOption.id,
+                heartPurchaseOption.name.stringValue(),
+                heartPurchaseOption.productId.stringValue(),
+                heartPurchaseOption.amount.amount,
+                heartPurchaseOption.price.value,
+                heartPurchaseOption.createdAt,
+                heartPurchaseOption.deletedAt
+            ))
+            .from(heartPurchaseOption)
+            .where(
+                nameContain(condition.name()),
+                productIdContain(condition.productId()),
+                createdAtGoe(condition.createdDateGoe()),
+                createdAtLoe(condition.createdDateLoe())
+            )
+            .orderBy(heartPurchaseOption.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long totalCount = queryFactory
+            .select(heartPurchaseOption.count())
+            .from(heartPurchaseOption)
+            .where(
+                nameContain(condition.name()),
+                productIdContain(condition.productId()),
+                createdAtGoe(condition.createdDateGoe()),
+                createdAtLoe(condition.createdDateLoe())
+            )
+            .fetchOne();
+
+        return new PageImpl<>(views, pageable, totalCount);
+    }
+
+    private BooleanExpression nameContain(String name) {
+        return name != null ? heartPurchaseOption.name.stringValue().contains(name) : null;
+    }
+
+    private BooleanExpression productIdContain(String productId) {
+        return productId != null ? heartPurchaseOption.productId.stringValue().contains(productId) : null;
+    }
+
+    private BooleanExpression createdAtGoe(LocalDate createdDateGoe) {
+        return createdDateGoe != null ? heartPurchaseOption.createdAt.goe(createdDateGoe.atStartOfDay()) : null;
+    }
+
+    private BooleanExpression createdAtLoe(LocalDate createdDateLoe) {
+        return createdDateLoe != null ? heartPurchaseOption.createdAt.loe(
+            createdDateLoe.plusDays(1).atStartOfDay().minusSeconds(1)) : null;
+    }
+
+
+}

--- a/src/main/java/atwoz/atwoz/payment/query/heartpurchaseoption/condition/HeartPurchaseOptionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/payment/query/heartpurchaseoption/condition/HeartPurchaseOptionSearchCondition.java
@@ -1,0 +1,18 @@
+package atwoz.atwoz.payment.query.heartpurchaseoption.condition;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record HeartPurchaseOptionSearchCondition(
+    String productId,
+
+    String name,
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    LocalDate createdDateGoe,
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    LocalDate createdDateLoe
+) {
+}

--- a/src/main/java/atwoz/atwoz/payment/query/heartpurchaseoption/view/HeartPurchaseOptionView.java
+++ b/src/main/java/atwoz/atwoz/payment/query/heartpurchaseoption/view/HeartPurchaseOptionView.java
@@ -1,0 +1,20 @@
+package atwoz.atwoz.payment.query.heartpurchaseoption.view;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+
+public record HeartPurchaseOptionView(
+    Long id,
+    String name,
+    String productId,
+    Long heartAmount,
+    Long price,
+    LocalDateTime createdAt,
+    LocalDateTime deletedAt
+
+) {
+    @QueryProjection
+    public HeartPurchaseOptionView {
+    }
+}

--- a/src/test/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionServiceTest.java
+++ b/src/test/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionServiceTest.java
@@ -1,6 +1,8 @@
 package atwoz.atwoz.payment.command.application.heartpurchaseoption;
 
 import atwoz.atwoz.payment.command.application.heartpurchaseoption.exception.HeartPurchaseOptionAlreadyExistsException;
+import atwoz.atwoz.payment.command.application.order.exception.HeartPurchaseOptionNotFoundException;
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOption;
 import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOptionCommandRepository;
 import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOptionCreateRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +12,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -72,6 +76,55 @@ class HeartPurchaseOptionServiceTest {
                     heartPurchaseOption.getProductId().equals(productId) &&
                     heartPurchaseOption.getName().equals(name)
             ));
+        }
+    }
+
+    @Nested
+    @DisplayName("delete 메서드 테스트")
+    class DeleteMethodTest {
+
+        Long id = 1L;
+        String productId = "productId";
+
+        @Test
+        @DisplayName("존재하지 않는 id로 삭제 요청 시 예외 발생")
+        void throwExceptionWhenProductIdNotExists() {
+            // Given
+            when(heartPurchaseOptionCommandRepository.findById(id)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> heartPurchaseOptionService.delete(id))
+                .isInstanceOf(HeartPurchaseOptionNotFoundException.class);
+            verify(heartPurchaseOptionCommandRepository, never()).deleteById(any());
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 id로 삭제 요청 시 예외 발생")
+        void throwExceptionWhenProductIdAlreadyDeleted() {
+            // Given
+            HeartPurchaseOption heartPurchaseOption = mock(HeartPurchaseOption.class);
+            when(heartPurchaseOption.isDeleted()).thenReturn(true);
+            when(heartPurchaseOptionCommandRepository.findById(id)).thenReturn(Optional.of(heartPurchaseOption));
+
+            // When & Then
+            assertThatThrownBy(() -> heartPurchaseOptionService.delete(id))
+                .isInstanceOf(HeartPurchaseOptionNotFoundException.class);
+            verify(heartPurchaseOptionCommandRepository, never()).deleteById(any());
+        }
+
+        @Test
+        @DisplayName("존재하는 id로 삭제 요청 시 정상 처리")
+        void deleteHeartPurchaseOption() {
+            // Given
+            HeartPurchaseOption heartPurchaseOption = mock(HeartPurchaseOption.class);
+            when(heartPurchaseOption.isDeleted()).thenReturn(false);
+            when(heartPurchaseOptionCommandRepository.findById(id)).thenReturn(Optional.of(heartPurchaseOption));
+
+            // When
+            heartPurchaseOptionService.delete(id);
+
+            // Then
+            verify(heartPurchaseOptionCommandRepository).deleteById(id);
         }
     }
 }

--- a/src/test/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionServiceTest.java
+++ b/src/test/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionServiceTest.java
@@ -46,7 +46,8 @@ class HeartPurchaseOptionServiceTest {
                 productId,
                 name
             );
-            when(heartPurchaseOptionCommandRepository.existsByProductId(request.productId())).thenReturn(true);
+            when(heartPurchaseOptionCommandRepository.existsByProductIdAndDeletedAtIsNull(
+                request.productId())).thenReturn(true);
 
             // When & Then
             assertThatThrownBy(() -> heartPurchaseOptionService.create(request))
@@ -64,7 +65,8 @@ class HeartPurchaseOptionServiceTest {
                 productId,
                 name
             );
-            when(heartPurchaseOptionCommandRepository.existsByProductId(request.productId())).thenReturn(false);
+            when(heartPurchaseOptionCommandRepository.existsByProductIdAndDeletedAtIsNull(
+                request.productId())).thenReturn(false);
 
             // When
             heartPurchaseOptionService.create(request);

--- a/src/test/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionServiceTest.java
+++ b/src/test/java/atwoz/atwoz/payment/command/application/heartpurchaseoption/HeartPurchaseOptionServiceTest.java
@@ -1,0 +1,77 @@
+package atwoz.atwoz.payment.command.application.heartpurchaseoption;
+
+import atwoz.atwoz.payment.command.application.heartpurchaseoption.exception.HeartPurchaseOptionAlreadyExistsException;
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOptionCommandRepository;
+import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOptionCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HeartPurchaseOptionServiceTest {
+
+    @InjectMocks
+    private HeartPurchaseOptionService heartPurchaseOptionService;
+
+    @Mock
+    private HeartPurchaseOptionCommandRepository heartPurchaseOptionCommandRepository;
+
+    @Nested
+    @DisplayName("create 메서드 테스트")
+    class CreateMethodTest {
+
+        String productId = "productId";
+        Long heartAmount = 100L;
+        Long price = 1000L;
+        String name = "name";
+
+        @Test
+        @DisplayName("이미 존재하는 productId로 생성 요청 시 예외 발생")
+        void throwExceptionWhenProductIdAlreadyExists() {
+            // Given
+            HeartPurchaseOptionCreateRequest request = new HeartPurchaseOptionCreateRequest(
+                heartAmount,
+                price,
+                productId,
+                name
+            );
+            when(heartPurchaseOptionCommandRepository.existsByProductId(request.productId())).thenReturn(true);
+
+            // When & Then
+            assertThatThrownBy(() -> heartPurchaseOptionService.create(request))
+                .isInstanceOf(HeartPurchaseOptionAlreadyExistsException.class);
+            verify(heartPurchaseOptionCommandRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 productId로 생성 요청 시 정상 처리")
+        void createHeartPurchaseOption() {
+            // Given
+            HeartPurchaseOptionCreateRequest request = new HeartPurchaseOptionCreateRequest(
+                heartAmount,
+                price,
+                productId,
+                name
+            );
+            when(heartPurchaseOptionCommandRepository.existsByProductId(request.productId())).thenReturn(false);
+
+            // When
+            heartPurchaseOptionService.create(request);
+
+            // Then
+            verify(heartPurchaseOptionCommandRepository).save(argThat(heartPurchaseOption ->
+                heartPurchaseOption.getHeartAmount().equals(heartAmount) &&
+                    heartPurchaseOption.getPrice().getValue().equals(price) &&
+                    heartPurchaseOption.getProductId().equals(productId) &&
+                    heartPurchaseOption.getName().equals(name)
+            ));
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/payment/command/application/order/OrderServiceTest.java
+++ b/src/test/java/atwoz/atwoz/payment/command/application/order/OrderServiceTest.java
@@ -46,7 +46,7 @@ class OrderServiceTest {
         assertThatThrownBy(
             () -> orderService.processReceipt(memberId, transactionId, productId, quantity, paymentMethod))
             .isInstanceOf(OrderAlreadyExistsException.class);
-        verify(heartPurchaseOptionCommandRepository, never()).findByProductId(any());
+        verify(heartPurchaseOptionCommandRepository, never()).findByProductIdAndDeletedAtIsNull(any());
         verify(orderCommandRepository, never()).save(any());
     }
 
@@ -56,7 +56,8 @@ class OrderServiceTest {
         // given
         when(orderCommandRepository.existsByTransactionIdAndPaymentMethod(transactionId, paymentMethod)).thenReturn(
             false);
-        when(heartPurchaseOptionCommandRepository.findByProductId(productId)).thenReturn(Optional.empty());
+        when(heartPurchaseOptionCommandRepository.findByProductIdAndDeletedAtIsNull(productId)).thenReturn(
+            Optional.empty());
 
         // when & then
         assertThatThrownBy(
@@ -73,7 +74,7 @@ class OrderServiceTest {
             false);
         HeartPurchaseOption heartPurchaseOption = mock(HeartPurchaseOption.class);
 
-        when(heartPurchaseOptionCommandRepository.findByProductId(productId)).thenReturn(
+        when(heartPurchaseOptionCommandRepository.findByProductIdAndDeletedAtIsNull(productId)).thenReturn(
             Optional.of(heartPurchaseOption));
 
         // when

--- a/src/test/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOptionTest.java
+++ b/src/test/java/atwoz/atwoz/payment/command/domain/heartpurchaseoption/HeartPurchaseOptionTest.java
@@ -17,42 +17,32 @@ import static org.mockito.Mockito.times;
 
 class HeartPurchaseOptionTest {
     @ParameterizedTest
-    @ValueSource(strings = {"amount is null", "price is null", "name is null"})
+    @ValueSource(strings = {"amount is null", "price is null", "name is null", "productId is null"})
     @DisplayName("of 메서드에서 필드 값이 null이면 예외를 던집니다.")
     void throwsExceptionWhenFieldValueIsNull(String fieldName) {
         // given
         HeartPurchaseAmount amount = fieldName.equals("amount is null") ? null : HeartPurchaseAmount.from(10L);
         Price price = fieldName.equals("price is null") ? null : Price.from(1000L);
+        String productId = fieldName.equals("productId is null") ? null : "productId";
         String name = fieldName.equals("name is null") ? null : "name";
 
         // when & then
-        assertThatThrownBy(() -> HeartPurchaseOption.of(amount, price, name))
+        assertThatThrownBy(() -> HeartPurchaseOption.of(amount, price, productId, name))
             .isInstanceOf(NullPointerException.class);
     }
 
-    @Test
-    @DisplayName("name 값이 빈 문자열이면 예외가 발생한다.")
-    void throwsExceptionWhenNameIsEmpty() {
+    @ParameterizedTest
+    @ValueSource(strings = {"name is blank", "productId is blank"})
+    @DisplayName("name, productId 이 blank 이면 예외가 발생한다.")
+    void throwsExceptionWhenNameOrProductIdIsBlank(String fieldName) {
         // given
         HeartPurchaseAmount amount = HeartPurchaseAmount.from(10L);
         Price price = Price.from(1000L);
-        String name = "";
+        String productId = fieldName.equals("productId is blank") ? " " : "productId";
+        String name = fieldName.equals("name is blank") ? " " : "name";
 
         // when, then
-        assertThatThrownBy(() -> HeartPurchaseOption.of(amount, price, name))
-            .isInstanceOf(InvalidHeartPurchaseOptionException.class);
-    }
-
-    @Test
-    @DisplayName("name 값이 공백이면 예외가 발생한다.")
-    void throwsExceptionWhenNameIsBlank() {
-        // given
-        HeartPurchaseAmount amount = HeartPurchaseAmount.from(10L);
-        Price price = Price.from(1000L);
-        String name = "   ";
-
-        // when, then
-        assertThatThrownBy(() -> HeartPurchaseOption.of(amount, price, name))
+        assertThatThrownBy(() -> HeartPurchaseOption.of(amount, price, productId, name))
             .isInstanceOf(InvalidHeartPurchaseOptionException.class);
     }
 
@@ -62,10 +52,11 @@ class HeartPurchaseOptionTest {
         // given
         HeartPurchaseAmount amount = HeartPurchaseAmount.from(10L);
         Price price = Price.from(1000L);
+        String productId = "productId";
         String name = "name";
 
         // when
-        HeartPurchaseOption heartPurchaseOption = HeartPurchaseOption.of(amount, price, name);
+        HeartPurchaseOption heartPurchaseOption = HeartPurchaseOption.of(amount, price, productId, name);
 
         // then
         assertThat(heartPurchaseOption).isNotNull();
@@ -78,8 +69,9 @@ class HeartPurchaseOptionTest {
         Long amount = 10L;
         HeartPurchaseAmount heartPurchaseAmount = HeartPurchaseAmount.from(amount);
         Price price = Price.from(1000L);
+        String productId = "productId";
         String name = "name";
-        HeartPurchaseOption heartPurchaseOption = HeartPurchaseOption.of(heartPurchaseAmount, price, name);
+        HeartPurchaseOption heartPurchaseOption = HeartPurchaseOption.of(heartPurchaseAmount, price, productId, name);
         Long memberId = 1L;
         Integer quantity = 5;
         Long expectedAmount = amount * quantity;

--- a/src/test/java/atwoz/atwoz/payment/query/heartpurchaseoption/HeartPurchaseOptionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/payment/query/heartpurchaseoption/HeartPurchaseOptionQueryRepositoryTest.java
@@ -70,8 +70,8 @@ class HeartPurchaseOptionQueryRepositoryTest {
     }
 
     @Test
-    @DisplayName("하트 구매 옵션 페이지 조회 name condition 테스트")
-    void findPageWithNameCondition() {
+    @DisplayName("하트 구매 옵션 페이지 조회 productId condition 테스트")
+    void findPageWithProductIdCondition() {
         // given
         HeartPurchaseOptionSearchCondition condition = new HeartPurchaseOptionSearchCondition(
             "Id1",
@@ -111,8 +111,8 @@ class HeartPurchaseOptionQueryRepositoryTest {
     }
 
     @Test
-    @DisplayName("하트 구매 옵션 페이지 조회 productId condition 테스트")
-    void findPageWithProductIdCondition() {
+    @DisplayName("하트 구매 옵션 페이지 조회 name condition 테스트")
+    void findPageWithNameCondition() {
         // given
         HeartPurchaseOptionSearchCondition condition = new HeartPurchaseOptionSearchCondition(
             null,

--- a/src/test/java/atwoz/atwoz/payment/query/heartpurchaseoption/HeartPurchaseOptionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/payment/query/heartpurchaseoption/HeartPurchaseOptionQueryRepositoryTest.java
@@ -1,0 +1,244 @@
+package atwoz.atwoz.payment.query.heartpurchaseoption;
+
+import atwoz.atwoz.common.config.QueryDslConfig;
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseAmount;
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.HeartPurchaseOption;
+import atwoz.atwoz.payment.command.domain.heartpurchaseoption.Price;
+import atwoz.atwoz.payment.query.heartpurchaseoption.condition.HeartPurchaseOptionSearchCondition;
+import atwoz.atwoz.payment.query.heartpurchaseoption.view.HeartPurchaseOptionView;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, HeartPurchaseOptionQueryRepository.class})
+class HeartPurchaseOptionQueryRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+    @Autowired
+    private HeartPurchaseOptionQueryRepository heartPurchaseOptionQueryRepository;
+
+    @Test
+    @DisplayName("하트 구매 옵션 페이지 조회 파라미터 순서 테스트")
+    void findPage() {
+        // given
+        HeartPurchaseOptionSearchCondition condition = new HeartPurchaseOptionSearchCondition(
+            null,
+            null,
+            null,
+            null
+        );
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        final HeartPurchaseOption productId1 = HeartPurchaseOption.of(
+            HeartPurchaseAmount.from(100L),
+            Price.from(1000L),
+            "productId1",
+            "하트 구매 옵션 1"
+        );
+        entityManager.persist(productId1);
+        entityManager.flush();
+
+        // when
+        final Page<HeartPurchaseOptionView> result = heartPurchaseOptionQueryRepository.findPage(condition,
+            pageRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        List<HeartPurchaseOptionView> heartPurchaseOptionViews = result.getContent();
+        assertThat(heartPurchaseOptionViews).hasSize(1);
+        HeartPurchaseOptionView heartPurchaseOptionView = heartPurchaseOptionViews.get(0);
+        assertThat(heartPurchaseOptionView.id()).isEqualTo(productId1.getId());
+        assertThat(heartPurchaseOptionView.name()).isEqualTo(productId1.getName());
+        assertThat(heartPurchaseOptionView.productId()).isEqualTo(productId1.getProductId());
+        assertThat(heartPurchaseOptionView.heartAmount()).isEqualTo(productId1.getHeartAmount());
+        assertThat(heartPurchaseOptionView.price()).isEqualTo(productId1.getPrice().getValue());
+        assertThat(heartPurchaseOptionView.createdAt()).isEqualTo(productId1.getCreatedAt());
+        assertThat(heartPurchaseOptionView.deletedAt()).isEqualTo(productId1.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("하트 구매 옵션 페이지 조회 name condition 테스트")
+    void findPageWithNameCondition() {
+        // given
+        HeartPurchaseOptionSearchCondition condition = new HeartPurchaseOptionSearchCondition(
+            "Id1",
+            null,
+            null,
+            null
+        );
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        final HeartPurchaseOption productId1 = HeartPurchaseOption.of(
+            HeartPurchaseAmount.from(100L),
+            Price.from(1000L),
+
+            "productId1",
+            "하트 구매 옵션 1"
+        );
+        final HeartPurchaseOption productId2 = HeartPurchaseOption.of(
+            HeartPurchaseAmount.from(100L),
+            Price.from(1000L),
+            "productId2",
+            "하트 구매 옵션 2"
+        );
+        entityManager.persist(productId1);
+        entityManager.persist(productId2);
+        entityManager.flush();
+
+        // when
+        final Page<HeartPurchaseOptionView> result = heartPurchaseOptionQueryRepository.findPage(condition,
+            pageRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        List<HeartPurchaseOptionView> heartPurchaseOptionViews = result.getContent();
+        assertThat(heartPurchaseOptionViews).hasSize(1);
+        HeartPurchaseOptionView heartPurchaseOptionView = heartPurchaseOptionViews.get(0);
+        assertThat(heartPurchaseOptionView.id()).isEqualTo(productId1.getId());
+    }
+
+    @Test
+    @DisplayName("하트 구매 옵션 페이지 조회 productId condition 테스트")
+    void findPageWithProductIdCondition() {
+        // given
+        HeartPurchaseOptionSearchCondition condition = new HeartPurchaseOptionSearchCondition(
+            null,
+            "옵션 1",
+            null,
+            null
+        );
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        final HeartPurchaseOption productId1 = HeartPurchaseOption.of(
+            HeartPurchaseAmount.from(100L),
+            Price.from(1000L),
+
+            "productId1",
+            "하트 구매 옵션 1"
+        );
+        final HeartPurchaseOption productId2 = HeartPurchaseOption.of(
+            HeartPurchaseAmount.from(100L),
+            Price.from(1000L),
+            "productId2",
+            "하트 구매 옵션 2"
+        );
+        entityManager.persist(productId1);
+        entityManager.persist(productId2);
+        entityManager.flush();
+
+        // when
+        final Page<HeartPurchaseOptionView> result = heartPurchaseOptionQueryRepository.findPage(condition,
+            pageRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        List<HeartPurchaseOptionView> heartPurchaseOptionViews = result.getContent();
+        assertThat(heartPurchaseOptionViews).hasSize(1);
+        HeartPurchaseOptionView heartPurchaseOptionView = heartPurchaseOptionViews.get(0);
+        assertThat(heartPurchaseOptionView.id()).isEqualTo(productId1.getId());
+    }
+
+    @Test
+    @DisplayName("하트 구매 옵션 페이지 조회 createdDateGoe condition 테스트")
+    void findPageWithCreatedDateGoeCondition() {
+        // given
+        final HeartPurchaseOption productId1 = HeartPurchaseOption.of(
+            HeartPurchaseAmount.from(100L),
+            Price.from(1000L),
+            "productId1",
+            "하트 구매 옵션 1"
+        );
+        entityManager.persist(productId1);
+        entityManager.flush();
+
+        HeartPurchaseOptionSearchCondition condition1 = new HeartPurchaseOptionSearchCondition(
+            null,
+            null,
+            productId1.getCreatedAt().toLocalDate(),
+            null
+        );
+
+        HeartPurchaseOptionSearchCondition condition2 = new HeartPurchaseOptionSearchCondition(
+            null,
+            null,
+            productId1.getCreatedAt().toLocalDate().plusDays(1),
+            null
+        );
+
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        // when
+        final Page<HeartPurchaseOptionView> result1 = heartPurchaseOptionQueryRepository.findPage(condition1,
+            pageRequest);
+        final Page<HeartPurchaseOptionView> result2 = heartPurchaseOptionQueryRepository.findPage(condition2,
+            pageRequest);
+
+        // then
+        assertThat(result1).isNotNull();
+        List<HeartPurchaseOptionView> heartPurchaseOptionViews1 = result1.getContent();
+        assertThat(heartPurchaseOptionViews1).hasSize(1);
+        HeartPurchaseOptionView heartPurchaseOptionView1 = heartPurchaseOptionViews1.get(0);
+        assertThat(heartPurchaseOptionView1.id()).isEqualTo(productId1.getId());
+
+        assertThat(result2).isNotNull();
+        List<HeartPurchaseOptionView> heartPurchaseOptionViews2 = result2.getContent();
+        assertThat(heartPurchaseOptionViews2).isEmpty();
+    }
+
+    @Test
+    @DisplayName("하트 구매 옵션 페이지 조회 createdDateLoe condition 테스트")
+    void findPageWithCreatedDateLoeCondition() {
+        // given
+        final HeartPurchaseOption productId1 = HeartPurchaseOption.of(
+            HeartPurchaseAmount.from(100L),
+            Price.from(1000L),
+            "productId1",
+            "하트 구매 옵션 1"
+        );
+        entityManager.persist(productId1);
+        entityManager.flush();
+
+        HeartPurchaseOptionSearchCondition condition1 = new HeartPurchaseOptionSearchCondition(
+            null,
+            null,
+            null,
+            productId1.getCreatedAt().toLocalDate()
+        );
+
+        HeartPurchaseOptionSearchCondition condition2 = new HeartPurchaseOptionSearchCondition(
+            null,
+            null,
+            null,
+            productId1.getCreatedAt().toLocalDate().minusDays(1)
+        );
+
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        // when
+        final Page<HeartPurchaseOptionView> result1 = heartPurchaseOptionQueryRepository.findPage(condition1,
+            pageRequest);
+        final Page<HeartPurchaseOptionView> result2 = heartPurchaseOptionQueryRepository.findPage(condition2,
+            pageRequest);
+
+        // then
+        assertThat(result1).isNotNull();
+        List<HeartPurchaseOptionView> heartPurchaseOptionViews1 = result1.getContent();
+        assertThat(heartPurchaseOptionViews1).hasSize(1);
+        HeartPurchaseOptionView heartPurchaseOptionView1 = heartPurchaseOptionViews1.get(0);
+        assertThat(heartPurchaseOptionView1.id()).isEqualTo(productId1.getId());
+
+        assertThat(result2).isNotNull();
+        List<HeartPurchaseOptionView> heartPurchaseOptionViews2 = result2.getContent();
+        assertThat(heartPurchaseOptionViews2).isEmpty();
+    }
+}

--- a/src/test/java/atwoz/atwoz/payment/query/heartpurchaseoption/HeartPurchaseOptionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/payment/query/heartpurchaseoption/HeartPurchaseOptionQueryRepositoryTest.java
@@ -15,9 +15,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 @DataJpaTest
 @Import({QueryDslConfig.class, HeartPurchaseOptionQueryRepository.class})
@@ -62,7 +64,8 @@ class HeartPurchaseOptionQueryRepositoryTest {
         assertThat(heartPurchaseOptionView.productId()).isEqualTo(productId1.getProductId());
         assertThat(heartPurchaseOptionView.heartAmount()).isEqualTo(productId1.getHeartAmount());
         assertThat(heartPurchaseOptionView.price()).isEqualTo(productId1.getPrice().getValue());
-        assertThat(heartPurchaseOptionView.createdAt()).isEqualTo(productId1.getCreatedAt());
+        assertThat(heartPurchaseOptionView.createdAt()).isCloseTo(productId1.getCreatedAt(),
+            within(1, ChronoUnit.MICROS));
         assertThat(heartPurchaseOptionView.deletedAt()).isEqualTo(productId1.getDeletedAt());
     }
 


### PR DESCRIPTION
### 관련 이슈

- closes #184 

<br>

### 작업 내용
- 하트 구매 옵션 등록, 삭제, 조회 API 구현
- 하트 구매 옵션 SQLDelete로 soft delete 적용
- 기존 하트 구매 옵션 조회 로직에서 deletedAt null 인 것만 조회하도록 수정

<br>

### 참고 자료
-

<br>

### 노트
- 하트 구매 옵션에서 수정 API는 구현하지 않고 soft delete로 삭제 이후 새로 생성하여 사용하도록 했습니다.
- 수정을 하게 되면 기존에 해당 옵션으로 구매한 유저가 지불한 가격, 지급된 하트 수와 하트 구매 옵션의 가격, 지급 하트 수가 다를 수 있어서 수정을 막았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 하트 구매 옵션을 생성, 삭제, 조회할 수 있는 관리자용 API가 추가되었습니다.
    - 하트 구매 옵션의 목록을 조건별로 검색 및 페이징 조회할 수 있습니다.
- **버그 수정**
    - 삭제된 하트 구매 옵션이 중복 생성/조회되지 않도록 처리되었습니다.
- **사용성 개선**
    - 하트 구매 옵션 생성 시 입력값에 대한 유효성 검사가 강화되었습니다.
    - 중복 생성 및 미존재 삭제 시 명확한 오류 메시지와 상태 코드가 제공됩니다.
- **테스트**
    - 하트 구매 옵션 서비스 및 조회 기능에 대한 단위 테스트와 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->