### PR TITLE
하트 구매내역 목록 조회 API 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/heart/command/domain/hearttransaction/HeartTransaction.java
+++ b/src/main/java/atwoz/atwoz/heart/command/domain/hearttransaction/HeartTransaction.java
@@ -18,6 +18,7 @@ public class HeartTransaction extends BaseEntity {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
+    @Getter
     private Long id;
 
     @Getter

--- a/src/main/java/atwoz/atwoz/heart/presentation/hearttransaction/AdminHeartTransactionController.java
+++ b/src/main/java/atwoz/atwoz/heart/presentation/hearttransaction/AdminHeartTransactionController.java
@@ -1,0 +1,32 @@
+package atwoz.atwoz.heart.presentation.hearttransaction;
+
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.heart.query.hearttransaction.HeartTransactionQueryRepository;
+import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/heart-transactions")
+public class AdminHeartTransactionController {
+    private final HeartTransactionQueryRepository heartTransactionQueryRepository;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<Page<HeartTransactionView>>> getPage(
+        @ModelAttribute HeartTransactionSearchCondition condition,
+        @PageableDefault(size = 100) Pageable pageable
+    ) {
+        Page<HeartTransactionView> page = heartTransactionQueryRepository.findPage(condition, pageable);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, page));
+    }
+}

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryRepository.java
@@ -1,0 +1,109 @@
+package atwoz.atwoz.heart.query.hearttransaction;
+
+import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import atwoz.atwoz.heart.query.hearttransaction.view.QHeartTransactionView;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static atwoz.atwoz.heart.command.domain.hearttransaction.QHeartTransaction.heartTransaction;
+import static atwoz.atwoz.member.command.domain.member.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class HeartTransactionQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public Page<HeartTransactionView> findPage(HeartTransactionSearchCondition condition, Pageable pageable) {
+        Set<Long> memberIds = getMemberIds(condition.nickname(), condition.phoneNumber());
+        if (memberIds != null && memberIds.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        List<HeartTransactionView> views = queryFactory
+            .select(
+                new QHeartTransactionView(
+                    heartTransaction.id,
+                    heartTransaction.createdAt,
+                    heartTransaction.transactionType.stringValue(),
+                    heartTransaction.heartAmount.amount,
+                    getHeartBalance()
+                ))
+            .from(heartTransaction)
+            .where(
+                memberIdIn(memberIds),
+                createdAtGoe(condition.createdDateGoe()),
+                createdAtLoe(condition.createdDateLoe())
+            )
+            .orderBy(heartTransaction.id.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long totalCount = queryFactory
+            .select(heartTransaction.count())
+            .from(heartTransaction)
+            .where(
+                memberIdIn(memberIds),
+                createdAtGoe(condition.createdDateGoe()),
+                createdAtLoe(condition.createdDateLoe())
+            )
+            .fetchOne();
+
+        return new PageImpl<>(views, pageable, totalCount);
+    }
+
+    private Set<Long> getMemberIds(String nickname, String phoneNumber) {
+        if (nickname == null && phoneNumber == null) {
+            return null;
+        }
+
+        List<Long> list = queryFactory
+            .select(member.id)
+            .from(member)
+            .where(
+                nicknameContains(nickname),
+                phoneNumberEq(phoneNumber)
+            )
+            .fetch();
+
+        return new HashSet<>(list);
+    }
+
+    private BooleanExpression nicknameContains(String nickname) {
+        return nickname != null ? member.profile.nickname.value.contains(nickname) : null;
+    }
+
+    private BooleanExpression phoneNumberEq(String phoneNumber) {
+        return phoneNumber != null ? member.phoneNumber.value.eq(phoneNumber) : null;
+    }
+
+    private NumberExpression<Long> getHeartBalance() {
+        return heartTransaction.heartBalance.missionHeartBalance.add(
+            heartTransaction.heartBalance.purchaseHeartBalance);
+    }
+
+    private BooleanExpression memberIdIn(Set<Long> memberIds) {
+        return memberIds != null ? heartTransaction.memberId.in(memberIds) : null;
+    }
+
+    private BooleanExpression createdAtGoe(LocalDate createdDateGoe) {
+        return createdDateGoe != null ? heartTransaction.createdAt.goe(createdDateGoe.atStartOfDay()) : null;
+    }
+
+    private BooleanExpression createdAtLoe(LocalDate createdDateLoe) {
+        return createdDateLoe != null ? heartTransaction.createdAt.loe(
+            createdDateLoe.plusDays(1).atStartOfDay().minusSeconds(1)) : null;
+    }
+}

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/condition/HeartTransactionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/condition/HeartTransactionSearchCondition.java
@@ -1,11 +1,15 @@
 package atwoz.atwoz.heart.query.hearttransaction.condition;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDate;
 
 public record HeartTransactionSearchCondition(
     String nickname,
     String phoneNumber,
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     LocalDate createdDateGoe,
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     LocalDate createdDateLoe
 ) {
 }

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/condition/HeartTransactionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/condition/HeartTransactionSearchCondition.java
@@ -1,0 +1,11 @@
+package atwoz.atwoz.heart.query.hearttransaction.condition;
+
+import java.time.LocalDate;
+
+public record HeartTransactionSearchCondition(
+    String nickname,
+    String phoneNumber,
+    LocalDate createdDateGoe,
+    LocalDate createdDateLoe
+) {
+}

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/HeartTransactionView.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/HeartTransactionView.java
@@ -1,0 +1,17 @@
+package atwoz.atwoz.heart.query.hearttransaction.view;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+
+public record HeartTransactionView(
+    Long id,
+    LocalDateTime createdAt,
+    String transactionType,
+    Long heartAmount,
+    Long heartBalance
+) {
+    @QueryProjection
+    public HeartTransactionView {
+    }
+}

--- a/src/test/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryRepositoryTest.java
@@ -1,0 +1,245 @@
+package atwoz.atwoz.heart.query.hearttransaction;
+
+import atwoz.atwoz.common.config.QueryDslConfig;
+import atwoz.atwoz.heart.command.domain.hearttransaction.HeartTransaction;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartAmount;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartBalance;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
+import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
+import atwoz.atwoz.member.command.domain.member.vo.Nickname;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, HeartTransactionQueryRepository.class})
+class HeartTransactionQueryRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+    @Autowired
+    private HeartTransactionQueryRepository heartTransactionQueryRepository;
+
+    @Test
+    @DisplayName("하트 거래 내역 페이지 조회 파라미터 순서 테스트")
+    void findPage() {
+        // given
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(
+            null,
+            null,
+            null,
+            null
+        );
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        HeartTransaction heartTransaction1 = createHeartTransaction(1L);
+        entityManager.persist(heartTransaction1);
+        entityManager.flush();
+
+        // when
+        final Page<HeartTransactionView> result = heartTransactionQueryRepository.findPage(condition,
+            pageRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        List<HeartTransactionView> heartTransactionViews = result.getContent();
+        assertThat(heartTransactionViews).hasSize(1);
+        HeartTransactionView heartTransactionView = heartTransactionViews.get(0);
+        assertThat(heartTransactionView.id()).isEqualTo(heartTransaction1.getId());
+        assertThat(heartTransactionView.transactionType()).isEqualTo(heartTransaction1.getTransactionType().name());
+        assertThat(heartTransactionView.heartAmount()).isEqualTo(heartTransaction1.getHeartAmount().getAmount());
+        Long heartBalance = heartTransaction1.getHeartBalance().getMissionHeartBalance() +
+            heartTransaction1.getHeartBalance().getPurchaseHeartBalance();
+        assertThat(heartTransactionView.heartBalance()).isEqualTo(heartBalance);
+        assertThat(heartTransactionView.createdAt()).isCloseTo(heartTransaction1.getCreatedAt(),
+            within(1, ChronoUnit.MICROS));
+    }
+
+    @Test
+    @DisplayName("하트 거래 내역 페이지 조회 nickname condition 테스트")
+    void findPageWithNicknameCondition() {
+        // given
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(
+            "name1",
+            null,
+            null,
+            null
+        );
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        Member member1 = createMember("01000000000", "nickname1");
+        Member member2 = createMember("01011111111", "nickname2");
+
+        entityManager.persist(member1);
+        entityManager.persist(member2);
+        entityManager.flush();
+
+        HeartTransaction heartTransaction1 = createHeartTransaction(member1.getId());
+        HeartTransaction heartTransaction2 = createHeartTransaction(member2.getId());
+
+        entityManager.persist(heartTransaction1);
+        entityManager.persist(heartTransaction2);
+        entityManager.flush();
+
+        // when
+        final Page<HeartTransactionView> result = heartTransactionQueryRepository.findPage(condition,
+            pageRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        List<HeartTransactionView> heartTransactionViews = result.getContent();
+        assertThat(heartTransactionViews).hasSize(1);
+        HeartTransactionView heartTransactionView = heartTransactionViews.get(0);
+        assertThat(heartTransactionView.id()).isEqualTo(heartTransaction1.getId());
+    }
+
+    @Test
+    @DisplayName("하트 거래 내역 페이지 조회 phoneNumber condition 테스트")
+    void findPageWithPhoneNumberCondition() {
+        // given
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(
+            null,
+            "01000000000",
+            null,
+            null
+        );
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        Member member1 = createMember("01000000000", "nickname1");
+        Member member2 = createMember("01011111111", "nickname2");
+
+        entityManager.persist(member1);
+        entityManager.persist(member2);
+        entityManager.flush();
+
+        HeartTransaction heartTransaction1 = createHeartTransaction(member1.getId());
+        HeartTransaction heartTransaction2 = createHeartTransaction(member2.getId());
+
+        entityManager.persist(heartTransaction1);
+        entityManager.persist(heartTransaction2);
+        entityManager.flush();
+
+        // when
+        final Page<HeartTransactionView> result = heartTransactionQueryRepository.findPage(condition,
+            pageRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        List<HeartTransactionView> heartTransactionViews = result.getContent();
+        assertThat(heartTransactionViews).hasSize(1);
+        HeartTransactionView heartTransactionView = heartTransactionViews.get(0);
+        assertThat(heartTransactionView.id()).isEqualTo(heartTransaction1.getId());
+    }
+
+    @Test
+    @DisplayName("하트 거래 내역 페이지 조회 createdDateGoe condition 테스트")
+    void findPageWithCreatedDateGoeCondition() {
+        // given
+        HeartTransaction heartTransaction1 = createHeartTransaction(1L);
+        entityManager.persist(heartTransaction1);
+        entityManager.flush();
+
+        HeartTransactionSearchCondition condition1 = new HeartTransactionSearchCondition(
+            null,
+            null,
+            heartTransaction1.getCreatedAt().toLocalDate(),
+            null
+        );
+
+        HeartTransactionSearchCondition condition2 = new HeartTransactionSearchCondition(
+            null,
+            null,
+            heartTransaction1.getCreatedAt().toLocalDate().plusDays(1),
+            null
+        );
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+
+        // when
+        final Page<HeartTransactionView> result1 = heartTransactionQueryRepository.findPage(condition1,
+            pageRequest);
+
+        final Page<HeartTransactionView> result2 = heartTransactionQueryRepository.findPage(condition2,
+            pageRequest);
+
+        // then
+        assertThat(result1).isNotNull();
+        List<HeartTransactionView> heartTransactionViews1 = result1.getContent();
+        assertThat(heartTransactionViews1).hasSize(1);
+        HeartTransactionView heartTransactionView1 = heartTransactionViews1.get(0);
+        assertThat(heartTransactionView1.id()).isEqualTo(heartTransaction1.getId());
+
+        assertThat(result2).isEmpty();
+    }
+
+    @Test
+    @DisplayName("하트 거래 내역 페이지 조회 createdDateLoe condition 테스트")
+    void findPageWithCreatedDateLoeCondition() {
+        // given
+        HeartTransaction heartTransaction1 = createHeartTransaction(1L);
+        entityManager.persist(heartTransaction1);
+        entityManager.flush();
+
+        HeartTransactionSearchCondition condition1 = new HeartTransactionSearchCondition(
+            null,
+            null,
+            null,
+            heartTransaction1.getCreatedAt().toLocalDate()
+        );
+
+        HeartTransactionSearchCondition condition2 = new HeartTransactionSearchCondition(
+            null,
+            null,
+            null,
+            heartTransaction1.getCreatedAt().toLocalDate().minusDays(1)
+        );
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        // when
+        final Page<HeartTransactionView> result1 = heartTransactionQueryRepository.findPage(condition1,
+            pageRequest);
+
+        final Page<HeartTransactionView> result2 = heartTransactionQueryRepository.findPage(condition2,
+            pageRequest);
+
+        // then
+        assertThat(result1).isNotNull();
+        List<HeartTransactionView> heartTransactionViews1 = result1.getContent();
+        assertThat(heartTransactionViews1).hasSize(1);
+        HeartTransactionView heartTransactionView1 = heartTransactionViews1.get(0);
+        assertThat(heartTransactionView1.id()).isEqualTo(heartTransaction1.getId());
+
+        assertThat(result2).isEmpty();
+    }
+
+    private Member createMember(String phoneNumber, String nickname) {
+        Member member = Member.fromPhoneNumber(phoneNumber);
+        MemberProfile memberProfile = MemberProfile.builder()
+            .nickname(Nickname.from(nickname))
+            .build();
+        member.updateProfile(memberProfile);
+        return member;
+    }
+
+    private HeartTransaction createHeartTransaction(Long memberId) {
+        return HeartTransaction.of(
+            memberId,
+            TransactionType.PURCHASE,
+            HeartAmount.from(100L),
+            HeartBalance.of(100L, 200L)
+        );
+    }
+}


### PR DESCRIPTION
### 관련 이슈

- closes #185 

<br>

### 작업 내용
- 하트 구매내역 목록 조회 API 구현

<br>

### 참고 자료
-

<br>

### 노트
- HeartTransaction 도메인에 content 필드가 없는데 별도의 PR으로 분리해서 content 필드 추가하는 작업 진행할게요
