### PR TITLE
신고현황 목록, 단건 조회 API, 신고 처리 API 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/report/command/application/AdminReportService.java
+++ b/src/main/java/atwoz/atwoz/report/command/application/AdminReportService.java
@@ -1,0 +1,41 @@
+package atwoz.atwoz.report.command.application;
+
+import atwoz.atwoz.report.command.application.exception.ReportNotFoundException;
+import atwoz.atwoz.report.command.domain.Report;
+import atwoz.atwoz.report.command.domain.ReportCommandRepository;
+import atwoz.atwoz.report.presentation.dto.ReportApproveRequest;
+import atwoz.atwoz.report.presentation.dto.ReportRejectRequest;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportService {
+    private final ReportCommandRepository reportCommandRepository;
+
+    @Transactional
+    public void approve(long reportId, ReportApproveRequest request, long adminId) {
+        Report report = getReport(reportId);
+        validateReport(report, request.version());
+        report.approve(adminId);
+    }
+
+    @Transactional
+    public void reject(long reportId, ReportRejectRequest request, long adminId) {
+        Report report = getReport(reportId);
+        validateReport(report, request.version());
+        report.reject(adminId);
+    }
+
+    private Report getReport(long id) {
+        return reportCommandRepository.findById(id).orElseThrow(ReportNotFoundException::new);
+    }
+
+    private void validateReport(Report report, long version) {
+        if (report.hasVersionConflict(version)) {
+            throw new OptimisticLockingFailureException("신고를 처리할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/report/command/application/ReportService.java
+++ b/src/main/java/atwoz/atwoz/report/command/application/ReportService.java
@@ -6,7 +6,7 @@ import atwoz.atwoz.report.command.application.exception.ReportAlreadyExistsExcep
 import atwoz.atwoz.report.command.domain.Report;
 import atwoz.atwoz.report.command.domain.ReportCommandRepository;
 import atwoz.atwoz.report.command.domain.ReportReasonType;
-import atwoz.atwoz.report.presentation.dto.ReportRequest;
+import atwoz.atwoz.report.presentation.dto.ReportCreateRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,14 +18,14 @@ public class ReportService {
     private final MemberCommandRepository memberCommandRepository;
 
     @Transactional
-    public void report(ReportRequest request, long reporterId) {
+    public void report(ReportCreateRequest request, long reporterId) {
         validateRequest(request, reporterId);
         ReportReasonType reportReasonType = ReportReasonType.from(request.reason());
         Report report = Report.of(reporterId, request.reporteeId(), reportReasonType, request.content());
         reportCommandRepository.save(report);
     }
 
-    private void validateRequest(ReportRequest request, long reporterId) {
+    private void validateRequest(ReportCreateRequest request, long reporterId) {
         if (!memberCommandRepository.existsById(request.reporteeId())) {
             throw new MemberNotFoundException();
         }

--- a/src/main/java/atwoz/atwoz/report/command/application/exception/ReportNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/report/command/application/exception/ReportNotFoundException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.report.command.application.exception;
+
+public class ReportNotFoundException extends RuntimeException {
+    public ReportNotFoundException() {
+        super("Report not found");
+    }
+}

--- a/src/main/java/atwoz/atwoz/report/command/domain/Report.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/Report.java
@@ -41,6 +41,9 @@ public class Report extends BaseEntity {
     @Column(columnDefinition = "varchar(50)")
     private ReportResult result;
 
+    @Version
+    private Long version;
+
     private Report(long reporterId, long reporteeId, Long adminId, ReportReasonType reason, String content,
         ReportResult status) {
         validateReport(reporterId, reporteeId);
@@ -71,6 +74,10 @@ public class Report extends BaseEntity {
         Events.raise(new ReportApprovedEvent(reporteeId));
     }
 
+    public boolean hasVersionConflict(long version) {
+        return this.version != version;
+    }
+    
     private void validateReport(long reporterId, long reporteeId) {
         if (reporterId == reporteeId) {
             throw new InvalidReportException("자기 자신을 신고할 수 없습니다.");

--- a/src/main/java/atwoz/atwoz/report/command/domain/Report.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/Report.java
@@ -17,6 +17,7 @@ import lombok.NonNull;
 public class Report extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
     private Long id;
 
     @Getter
@@ -77,7 +78,7 @@ public class Report extends BaseEntity {
     public boolean hasVersionConflict(long version) {
         return this.version != version;
     }
-    
+
     private void validateReport(long reporterId, long reporteeId) {
         if (reporterId == reporteeId) {
             throw new InvalidReportException("자기 자신을 신고할 수 없습니다.");

--- a/src/main/java/atwoz/atwoz/report/command/domain/Report.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/Report.java
@@ -60,7 +60,7 @@ public class Report extends BaseEntity {
 
     public static Report of(long reporterId, long reporteeId, ReportReasonType reason, String content) {
         Report report = new Report(reporterId, reporteeId, null, reason, content, ReportResult.PENDING);
-        Events.raise(new ReportCreatedEvent(reporterId, reporteeId));
+        Events.raise(ReportCreatedEvent.of(reporterId, reporteeId));
         return report;
     }
 
@@ -74,14 +74,14 @@ public class Report extends BaseEntity {
         validateResult();
         setAdminId(adminId);
         setResult(ReportResult.WARNED);
-        Events.raise(new ReportWarnedEvent(reporteeId, reason.name()));
+        Events.raise(ReportWarnedEvent.of(reporteeId, reason.name()));
     }
 
     public void suspend(long adminId) {
         validateResult();
         setAdminId(adminId);
         setResult(ReportResult.SUSPENDED);
-        Events.raise(new ReportSuspendedEvent(this.reporteeId));
+        Events.raise(ReportSuspendedEvent.from(this.reporteeId));
     }
 
 

--- a/src/main/java/atwoz/atwoz/report/command/domain/Report.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/Report.java
@@ -2,8 +2,9 @@ package atwoz.atwoz.report.command.domain;
 
 import atwoz.atwoz.common.entity.BaseEntity;
 import atwoz.atwoz.common.event.Events;
-import atwoz.atwoz.report.command.domain.event.ReportApprovedEvent;
 import atwoz.atwoz.report.command.domain.event.ReportCreatedEvent;
+import atwoz.atwoz.report.command.domain.event.ReportSuspendedEvent;
+import atwoz.atwoz.report.command.domain.event.ReportWarnedEvent;
 import atwoz.atwoz.report.command.domain.exception.InvalidReportResultException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -69,12 +70,20 @@ public class Report extends BaseEntity {
         setResult(ReportResult.REJECTED);
     }
 
-    public void approve(long adminId) {
+    public void warn(long adminId) {
         validateResult();
         setAdminId(adminId);
-        setResult(ReportResult.BANNED);
-        Events.raise(new ReportApprovedEvent(reporteeId));
+        setResult(ReportResult.WARNED);
+        Events.raise(new ReportWarnedEvent(reporteeId, reason.name()));
     }
+
+    public void suspend(long adminId) {
+        validateResult();
+        setAdminId(adminId);
+        setResult(ReportResult.SUSPENDED);
+        Events.raise(new ReportSuspendedEvent(this.reporteeId));
+    }
+
 
     public boolean hasVersionConflict(long version) {
         return this.version != version;

--- a/src/main/java/atwoz/atwoz/report/command/domain/Report.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/Report.java
@@ -43,6 +43,7 @@ public class Report extends BaseEntity {
     private ReportResult result;
 
     @Version
+    @Getter
     private Long version;
 
     private Report(long reporterId, long reporteeId, Long adminId, ReportReasonType reason, String content,

--- a/src/main/java/atwoz/atwoz/report/command/domain/ReportReasonType.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/ReportReasonType.java
@@ -1,7 +1,14 @@
 package atwoz.atwoz.report.command.domain;
 
 import atwoz.atwoz.report.command.domain.exception.InvalidReportReasonTypeException;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "ReportReasonType",
+    description = "신고 사유",
+    type = "string",
+    example = "STOLEN_IMAGE"
+)
 public enum ReportReasonType {
     STOLEN_IMAGE("사진 도용"),
     INAPPROPRIATE_IMAGE("부적절한 사진"),

--- a/src/main/java/atwoz/atwoz/report/command/domain/ReportResult.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/ReportResult.java
@@ -1,14 +1,26 @@
 package atwoz.atwoz.report.command.domain;
 
+import atwoz.atwoz.report.command.domain.exception.InvalidReportResultException;
+import lombok.NonNull;
+
 public enum ReportResult {
     PENDING("대기"),
     REJECTED("기각"),
-    BANNED("정지");
+    WARNED("경고"),
+    SUSPENDED("일시 정지");
 
     private final String description;
 
     ReportResult(String description) {
         this.description = description;
+    }
+
+    public static ReportResult from(@NonNull String result) {
+        try {
+            return ReportResult.valueOf(result.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidReportResultException("Invalid report result: " + result);
+        }
     }
 
     public String getDescription() {

--- a/src/main/java/atwoz/atwoz/report/command/domain/ReportResult.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/ReportResult.java
@@ -1,8 +1,15 @@
 package atwoz.atwoz.report.command.domain;
 
 import atwoz.atwoz.report.command.domain.exception.InvalidReportResultException;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.NonNull;
 
+@Schema(
+    name = "ReportResult",
+    description = "신고 결과",
+    type = "string",
+    example = "PENDING"
+)
 public enum ReportResult {
     PENDING("대기"),
     REJECTED("기각"),

--- a/src/main/java/atwoz/atwoz/report/command/domain/event/ReportCreatedEvent.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/event/ReportCreatedEvent.java
@@ -1,11 +1,12 @@
 package atwoz.atwoz.report.command.domain.event;
 
 import atwoz.atwoz.common.event.Event;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReportCreatedEvent extends Event {
     private final long reporterId;
     private final long reporteeId;

--- a/src/main/java/atwoz/atwoz/report/command/domain/event/ReportSuspendedEvent.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/event/ReportSuspendedEvent.java
@@ -6,10 +6,10 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class ReportApprovedEvent extends Event {
+public class ReportSuspendedEvent extends Event {
     private final long reporteeId;
 
-    public static ReportApprovedEvent from(long reporteeId) {
-        return new ReportApprovedEvent(reporteeId);
+    public static ReportSuspendedEvent from(long reporteeId) {
+        return new ReportSuspendedEvent(reporteeId);
     }
 }

--- a/src/main/java/atwoz/atwoz/report/command/domain/event/ReportSuspendedEvent.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/event/ReportSuspendedEvent.java
@@ -1,11 +1,12 @@
 package atwoz.atwoz.report.command.domain.event;
 
 import atwoz.atwoz.common.event.Event;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReportSuspendedEvent extends Event {
     private final long reporteeId;
 

--- a/src/main/java/atwoz/atwoz/report/command/domain/event/ReportWarnedEvent.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/event/ReportWarnedEvent.java
@@ -1,0 +1,16 @@
+package atwoz.atwoz.report.command.domain.event;
+
+import atwoz.atwoz.common.event.Event;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReportWarnedEvent extends Event {
+    private final long reporteeId;
+    private final String reportReason;
+
+    public static ReportWarnedEvent of(long reporteeId, String reportReason) {
+        return new ReportWarnedEvent(reporteeId, reportReason);
+    }
+}

--- a/src/main/java/atwoz/atwoz/report/command/domain/event/ReportWarnedEvent.java
+++ b/src/main/java/atwoz/atwoz/report/command/domain/event/ReportWarnedEvent.java
@@ -1,11 +1,12 @@
 package atwoz.atwoz.report.command.domain.event;
 
 import atwoz.atwoz.common.event.Event;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReportWarnedEvent extends Event {
     private final long reporteeId;
     private final String reportReason;

--- a/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
@@ -6,8 +6,7 @@ import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.report.command.application.AdminReportService;
 import atwoz.atwoz.report.command.application.exception.ReportNotFoundException;
-import atwoz.atwoz.report.presentation.dto.ReportApproveRequest;
-import atwoz.atwoz.report.presentation.dto.ReportRejectRequest;
+import atwoz.atwoz.report.presentation.dto.ReportResultUpdateRequest;
 import atwoz.atwoz.report.query.ReportQueryRepository;
 import atwoz.atwoz.report.query.condition.ReportSearchCondition;
 import atwoz.atwoz.report.query.view.ReportDetailView;
@@ -27,21 +26,14 @@ public class AdminReportController {
     private final AdminReportService adminReportService;
     private final ReportQueryRepository reportQueryRepository;
 
-    @PatchMapping("/{id}/approve")
-    public void approve(
+    @PatchMapping("/{id}/result")
+    public ResponseEntity<BaseResponse<Void>> updateResult(
         @PathVariable long id,
-        @Valid @RequestBody ReportApproveRequest request,
+        @Valid @RequestBody ReportResultUpdateRequest request,
         @AuthPrincipal AuthContext authContext
     ) {
-        adminReportService.approve(id, request, authContext.getId());
-    }
-
-    @PatchMapping("/{id}/reject")
-    public void reject(@PathVariable long id,
-        @Valid @RequestBody ReportRejectRequest request,
-        @AuthPrincipal AuthContext authContext
-    ) {
-        adminReportService.reject(id, request, authContext.getId());
+        adminReportService.updateResult(id, request, authContext.getId());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
     @GetMapping

--- a/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
@@ -5,10 +5,12 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.report.command.application.AdminReportService;
+import atwoz.atwoz.report.command.application.exception.ReportNotFoundException;
 import atwoz.atwoz.report.presentation.dto.ReportApproveRequest;
 import atwoz.atwoz.report.presentation.dto.ReportRejectRequest;
 import atwoz.atwoz.report.query.ReportQueryRepository;
 import atwoz.atwoz.report.query.condition.ReportSearchCondition;
+import atwoz.atwoz.report.query.view.ReportDetailView;
 import atwoz.atwoz.report.query.view.ReportView;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -49,5 +51,12 @@ public class AdminReportController {
     ) {
         Page<ReportView> page = reportQueryRepository.getPage(condition, pageable);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, page));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<ReportDetailView>> getReport(@PathVariable long id) {
+        ReportDetailView view = reportQueryRepository.findReportDetailView(id)
+            .orElseThrow(ReportNotFoundException::new);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, view));
     }
 }

--- a/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
@@ -2,11 +2,20 @@ package atwoz.atwoz.report.presentation;
 
 import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.report.command.application.AdminReportService;
 import atwoz.atwoz.report.presentation.dto.ReportApproveRequest;
 import atwoz.atwoz.report.presentation.dto.ReportRejectRequest;
+import atwoz.atwoz.report.query.ReportQueryRepository;
+import atwoz.atwoz.report.query.condition.ReportSearchCondition;
+import atwoz.atwoz.report.query.view.ReportView;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AdminReportController {
     private final AdminReportService adminReportService;
+    private final ReportQueryRepository reportQueryRepository;
 
     @PatchMapping("/{id}/approve")
     public void approve(
@@ -30,5 +40,14 @@ public class AdminReportController {
         @AuthPrincipal AuthContext authContext
     ) {
         adminReportService.reject(id, request, authContext.getId());
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<Page<ReportView>>> getPage(
+        @ModelAttribute ReportSearchCondition condition,
+        @PageableDefault(size = 100) Pageable pageable
+    ) {
+        Page<ReportView> page = reportQueryRepository.getPage(condition, pageable);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, page));
     }
 }

--- a/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
@@ -1,0 +1,34 @@
+package atwoz.atwoz.report.presentation;
+
+import atwoz.atwoz.auth.presentation.AuthContext;
+import atwoz.atwoz.auth.presentation.AuthPrincipal;
+import atwoz.atwoz.report.command.application.AdminReportService;
+import atwoz.atwoz.report.presentation.dto.ReportApproveRequest;
+import atwoz.atwoz.report.presentation.dto.ReportRejectRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportController {
+    private final AdminReportService adminReportService;
+
+    @PatchMapping("/{id}/approve")
+    public void approve(
+        @PathVariable long id,
+        @Valid @RequestBody ReportApproveRequest request,
+        @AuthPrincipal AuthContext authContext
+    ) {
+        adminReportService.approve(id, request, authContext.getId());
+    }
+
+    @PatchMapping("/{id}/reject")
+    public void reject(@PathVariable long id,
+        @Valid @RequestBody ReportRejectRequest request,
+        @AuthPrincipal AuthContext authContext
+    ) {
+        adminReportService.reject(id, request, authContext.getId());
+    }
+}

--- a/src/main/java/atwoz/atwoz/report/presentation/ReportController.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/ReportController.java
@@ -5,7 +5,7 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.report.command.application.ReportService;
-import atwoz.atwoz.report.presentation.dto.ReportRequest;
+import atwoz.atwoz.report.presentation.dto.ReportCreateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +21,7 @@ public class ReportController {
     private final ReportService reportService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Void>> report(@Valid @RequestBody ReportRequest request,
+    public ResponseEntity<BaseResponse<Void>> report(@Valid @RequestBody ReportCreateRequest request,
         @AuthPrincipal AuthContext authContext) {
         reportService.report(request, authContext.getId());
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));

--- a/src/main/java/atwoz/atwoz/report/presentation/ReportExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/ReportExceptionHandler.java
@@ -3,6 +3,7 @@ package atwoz.atwoz.report.presentation;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.report.command.application.exception.ReportAlreadyExistsException;
+import atwoz.atwoz.report.command.application.exception.ReportNotFoundException;
 import atwoz.atwoz.report.command.domain.InvalidReportException;
 import atwoz.atwoz.report.command.domain.exception.InvalidReportReasonTypeException;
 import atwoz.atwoz.report.command.domain.exception.InvalidReportResultException;
@@ -46,5 +47,12 @@ public class ReportExceptionHandler {
         log.warn("잘못된 신고입니다. {}", e.getMessage());
 
         return ResponseEntity.badRequest().body(BaseResponse.from(StatusType.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(ReportNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleReportNotFoundException(ReportNotFoundException e) {
+        log.warn("해당 신고가 존재하지 않습니다. {}", e.getMessage());
+
+        return ResponseEntity.status(404).body(BaseResponse.from(StatusType.NOT_FOUND));
     }
 }

--- a/src/main/java/atwoz/atwoz/report/presentation/dto/ReportApproveRequest.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/dto/ReportApproveRequest.java
@@ -1,6 +1,0 @@
-package atwoz.atwoz.report.presentation.dto;
-
-public record ReportApproveRequest(
-    long version
-) {
-}

--- a/src/main/java/atwoz/atwoz/report/presentation/dto/ReportApproveRequest.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/dto/ReportApproveRequest.java
@@ -1,0 +1,6 @@
+package atwoz.atwoz.report.presentation.dto;
+
+public record ReportApproveRequest(
+    long version
+) {
+}

--- a/src/main/java/atwoz/atwoz/report/presentation/dto/ReportCreateRequest.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/dto/ReportCreateRequest.java
@@ -1,13 +1,16 @@
 package atwoz.atwoz.report.presentation.dto;
 
+import atwoz.atwoz.report.command.domain.ReportReasonType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record ReportRequest(
+public record ReportCreateRequest(
     @NotNull(message = "신고 대상 아이디를 입력해주세요.")
     Long reporteeId,
 
     @NotBlank(message = "신고 사유를 입력해주세요.")
+    @Schema(implementation = ReportReasonType.class)
     String reason,
 
     @NotNull(message = "신고 내용을 입력해주세요.")

--- a/src/main/java/atwoz/atwoz/report/presentation/dto/ReportRejectRequest.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/dto/ReportRejectRequest.java
@@ -1,6 +1,0 @@
-package atwoz.atwoz.report.presentation.dto;
-
-public record ReportRejectRequest(
-    long version
-) {
-}

--- a/src/main/java/atwoz/atwoz/report/presentation/dto/ReportRejectRequest.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/dto/ReportRejectRequest.java
@@ -1,0 +1,6 @@
+package atwoz.atwoz.report.presentation.dto;
+
+public record ReportRejectRequest(
+    long version
+) {
+}

--- a/src/main/java/atwoz/atwoz/report/presentation/dto/ReportResultUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/dto/ReportResultUpdateRequest.java
@@ -1,5 +1,7 @@
 package atwoz.atwoz.report.presentation.dto;
 
+import atwoz.atwoz.report.command.domain.ReportResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -7,6 +9,7 @@ public record ReportResultUpdateRequest(
     @NotNull(message = "버전을 입력해주세요.")
     Long version,
     @NotBlank(message = "신고 결과를 입력해주세요.")
+    @Schema(implementation = ReportResult.class)
     String result
 ) {
 }

--- a/src/main/java/atwoz/atwoz/report/presentation/dto/ReportResultUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/dto/ReportResultUpdateRequest.java
@@ -1,0 +1,12 @@
+package atwoz.atwoz.report.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportResultUpdateRequest(
+    @NotNull(message = "버전을 입력해주세요.")
+    Long version,
+    @NotBlank(message = "신고 결과를 입력해주세요.")
+    String result
+) {
+}

--- a/src/main/java/atwoz/atwoz/report/query/ReportQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/report/query/ReportQueryRepository.java
@@ -41,7 +41,7 @@ public class ReportQueryRepository {
             .where(
                 resultEq(condition.result()),
                 createdAtGoe(condition.createdAtGoe()),
-                createdAtLoe(condition.createdAtGoe())
+                createdAtLoe(condition.createdAtLoe())
             )
             .leftJoin(reporterMember).on(report.reporterId.eq(reporterMember.id))
             .leftJoin(reporteeMember).on(report.reporteeId.eq(reporteeMember.id))
@@ -56,7 +56,7 @@ public class ReportQueryRepository {
             .where(
                 resultEq(condition.result()),
                 createdAtGoe(condition.createdAtGoe()),
-                createdAtLoe(condition.createdAtGoe())
+                createdAtLoe(condition.createdAtLoe())
             )
             .leftJoin(reporterMember).on(report.reporterId.eq(reporterMember.id))
             .leftJoin(reporteeMember).on(report.reporteeId.eq(reporteeMember.id))

--- a/src/main/java/atwoz/atwoz/report/query/ReportQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/report/query/ReportQueryRepository.java
@@ -1,0 +1,80 @@
+package atwoz.atwoz.report.query;
+
+import atwoz.atwoz.member.command.domain.member.QMember;
+import atwoz.atwoz.report.query.condition.ReportSearchCondition;
+import atwoz.atwoz.report.query.view.QReportView;
+import atwoz.atwoz.report.query.view.ReportView;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static atwoz.atwoz.report.command.domain.QReport.report;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public Page<ReportView> getPage(ReportSearchCondition condition, Pageable pageable) {
+        QMember reporterMember = new QMember("reporterMember");
+        QMember reporteeMember = new QMember("reporteeMember");
+
+        List<ReportView> views = queryFactory
+            .select(new QReportView(
+                report.id,
+                report.reporterId,
+                reporterMember.profile.nickname.value,
+                report.reporteeId,
+                reporteeMember.profile.nickname.value,
+                report.reason.stringValue(),
+                report.result.stringValue(),
+                report.createdAt
+            ))
+            .from(report)
+            .where(
+                resultEq(condition.result()),
+                createdAtGoe(condition.createdAtGoe()),
+                createdAtLoe(condition.createdAtGoe())
+            )
+            .leftJoin(reporterMember).on(report.reporterId.eq(reporterMember.id))
+            .leftJoin(reporteeMember).on(report.reporteeId.eq(reporteeMember.id))
+            .orderBy(report.id.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long totalCount = queryFactory
+            .select(report.count())
+            .from(report)
+            .where(
+                resultEq(condition.result()),
+                createdAtGoe(condition.createdAtGoe()),
+                createdAtLoe(condition.createdAtGoe())
+            )
+            .leftJoin(reporterMember).on(report.reporterId.eq(reporterMember.id))
+            .leftJoin(reporteeMember).on(report.reporteeId.eq(reporteeMember.id))
+            .fetchOne();
+
+        return new PageImpl<>(views, pageable, totalCount);
+    }
+
+    private BooleanExpression resultEq(String result) {
+        return result != null ? report.result.stringValue().eq(result) : null;
+    }
+
+    private BooleanExpression createdAtGoe(LocalDate createdDateGoe) {
+        return createdDateGoe != null ? report.createdAt.goe(createdDateGoe.atStartOfDay()) : null;
+    }
+
+    private BooleanExpression createdAtLoe(LocalDate createdDateLoe) {
+        return createdDateLoe != null ? report.createdAt.loe(
+            createdDateLoe.plusDays(1).atStartOfDay().minusSeconds(1)) : null;
+    }
+}

--- a/src/main/java/atwoz/atwoz/report/query/ReportQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/report/query/ReportQueryRepository.java
@@ -2,7 +2,9 @@ package atwoz.atwoz.report.query;
 
 import atwoz.atwoz.member.command.domain.member.QMember;
 import atwoz.atwoz.report.query.condition.ReportSearchCondition;
+import atwoz.atwoz.report.query.view.QReportDetailView;
 import atwoz.atwoz.report.query.view.QReportView;
+import atwoz.atwoz.report.query.view.ReportDetailView;
 import atwoz.atwoz.report.query.view.ReportView;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -14,18 +16,18 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static atwoz.atwoz.report.command.domain.QReport.report;
 
 @Repository
 @RequiredArgsConstructor
 public class ReportQueryRepository {
+    private static final QMember reporterMember = new QMember("reporterMember");
+    private static final QMember reporteeMember = new QMember("reporteeMember");
     private final JPAQueryFactory queryFactory;
 
     public Page<ReportView> getPage(ReportSearchCondition condition, Pageable pageable) {
-        QMember reporterMember = new QMember("reporterMember");
-        QMember reporteeMember = new QMember("reporteeMember");
-
         List<ReportView> views = queryFactory
             .select(new QReportView(
                 report.id,
@@ -76,5 +78,32 @@ public class ReportQueryRepository {
     private BooleanExpression createdAtLoe(LocalDate createdDateLoe) {
         return createdDateLoe != null ? report.createdAt.loe(
             createdDateLoe.plusDays(1).atStartOfDay().minusSeconds(1)) : null;
+    }
+
+    public Optional<ReportDetailView> findReportDetailView(final long id) {
+        final ReportDetailView view = queryFactory
+            .select(new QReportDetailView(
+                report.id,
+                report.version,
+                report.reporterId,
+                reporterMember.profile.nickname.value,
+                report.reporteeId,
+                reporteeMember.profile.nickname.value,
+                report.reason.stringValue(),
+                report.result.stringValue(),
+                report.content,
+                report.createdAt
+            ))
+            .from(report)
+            .where(idEq(id))
+            .leftJoin(reporterMember).on(report.reporterId.eq(reporterMember.id))
+            .leftJoin(reporteeMember).on(report.reporteeId.eq(reporteeMember.id))
+            .fetchOne();
+
+        return Optional.ofNullable(view);
+    }
+
+    private BooleanExpression idEq(long id) {
+        return report.id.eq(id);
     }
 }

--- a/src/main/java/atwoz/atwoz/report/query/condition/ReportSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/report/query/condition/ReportSearchCondition.java
@@ -1,8 +1,12 @@
 package atwoz.atwoz.report.query.condition;
 
+import atwoz.atwoz.report.command.domain.ReportResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 
 public record ReportSearchCondition(
+    @Schema(implementation = ReportResult.class)
     String result,
     LocalDate createdAtGoe,
     LocalDate createdAtLoe

--- a/src/main/java/atwoz/atwoz/report/query/condition/ReportSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/report/query/condition/ReportSearchCondition.java
@@ -1,0 +1,10 @@
+package atwoz.atwoz.report.query.condition;
+
+import java.time.LocalDate;
+
+public record ReportSearchCondition(
+    String result,
+    LocalDate createdAtGoe,
+    LocalDate createdAtLoe
+) {
+}

--- a/src/main/java/atwoz/atwoz/report/query/view/ReportDetailView.java
+++ b/src/main/java/atwoz/atwoz/report/query/view/ReportDetailView.java
@@ -1,0 +1,23 @@
+package atwoz.atwoz.report.query.view;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+
+public record ReportDetailView(
+    Long id,
+    Long version,
+    Long reporterId,
+    String reporterNickname,
+    Long reporteeId,
+    String reporteeNickname,
+    String reason,
+    String result,
+    String content,
+    LocalDateTime createdAt
+) {
+    @QueryProjection
+    public ReportDetailView {
+        // QueryDSL에서 사용하기 위한 생성자
+    }
+}

--- a/src/main/java/atwoz/atwoz/report/query/view/ReportDetailView.java
+++ b/src/main/java/atwoz/atwoz/report/query/view/ReportDetailView.java
@@ -1,6 +1,9 @@
 package atwoz.atwoz.report.query.view;
 
+import atwoz.atwoz.report.command.domain.ReportReasonType;
+import atwoz.atwoz.report.command.domain.ReportResult;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +14,9 @@ public record ReportDetailView(
     String reporterNickname,
     Long reporteeId,
     String reporteeNickname,
+    @Schema(implementation = ReportReasonType.class)
     String reason,
+    @Schema(implementation = ReportResult.class)
     String result,
     String content,
     LocalDateTime createdAt

--- a/src/main/java/atwoz/atwoz/report/query/view/ReportView.java
+++ b/src/main/java/atwoz/atwoz/report/query/view/ReportView.java
@@ -1,0 +1,21 @@
+package atwoz.atwoz.report.query.view;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+
+public record ReportView(
+    Long id,
+    Long reporterId,
+    String reporterNickname,
+    Long reporteeId,
+    String reporteeNickname,
+    String reason,
+    String result,
+    LocalDateTime createdAt
+) {
+    @QueryProjection
+    public ReportView {
+        // QueryDSL에서 사용하기 위한 생성자
+    }
+}

--- a/src/main/java/atwoz/atwoz/report/query/view/ReportView.java
+++ b/src/main/java/atwoz/atwoz/report/query/view/ReportView.java
@@ -1,6 +1,9 @@
 package atwoz.atwoz.report.query.view;
 
+import atwoz.atwoz.report.command.domain.ReportReasonType;
+import atwoz.atwoz.report.command.domain.ReportResult;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
@@ -10,7 +13,9 @@ public record ReportView(
     String reporterNickname,
     Long reporteeId,
     String reporteeNickname,
+    @Schema(implementation = ReportReasonType.class)
     String reason,
+    @Schema(implementation = ReportResult.class)
     String result,
     LocalDateTime createdAt
 ) {

--- a/src/test/java/atwoz/atwoz/report/command/application/AdminReportServiceTest.java
+++ b/src/test/java/atwoz/atwoz/report/command/application/AdminReportServiceTest.java
@@ -3,8 +3,8 @@ package atwoz.atwoz.report.command.application;
 import atwoz.atwoz.report.command.application.exception.ReportNotFoundException;
 import atwoz.atwoz.report.command.domain.Report;
 import atwoz.atwoz.report.command.domain.ReportCommandRepository;
-import atwoz.atwoz.report.presentation.dto.ReportApproveRequest;
-import atwoz.atwoz.report.presentation.dto.ReportRejectRequest;
+import atwoz.atwoz.report.command.domain.exception.InvalidReportResultException;
+import atwoz.atwoz.report.presentation.dto.ReportResultUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,6 +16,7 @@ import org.springframework.dao.OptimisticLockingFailureException;
 
 import java.util.Optional;
 
+import static atwoz.atwoz.report.command.domain.ReportResult.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -25,170 +26,168 @@ class AdminReportServiceTest {
     @Mock
     private ReportCommandRepository reportCommandRepository;
 
-    @Mock
-    private Report report;
-
     @InjectMocks
     private AdminReportService adminReportService;
 
     @Nested
-    @DisplayName("approve 메서드")
-    class ApproveTests {
+    @DisplayName("updateResult 메서드 테스트")
+    class UpdateResultTests {
+        private final long reportId = 1L;
+        private final long adminId = 100L;
+        private final long version = 0L;
+        private Report mockReport;
+
+        private void stubFindReport() {
+            mockReport = mock(Report.class);
+            when(reportCommandRepository.findById(reportId))
+                .thenReturn(Optional.of(mockReport));
+        }
 
         @Test
-        @DisplayName("존재하지 않는 신고를 승인하면 ReportNotFoundException을 던진다")
-        void shouldThrowReportNotFoundExceptionWhenReportNotFound() {
+        @DisplayName("정상 케이스: 결과가 REJECTED일 때 report.reject 호출")
+        void shouldRejectReportWhenResultIsRejected() {
             // given
-            long reportId = 1L;
-            ReportApproveRequest request = new ReportApproveRequest(0L);
-            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.empty());
+            stubFindReport();
+            var request = new ReportResultUpdateRequest(version, REJECTED.name());
+            when(mockReport.hasVersionConflict(version)).thenReturn(false);
+
+            // when
+            adminReportService.updateResult(reportId, request, adminId);
+
+            // then
+            verify(mockReport).reject(adminId);
+            verify(mockReport, never()).warn(anyLong());
+            verify(mockReport, never()).suspend(anyLong());
+            verify(reportCommandRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("정상 케이스: 결과가 WARNED일 때 report.warn 호출")
+        void shouldWarnReportWhenResultIsWarned() {
+            // given
+            stubFindReport();
+            var request = new ReportResultUpdateRequest(version, WARNED.name());
+            when(mockReport.hasVersionConflict(version)).thenReturn(false);
+
+            // when
+            adminReportService.updateResult(reportId, request, adminId);
+
+            // then
+            verify(mockReport).warn(adminId);
+            verify(mockReport, never()).reject(anyLong());
+            verify(mockReport, never()).suspend(anyLong());
+            verify(reportCommandRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("정상 케이스: 결과가 SUSPENDED일 때 report.suspend 호출")
+        void shouldSuspendReportWhenResultIsSuspended() {
+            // given
+            stubFindReport();
+            var request = new ReportResultUpdateRequest(version, SUSPENDED.name());
+            when(mockReport.hasVersionConflict(version)).thenReturn(false);
+
+            // when
+            adminReportService.updateResult(reportId, request, adminId);
+
+            // then
+            verify(mockReport).suspend(adminId);
+            verify(mockReport, never()).reject(anyLong());
+            verify(mockReport, never()).warn(anyLong());
+            verify(reportCommandRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("예외 케이스: PENDING 결과는 설정 불가")
+        void shouldThrowInvalidReportResultExceptionWhenResultIsPending() {
+            // given
+            stubFindReport();
+            var request = new ReportResultUpdateRequest(version, PENDING.name());
+            when(mockReport.hasVersionConflict(version)).thenReturn(false);
 
             // when & then
-            assertThatThrownBy(() -> adminReportService.approve(reportId, request, 100L))
+            assertThatThrownBy(() ->
+                adminReportService.updateResult(reportId, request, adminId))
+                .isInstanceOf(InvalidReportResultException.class)
+                .hasMessageContaining("PENDING 으로 결과를 설정할 수 없습니다.");
+
+            verify(mockReport, never()).reject(anyLong());
+            verify(mockReport, never()).warn(anyLong());
+            verify(mockReport, never()).suspend(anyLong());
+            verify(reportCommandRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("예외 케이스: 알 수 없는 결과는 설정 불가")
+        void shouldThrowInvalidReportResultExceptionWhenResultIsUnknown() {
+            // given
+            stubFindReport();
+            var request = new ReportResultUpdateRequest(version, "UNKNOWN");
+            when(mockReport.hasVersionConflict(version)).thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminReportService.updateResult(reportId, request, adminId))
+                .isInstanceOf(InvalidReportResultException.class)
+                .hasMessageContaining("Invalid report result: UNKNOWN");
+
+            verify(mockReport, never()).reject(anyLong());
+            verify(mockReport, never()).warn(anyLong());
+            verify(mockReport, never()).suspend(anyLong());
+            verify(reportCommandRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("예외 케이스: 버전 충돌 시 OptimisticLockingFailureException 발생")
+        void shouldThrowOptimisticLockingFailureExceptionWhenVersionConflict() {
+            // given
+            stubFindReport();
+            var request = new ReportResultUpdateRequest(version, REJECTED.name());
+            when(mockReport.hasVersionConflict(version)).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminReportService.updateResult(reportId, request, adminId))
+                .isInstanceOf(OptimisticLockingFailureException.class)
+                .hasMessageContaining("신고를 처리할 수 없습니다.");
+
+            verify(mockReport, never()).reject(anyLong());
+            verify(mockReport, never()).warn(anyLong());
+            verify(mockReport, never()).suspend(anyLong());
+            verify(reportCommandRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("예외 케이스: 존재하지 않는 리포트 ID면 ReportNotFoundException 발생")
+        void shouldThrowReportNotFoundExceptionWhenReportNotFound() {
+            // given
+            when(reportCommandRepository.findById(reportId))
+                .thenReturn(Optional.empty());
+            var request = new ReportResultUpdateRequest(version, REJECTED.name());
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminReportService.updateResult(reportId, request, adminId))
                 .isInstanceOf(ReportNotFoundException.class);
 
             verify(reportCommandRepository).findById(reportId);
-            verify(report, never()).hasVersionConflict(anyLong());
-            verify(report, never()).approve(anyLong());
+            verify(reportCommandRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("버전이 일치하지 않으면 OptimisticLockingFailureException을 던진다")
-        void shouldThrowOptimisticLockingFailureExceptionWhenVersionConflict() {
-            // given
-            long reportId = 2L;
-            ReportApproveRequest request = new ReportApproveRequest(5L);
-            long adminId = 200L;
-            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
-            when(report.hasVersionConflict(request.version())).thenReturn(true);
-
-            // when & then
-            assertThatThrownBy(() ->
-                adminReportService.approve(reportId, request, adminId)
-            ).isInstanceOf(OptimisticLockingFailureException.class)
-                .hasMessage("신고를 처리할 수 없습니다.");
-
-            verify(reportCommandRepository).findById(reportId);
-            verify(report).hasVersionConflict(request.version());
-            verify(report, never()).approve(anyLong());
-        }
-
-        @Test
-        @DisplayName("유효한 요청이면 report.approve를 호출한다")
-        void shouldApproveReportWhenValid() {
-            // given
-            long reportId = 3L;
-            ReportApproveRequest request = new ReportApproveRequest(1L);
-            long adminId = 300L;
-            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
-            when(report.hasVersionConflict(request.version())).thenReturn(false);
-
-            // when
-            adminReportService.approve(reportId, request, adminId);
-
-            // then
-            verify(reportCommandRepository).findById(reportId);
-            verify(report).hasVersionConflict(request.version());
-            verify(report).approve(adminId);
-        }
-
-        @Test
-        @DisplayName("요청 객체가 null이면 NullPointerException을 던진다")
+        @DisplayName("예외 케이스: null 요청 객체 전달 시 NPE 발생")
         void shouldThrowNullPointerExceptionWhenRequestIsNull() {
             // given
-            long reportId = 4L;
-            long adminId = 400L;
-            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
+            stubFindReport();
 
             // when & then
             assertThatThrownBy(() ->
-                adminReportService.approve(reportId, null, adminId)
-            ).isInstanceOf(NullPointerException.class);
+                adminReportService.updateResult(reportId, null, adminId))
+                .isInstanceOf(NullPointerException.class);
 
             verify(reportCommandRepository).findById(reportId);
-            verify(report, never()).hasVersionConflict(anyLong());
-            verify(report, never()).approve(anyLong());
-        }
-    }
-
-    @Nested
-    @DisplayName("reject 메서드")
-    class RejectTests {
-
-        @Test
-        @DisplayName("존재하지 않는 신고를 거부하면 ReportNotFoundException을 던진다")
-        void shouldThrowReportNotFoundExceptionWhenReportNotFound() {
-            // given
-            long reportId = 5L;
-            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.empty());
-            ReportRejectRequest request = new ReportRejectRequest(0L);
-
-            // when & then
-            assertThatThrownBy(() ->
-                adminReportService.reject(reportId, request, 101L)
-            ).isInstanceOf(ReportNotFoundException.class);
-
-            verify(reportCommandRepository).findById(reportId);
-            verify(report, never()).hasVersionConflict(anyLong());
-            verify(report, never()).reject(anyLong());
-        }
-
-        @Test
-        @DisplayName("버전이 일치하지 않으면 OptimisticLockingFailureException을 던진다")
-        void shouldThrowOptimisticLockingFailureExceptionWhenVersionConflict() {
-            // given
-            long reportId = 6L;
-            ReportRejectRequest request = new ReportRejectRequest(5L);
-            long adminId = 202L;
-            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
-            when(report.hasVersionConflict(request.version())).thenReturn(true);
-
-            // when & then
-            assertThatThrownBy(() ->
-                adminReportService.reject(reportId, request, adminId)
-            ).isInstanceOf(OptimisticLockingFailureException.class)
-                .hasMessage("신고를 처리할 수 없습니다.");
-
-            verify(reportCommandRepository).findById(reportId);
-            verify(report).hasVersionConflict(request.version());
-            verify(report, never()).reject(anyLong());
-        }
-
-        @Test
-        @DisplayName("유효한 요청이면 report.reject를 호출한다")
-        void shouldRejectReportWhenValid() {
-            // given
-            long reportId = 7L;
-            ReportRejectRequest request = new ReportRejectRequest(1L);
-            long adminId = 303L;
-            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
-            when(report.hasVersionConflict(request.version())).thenReturn(false);
-
-            // when
-            adminReportService.reject(reportId, request, adminId);
-
-            // then
-            verify(reportCommandRepository).findById(reportId);
-            verify(report).hasVersionConflict(request.version());
-            verify(report).reject(adminId);
-        }
-
-        @Test
-        @DisplayName("요청 객체가 null이면 NullPointerException을 던진다")
-        void shouldThrowNullPointerExceptionWhenRequestIsNull() {
-            // given
-            long reportId = 8L;
-            long adminId = 404L;
-            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
-
-            // when & then
-            assertThatThrownBy(() ->
-                adminReportService.reject(reportId, null, adminId)
-            ).isInstanceOf(NullPointerException.class);
-
-            verify(reportCommandRepository).findById(reportId);
-            verify(report, never()).hasVersionConflict(anyLong());
-            verify(report, never()).reject(anyLong());
+            verify(mockReport, never()).hasVersionConflict(anyLong());
+            verify(reportCommandRepository, never()).save(any());
         }
     }
 }

--- a/src/test/java/atwoz/atwoz/report/command/application/AdminReportServiceTest.java
+++ b/src/test/java/atwoz/atwoz/report/command/application/AdminReportServiceTest.java
@@ -1,0 +1,195 @@
+package atwoz.atwoz.report.command.application;
+
+import atwoz.atwoz.report.command.application.exception.ReportNotFoundException;
+import atwoz.atwoz.report.command.domain.Report;
+import atwoz.atwoz.report.command.domain.ReportCommandRepository;
+import atwoz.atwoz.report.presentation.dto.ReportApproveRequest;
+import atwoz.atwoz.report.presentation.dto.ReportRejectRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminReportServiceTest {
+
+    @Mock
+    private ReportCommandRepository reportCommandRepository;
+
+    @Mock
+    private Report report;
+
+    @InjectMocks
+    private AdminReportService adminReportService;
+
+    @Nested
+    @DisplayName("approve 메서드")
+    class ApproveTests {
+
+        @Test
+        @DisplayName("존재하지 않는 신고를 승인하면 ReportNotFoundException을 던진다")
+        void shouldThrowReportNotFoundExceptionWhenReportNotFound() {
+            // given
+            long reportId = 1L;
+            ReportApproveRequest request = new ReportApproveRequest(0L);
+            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.empty());
+
+
+            // when & then
+            assertThatThrownBy(() -> adminReportService.approve(reportId, request, 100L))
+                .isInstanceOf(ReportNotFoundException.class);
+
+            verify(reportCommandRepository).findById(reportId);
+            verify(report, never()).hasVersionConflict(anyLong());
+            verify(report, never()).approve(anyLong());
+        }
+
+        @Test
+        @DisplayName("버전이 일치하지 않으면 OptimisticLockingFailureException을 던진다")
+        void shouldThrowOptimisticLockingFailureExceptionWhenVersionConflict() {
+            // given
+            long reportId = 2L;
+            ReportApproveRequest request = new ReportApproveRequest(5L);
+            long adminId = 200L;
+            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
+            when(report.hasVersionConflict(request.version())).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminReportService.approve(reportId, request, adminId)
+            ).isInstanceOf(OptimisticLockingFailureException.class)
+                .hasMessage("신고를 처리할 수 없습니다.");
+
+            verify(reportCommandRepository).findById(reportId);
+            verify(report).hasVersionConflict(request.version());
+            verify(report, never()).approve(anyLong());
+        }
+
+        @Test
+        @DisplayName("유효한 요청이면 report.approve를 호출한다")
+        void shouldApproveReportWhenValid() {
+            // given
+            long reportId = 3L;
+            ReportApproveRequest request = new ReportApproveRequest(1L);
+            long adminId = 300L;
+            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
+            when(report.hasVersionConflict(request.version())).thenReturn(false);
+
+            // when
+            adminReportService.approve(reportId, request, adminId);
+
+            // then
+            verify(reportCommandRepository).findById(reportId);
+            verify(report).hasVersionConflict(request.version());
+            verify(report).approve(adminId);
+        }
+
+        @Test
+        @DisplayName("요청 객체가 null이면 NullPointerException을 던진다")
+        void shouldThrowNullPointerExceptionWhenRequestIsNull() {
+            // given
+            long reportId = 4L;
+            long adminId = 400L;
+            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminReportService.approve(reportId, null, adminId)
+            ).isInstanceOf(NullPointerException.class);
+
+            verify(reportCommandRepository).findById(reportId);
+            verify(report, never()).hasVersionConflict(anyLong());
+            verify(report, never()).approve(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("reject 메서드")
+    class RejectTests {
+
+        @Test
+        @DisplayName("존재하지 않는 신고를 거부하면 ReportNotFoundException을 던진다")
+        void shouldThrowReportNotFoundExceptionWhenReportNotFound() {
+            // given
+            long reportId = 5L;
+            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.empty());
+            ReportRejectRequest request = new ReportRejectRequest(0L);
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminReportService.reject(reportId, request, 101L)
+            ).isInstanceOf(ReportNotFoundException.class);
+
+            verify(reportCommandRepository).findById(reportId);
+            verify(report, never()).hasVersionConflict(anyLong());
+            verify(report, never()).reject(anyLong());
+        }
+
+        @Test
+        @DisplayName("버전이 일치하지 않으면 OptimisticLockingFailureException을 던진다")
+        void shouldThrowOptimisticLockingFailureExceptionWhenVersionConflict() {
+            // given
+            long reportId = 6L;
+            ReportRejectRequest request = new ReportRejectRequest(5L);
+            long adminId = 202L;
+            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
+            when(report.hasVersionConflict(request.version())).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminReportService.reject(reportId, request, adminId)
+            ).isInstanceOf(OptimisticLockingFailureException.class)
+                .hasMessage("신고를 처리할 수 없습니다.");
+
+            verify(reportCommandRepository).findById(reportId);
+            verify(report).hasVersionConflict(request.version());
+            verify(report, never()).reject(anyLong());
+        }
+
+        @Test
+        @DisplayName("유효한 요청이면 report.reject를 호출한다")
+        void shouldRejectReportWhenValid() {
+            // given
+            long reportId = 7L;
+            ReportRejectRequest request = new ReportRejectRequest(1L);
+            long adminId = 303L;
+            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
+            when(report.hasVersionConflict(request.version())).thenReturn(false);
+
+            // when
+            adminReportService.reject(reportId, request, adminId);
+
+            // then
+            verify(reportCommandRepository).findById(reportId);
+            verify(report).hasVersionConflict(request.version());
+            verify(report).reject(adminId);
+        }
+
+        @Test
+        @DisplayName("요청 객체가 null이면 NullPointerException을 던진다")
+        void shouldThrowNullPointerExceptionWhenRequestIsNull() {
+            // given
+            long reportId = 8L;
+            long adminId = 404L;
+            when(reportCommandRepository.findById(reportId)).thenReturn(Optional.of(report));
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminReportService.reject(reportId, null, adminId)
+            ).isInstanceOf(NullPointerException.class);
+
+            verify(reportCommandRepository).findById(reportId);
+            verify(report, never()).hasVersionConflict(anyLong());
+            verify(report, never()).reject(anyLong());
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/report/command/application/AdminReportServiceTest.java
+++ b/src/test/java/atwoz/atwoz/report/command/application/AdminReportServiceTest.java
@@ -43,7 +43,6 @@ class AdminReportServiceTest {
             ReportApproveRequest request = new ReportApproveRequest(0L);
             when(reportCommandRepository.findById(reportId)).thenReturn(Optional.empty());
 
-
             // when & then
             assertThatThrownBy(() -> adminReportService.approve(reportId, request, 100L))
                 .isInstanceOf(ReportNotFoundException.class);

--- a/src/test/java/atwoz/atwoz/report/command/application/ReportServiceTest.java
+++ b/src/test/java/atwoz/atwoz/report/command/application/ReportServiceTest.java
@@ -6,7 +6,7 @@ import atwoz.atwoz.report.command.application.exception.ReportAlreadyExistsExcep
 import atwoz.atwoz.report.command.domain.ReportCommandRepository;
 import atwoz.atwoz.report.command.domain.ReportReasonType;
 import atwoz.atwoz.report.command.domain.exception.InvalidReportReasonTypeException;
-import atwoz.atwoz.report.presentation.dto.ReportRequest;
+import atwoz.atwoz.report.presentation.dto.ReportCreateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +36,7 @@ class ReportServiceTest {
         long reporteeId = 1L;
         long reporterId = 2L;
         ReportReasonType reportReasonType = ReportReasonType.ETC;
-        ReportRequest request = new ReportRequest(reporteeId, reportReasonType.name(), "content");
+        ReportCreateRequest request = new ReportCreateRequest(reporteeId, reportReasonType.name(), "content");
 
         // when, then
         assertThatThrownBy(() -> reportService.report(request, reporterId))
@@ -52,7 +52,7 @@ class ReportServiceTest {
         long reporteeId = 1L;
         long reporterId = 2L;
         ReportReasonType reportReasonType = ReportReasonType.ETC;
-        ReportRequest request = new ReportRequest(reporteeId, reportReasonType.name(), "content");
+        ReportCreateRequest request = new ReportCreateRequest(reporteeId, reportReasonType.name(), "content");
 
         when(memberCommandRepository.existsById(reporteeId)).thenReturn(true);
         when(reportCommandRepository.existsByReporterIdAndReporteeId(reporterId, reporteeId)).thenReturn(true);
@@ -71,7 +71,7 @@ class ReportServiceTest {
         long reporteeId = 1L;
         long reporterId = 2L;
         String invalidReason = "INVALID_REASON";
-        ReportRequest request = new ReportRequest(reporteeId, invalidReason, "content");
+        ReportCreateRequest request = new ReportCreateRequest(reporteeId, invalidReason, "content");
 
         when(memberCommandRepository.existsById(reporteeId)).thenReturn(true);
 
@@ -89,7 +89,7 @@ class ReportServiceTest {
         long reporteeId = 1L;
         long reporterId = 2L;
         ReportReasonType reportReasonType = ReportReasonType.ETC;
-        ReportRequest request = new ReportRequest(reporteeId, reportReasonType.name(), "content");
+        ReportCreateRequest request = new ReportCreateRequest(reporteeId, reportReasonType.name(), "content");
 
         when(memberCommandRepository.existsById(reporteeId)).thenReturn(true);
 

--- a/src/test/java/atwoz/atwoz/report/query/ReportQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/report/query/ReportQueryRepositoryTest.java
@@ -50,10 +50,12 @@ class ReportQueryRepositoryTest {
 
     private Report createReport(Member reporter, Member reportee, ReportReasonType reason, ReportResult result) {
         Report report = Report.of(reporter.getId(), reportee.getId(), reason, "test content");
-        if (result == ReportResult.BANNED) {
-            report.approve(1L);
+        if (result == ReportResult.SUSPENDED) {
+            report.suspend(1L);
         } else if (result == ReportResult.REJECTED) {
             report.reject(1L);
+        } else if (result == ReportResult.WARNED) {
+            report.warn(1L);
         }
         entityManager.persist(report);
         return report;
@@ -102,7 +104,7 @@ class ReportQueryRepositoryTest {
             Member reporter = createMember("01000000001", "Reporter1");
             Member reportee = createMember("01000000002", "Reportee1");
             createReport(reporter, reportee, ReportReasonType.INAPPROPRIATE_IMAGE, ReportResult.PENDING);
-            createReport(reporter, reportee, ReportReasonType.INAPPROPRIATE_IMAGE, ReportResult.BANNED);
+            createReport(reporter, reportee, ReportReasonType.INAPPROPRIATE_IMAGE, ReportResult.SUSPENDED);
             entityManager.flush();
 
             ReportSearchCondition condition = new ReportSearchCondition(
@@ -128,7 +130,7 @@ class ReportQueryRepositoryTest {
             Member reporter = createMember("01000000001", "Reporter1");
             Member reportee = createMember("01000000002", "Reportee1");
             createReport(reporter, reportee, ReportReasonType.OFFENSIVE_LANGUAGE, ReportResult.REJECTED);
-            createReport(reporter, reportee, ReportReasonType.OFFENSIVE_LANGUAGE, ReportResult.BANNED);
+            createReport(reporter, reportee, ReportReasonType.OFFENSIVE_LANGUAGE, ReportResult.SUSPENDED);
             entityManager.flush();
 
             ReportSearchCondition condition = new ReportSearchCondition(

--- a/src/test/java/atwoz/atwoz/report/query/ReportQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/report/query/ReportQueryRepositoryTest.java
@@ -1,0 +1,207 @@
+package atwoz.atwoz.report.query;
+
+import atwoz.atwoz.QuerydslConfig;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
+import atwoz.atwoz.member.command.domain.member.vo.Nickname;
+import atwoz.atwoz.report.command.domain.Report;
+import atwoz.atwoz.report.command.domain.ReportReasonType;
+import atwoz.atwoz.report.command.domain.ReportResult;
+import atwoz.atwoz.report.query.condition.ReportSearchCondition;
+import atwoz.atwoz.report.query.view.ReportView;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, ReportQueryRepository.class})
+class ReportQueryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private ReportQueryRepository reportQueryRepository;
+
+    private Member createMember(String phoneNumber, String nickname) {
+        Member member = Member.fromPhoneNumber(phoneNumber);
+        MemberProfile profile = MemberProfile.builder()
+            .nickname(Nickname.from(nickname))
+            .build();
+        member.updateProfile(profile);
+        entityManager.persist(member);
+        return member;
+    }
+
+    private Report createReport(Member reporter, Member reportee, ReportReasonType reason, ReportResult result) {
+        Report report = Report.of(reporter.getId(), reportee.getId(), reason, "test content");
+        if (result == ReportResult.BANNED) {
+            report.approve(1L);
+        } else if (result == ReportResult.REJECTED) {
+            report.reject(1L);
+        }
+        entityManager.persist(report);
+        return report;
+    }
+
+    @Nested
+    @DisplayName("getPage 메소드 테스트")
+    class GetPageMethodTests {
+        @Test
+        @DisplayName("리포트 조회 시 모든 필드가 정확히 매핑되어 DTO 반환")
+        void shouldReturnExactReportView() {
+            // given
+            Member reporter = createMember("01000000001", "Reporter1");
+            Member reportee = createMember("01000000002", "Reportee1");
+            Report report = createReport(reporter, reportee, ReportReasonType.ETC, ReportResult.PENDING);
+            entityManager.flush();
+
+            ReportSearchCondition condition = new ReportSearchCondition(
+                null,
+                null,
+                null
+            );
+
+            // when
+            Page<ReportView> page = reportQueryRepository.getPage(condition, PageRequest.of(0, 10));
+            List<ReportView> content = page.getContent();
+
+            // then
+            assertThat(content).hasSize(1);
+            ReportView view = content.get(0);
+            assertThat(view.id()).isEqualTo(report.getId());
+            assertThat(view.reporterId()).isEqualTo(reporter.getId());
+            assertThat(view.reporterNickname()).isEqualTo(reporter.getProfile().getNickname().getValue());
+            assertThat(view.reporteeId()).isEqualTo(reportee.getId());
+            assertThat(view.reporteeNickname()).isEqualTo(reportee.getProfile().getNickname().getValue());
+            assertThat(view.reason()).isEqualTo(report.getReason().name());
+            assertThat(view.result()).isEqualTo(report.getResult().name());
+            assertThat(view.createdAt())
+                .isCloseTo(report.getCreatedAt(), within(1, ChronoUnit.MICROS));
+        }
+
+        @Test
+        @DisplayName("결과가 PENDING인 경우만 반환")
+        void shouldReturnRecordsWhenResultMatches() {
+            // given
+            Member reporter = createMember("01000000001", "Reporter1");
+            Member reportee = createMember("01000000002", "Reportee1");
+            createReport(reporter, reportee, ReportReasonType.INAPPROPRIATE_IMAGE, ReportResult.PENDING);
+            createReport(reporter, reportee, ReportReasonType.INAPPROPRIATE_IMAGE, ReportResult.BANNED);
+            entityManager.flush();
+
+            ReportSearchCondition condition = new ReportSearchCondition(
+                ReportResult.PENDING.name(),
+                null,
+                null
+            );
+
+            // when
+            Page<ReportView> page = reportQueryRepository.getPage(condition, PageRequest.of(0, 10));
+
+            // then
+            assertThat(page.getTotalElements()).isEqualTo(1);
+            assertThat(page.getContent())
+                .extracting(ReportView::result)
+                .allMatch(res -> res.equals(ReportResult.PENDING.name()));
+        }
+
+        @Test
+        @DisplayName("result가 null이면 전체 반환")
+        void shouldReturnAllWhenResultIsNull() {
+            // given
+            Member reporter = createMember("01000000001", "Reporter1");
+            Member reportee = createMember("01000000002", "Reportee1");
+            createReport(reporter, reportee, ReportReasonType.OFFENSIVE_LANGUAGE, ReportResult.REJECTED);
+            createReport(reporter, reportee, ReportReasonType.OFFENSIVE_LANGUAGE, ReportResult.BANNED);
+            entityManager.flush();
+
+            ReportSearchCondition condition = new ReportSearchCondition(
+                null,
+                null,
+                null
+            );
+
+            // when
+            Page<ReportView> page = reportQueryRepository.getPage(condition, PageRequest.of(0, 10));
+
+            // then
+            assertThat(page.getTotalElements()).isEqualTo(2);
+        }
+
+
+        @Test
+        @DisplayName("createdAt >= 지정 날짜 이후인 경우 반환")
+        void shouldReturnRecordsWithCreatedAtAfterOrEqual() {
+            // given
+            Member reporter = createMember("01000000001", "Reporter1");
+            Member reportee = createMember("01000000002", "Reportee1");
+            Report report = createReport(reporter, reportee, ReportReasonType.CONTACT_IN_PROFILE, ReportResult.PENDING);
+            entityManager.flush();
+
+            LocalDate reportDate = report.getCreatedAt().toLocalDate();
+            ReportSearchCondition condSame = new ReportSearchCondition(
+                null,
+                reportDate,
+                null
+            );
+            ReportSearchCondition condNext = new ReportSearchCondition(
+                null,
+                reportDate.plusDays(1),
+                null
+            );
+
+            // when
+            Page<ReportView> pageSame = reportQueryRepository.getPage(condSame, PageRequest.of(0, 10));
+            Page<ReportView> pageNext = reportQueryRepository.getPage(condNext, PageRequest.of(0, 10));
+
+            // then
+            assertThat(pageSame.getTotalElements()).isEqualTo(1);
+            assertThat(pageNext.getTotalElements()).isZero();
+        }
+
+        @Test
+        @DisplayName("createdAt <= 지정 날짜 이전인 경우 반환")
+        void shouldReturnRecordsWithCreatedAtBeforeOrEqual() {
+            // given
+            Member reporter = createMember("01000000001", "Reporter1");
+            Member reportee = createMember("01000000002", "Reportee1");
+            Report report = createReport(reporter, reportee, ReportReasonType.EXPLICIT_CONTENT, ReportResult.REJECTED);
+            entityManager.flush();
+            LocalDate reportDate = report.getCreatedAt().toLocalDate();
+
+            ReportSearchCondition condSame = new ReportSearchCondition(
+                null,
+                null,
+                reportDate
+            );
+
+            ReportSearchCondition condPrev = new ReportSearchCondition(
+                null,
+                null,
+                reportDate.minusDays(1)
+            );
+
+            // when
+            Page<ReportView> pageSame = reportQueryRepository.getPage(condSame, PageRequest.of(0, 10));
+            Page<ReportView> pagePrev = reportQueryRepository.getPage(condPrev, PageRequest.of(0, 10));
+
+            // then
+            assertThat(pageSame.getTotalElements()).isEqualTo(1);
+            assertThat(pagePrev.getTotalElements()).isZero();
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/report/query/ReportQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/report/query/ReportQueryRepositoryTest.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.report.query;
 
 import atwoz.atwoz.QuerydslConfig;
+import atwoz.atwoz.common.event.Events;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
 import atwoz.atwoz.member.command.domain.member.vo.Nickname;
@@ -10,9 +11,9 @@ import atwoz.atwoz.report.command.domain.ReportResult;
 import atwoz.atwoz.report.query.condition.ReportSearchCondition;
 import atwoz.atwoz.report.query.view.ReportDetailView;
 import atwoz.atwoz.report.query.view.ReportView;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -32,11 +33,23 @@ import static org.assertj.core.api.Assertions.within;
 @Import({QuerydslConfig.class, ReportQueryRepository.class})
 class ReportQueryRepositoryTest {
 
+    private static MockedStatic<Events> eventsMockedStatic;
     @Autowired
     private TestEntityManager entityManager;
-
     @Autowired
     private ReportQueryRepository reportQueryRepository;
+
+    @BeforeEach
+    void setUp() {
+        eventsMockedStatic = Mockito.mockStatic(Events.class);
+        eventsMockedStatic.when(() -> Events.raise(Mockito.any()))
+            .thenAnswer(invocation -> null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        eventsMockedStatic.close();
+    }
 
     private Member createMember(String phoneNumber, String nickname) {
         Member member = Member.fromPhoneNumber(phoneNumber);

--- a/src/test/java/atwoz/atwoz/report/query/ReportQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/report/query/ReportQueryRepositoryTest.java
@@ -8,6 +8,7 @@ import atwoz.atwoz.report.command.domain.Report;
 import atwoz.atwoz.report.command.domain.ReportReasonType;
 import atwoz.atwoz.report.command.domain.ReportResult;
 import atwoz.atwoz.report.query.condition.ReportSearchCondition;
+import atwoz.atwoz.report.query.view.ReportDetailView;
 import atwoz.atwoz.report.query.view.ReportView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.PageRequest;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -202,6 +204,52 @@ class ReportQueryRepositoryTest {
             // then
             assertThat(pageSame.getTotalElements()).isEqualTo(1);
             assertThat(pagePrev.getTotalElements()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("findReportDetailView 메소드 테스트")
+    class FindReportDetailViewMethodTests {
+        @Test
+        @DisplayName("리포트 조회 시 모든 필드가 정확히 매핑되어 DTO 반환")
+        void shouldReturnExactReportDetailView() {
+            // given
+            Member reporter = createMember("01000000001", "Reporter1");
+            Member reportee = createMember("01000000002", "Reportee1");
+            Report report = createReport(reporter, reportee, ReportReasonType.ETC, ReportResult.PENDING);
+            entityManager.flush();
+
+            // when
+            Optional<ReportDetailView> optionalView = reportQueryRepository.findReportDetailView(report.getId());
+
+            // then
+            assertThat(optionalView).isPresent();
+
+            ReportDetailView view = optionalView.get();
+            assertThat(view.id()).isEqualTo(report.getId());
+            assertThat(view.version()).isEqualTo(report.getVersion());
+            assertThat(view.reporterId()).isEqualTo(reporter.getId());
+            assertThat(view.reporterNickname()).isEqualTo(reporter.getProfile().getNickname().getValue());
+            assertThat(view.reporteeId()).isEqualTo(reportee.getId());
+            assertThat(view.reporteeNickname()).isEqualTo(reportee.getProfile().getNickname().getValue());
+            assertThat(view.reason()).isEqualTo(report.getReason().name());
+            assertThat(view.result()).isEqualTo(report.getResult().name());
+            assertThat(view.content()).isEqualTo(report.getContent());
+            assertThat(view.createdAt())
+                .isCloseTo(report.getCreatedAt(), within(1, ChronoUnit.MICROS));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리포트 ID로 조회 시 Optional.empty() 반환")
+        void shouldReturnEmptyOptionalWhenReportNotFound() {
+            // given
+            long nonExistentId = 999L;
+
+            // when
+            Optional<ReportDetailView> optionalView = reportQueryRepository.findReportDetailView(nonExistentId);
+
+            // then
+            assertThat(optionalView).isEmpty();
         }
     }
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 관리자를 위한 신고 내역 조회, 상세보기, 결과 변경(경고/정지/거절) API가 추가되었습니다.
  - 신고 결과 필터, 날짜 범위 등으로 신고 내역을 검색할 수 있습니다.
  - 신고 결과가 '경고', '정지'로 세분화되고, API 문서에 관련 설명이 추가되었습니다.

- **버그 수정**
  - 신고 내역이 존재하지 않을 때 404 에러가 반환됩니다.

- **리팩터**
  - 신고 요청 DTO 명칭이 일관성 있게 변경되었습니다.

- **테스트**
  - 관리자 신고 처리 및 조회 기능에 대한 단위/통합 테스트가 추가되었습니다.

- **문서화**
  - API 문서에 신고 사유 및 결과 관련 설명이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- 신고 처리는 한번만 가능하고 수정이 불가능합니다.
- WARNED으로 처리 시 신고 사유가 `프로필 연락처 노출, 기타` 인 경우에는 알림을 보내지 않습니다.
- 두 케이스에 대해서 알림을 위한 `ReportWarnedEvent` 이벤트를 발행하지 않도록 할지 고민했으나, 이벤트 의도가 알림 보내기가 아니라 신고가 WARNED으로 처리됐다는 것이기 때문에 동일하게 이벤트를 발행하고 handler에서 구분해서 처리하는 방향으로 결정했습니다.
- STOLEN_IMAGE("사진 도용"), INAPPROPRIATE_IMAGE("부적절한 사진") 이 두개는 프로필 사진 권고 알림을 보냅니다.
- EXPLICIT_CONTENT("과도한 성적 컨텐츠"), OFFENSIVE_LANGUAGE("욕설 또는 불쾌한 표현") 이 두개는 게시물 경고 알림을 보냅니다.
