### PR TITLE
인터뷰 답변 수정, 단건 조회 API 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/interview/command/application/answer/InterviewAnswerService.java
+++ b/src/main/java/atwoz/atwoz/interview/command/application/answer/InterviewAnswerService.java
@@ -1,6 +1,8 @@
 package atwoz.atwoz.interview.command.application.answer;
 
+import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerAccessDeniedException;
 import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerAlreadyExistsException;
+import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerNotFoundException;
 import atwoz.atwoz.interview.command.application.question.exception.InterviewQuestionIsNotPublicException;
 import atwoz.atwoz.interview.command.application.question.exception.InterviewQuestionNotFoundException;
 import atwoz.atwoz.interview.command.domain.answer.InterviewAnswer;
@@ -8,6 +10,7 @@ import atwoz.atwoz.interview.command.domain.answer.InterviewAnswerCommandReposit
 import atwoz.atwoz.interview.command.domain.question.InterviewQuestion;
 import atwoz.atwoz.interview.command.domain.question.InterviewQuestionCommandRepository;
 import atwoz.atwoz.interview.presentation.answer.dto.InterviewAnswerSaveRequest;
+import atwoz.atwoz.interview.presentation.answer.dto.InterviewAnswerUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,9 +28,16 @@ public class InterviewAnswerService {
         createInterviewAnswer(request.interviewQuestionId(), memberId, request.answerContent());
     }
 
+    @Transactional
+    public void updateAnswer(Long answerId, InterviewAnswerUpdateRequest request, Long memberId) {
+        InterviewAnswer interviewAnswer = getInterviewAnswer(answerId);
+        validateAnswer(interviewAnswer, memberId);
+        interviewAnswer.updateContent(request.answerContent());
+    }
+
     private void validateQuestion(Long questionId, Long memberId) {
         InterviewQuestion interviewQuestion = interviewQuestionCommandRepository.findById(questionId)
-            .orElseThrow(() -> new InterviewQuestionNotFoundException());
+            .orElseThrow(InterviewQuestionNotFoundException::new);
         if (!interviewQuestion.isPublic()) {
             throw new InterviewQuestionIsNotPublicException();
         }
@@ -46,5 +56,16 @@ public class InterviewAnswerService {
 
     private boolean isFirstInterviewAnswer(Long memberId) {
         return !interviewAnswerCommandRepository.existsByMemberId(memberId);
+    }
+
+    private InterviewAnswer getInterviewAnswer(Long id) {
+        return interviewAnswerCommandRepository.findById(id)
+            .orElseThrow(InterviewAnswerNotFoundException::new);
+    }
+
+    private void validateAnswer(InterviewAnswer interviewAnswer, Long memberId) {
+        if (interviewAnswer.isAnsweredBy(memberId)) {
+            throw new InterviewAnswerAccessDeniedException();
+        }
     }
 }

--- a/src/main/java/atwoz/atwoz/interview/command/application/answer/InterviewAnswerService.java
+++ b/src/main/java/atwoz/atwoz/interview/command/application/answer/InterviewAnswerService.java
@@ -64,7 +64,7 @@ public class InterviewAnswerService {
     }
 
     private void validateAnswer(InterviewAnswer interviewAnswer, Long memberId) {
-        if (interviewAnswer.isAnsweredBy(memberId)) {
+        if (!interviewAnswer.isAnsweredBy(memberId)) {
             throw new InterviewAnswerAccessDeniedException();
         }
     }

--- a/src/main/java/atwoz/atwoz/interview/command/application/answer/exception/InterviewAnswerAccessDeniedException.java
+++ b/src/main/java/atwoz/atwoz/interview/command/application/answer/exception/InterviewAnswerAccessDeniedException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.interview.command.application.answer.exception;
+
+public class InterviewAnswerAccessDeniedException extends RuntimeException {
+    public InterviewAnswerAccessDeniedException() {
+        super("Access denied to the interview answer.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/interview/command/application/answer/exception/InterviewAnswerNotFoundException.java
+++ b/src/main/java/atwoz/atwoz/interview/command/application/answer/exception/InterviewAnswerNotFoundException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.interview.command.application.answer.exception;
+
+public class InterviewAnswerNotFoundException extends RuntimeException {
+    public InterviewAnswerNotFoundException() {
+        super("Interview answer not found.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/interview/command/domain/answer/InterviewAnswer.java
+++ b/src/main/java/atwoz/atwoz/interview/command/domain/answer/InterviewAnswer.java
@@ -36,8 +36,16 @@ public class InterviewAnswer extends BaseEntity {
         return new InterviewAnswer(questionId, memberId, content);
     }
 
+    public void updateContent(String content) {
+        setContent(content);
+    }
+
     public void submitFirstInterviewAnswer() {
         Events.raise(new FirstInterviewSubmittedEvent(memberId));
+    }
+
+    public boolean isAnsweredBy(final long memberId) {
+        return this.memberId.equals(memberId);
     }
 
     private void setQuestionId(@NonNull Long questionId) {

--- a/src/main/java/atwoz/atwoz/interview/command/domain/question/InterviewCategory.java
+++ b/src/main/java/atwoz/atwoz/interview/command/domain/question/InterviewCategory.java
@@ -1,13 +1,7 @@
 package atwoz.atwoz.interview.command.domain.question;
 
 import atwoz.atwoz.interview.command.domain.question.exception.InvalidInterviewCategoryException;
-import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(
-    description = "인터뷰 질문 카테고리",
-    example = "PERSONAL",
-    type = "string"
-)
 public enum InterviewCategory {
     PERSONAL("나"),
     SOCIAL("관계"),

--- a/src/main/java/atwoz/atwoz/interview/command/domain/question/InterviewCategory.java
+++ b/src/main/java/atwoz/atwoz/interview/command/domain/question/InterviewCategory.java
@@ -1,7 +1,13 @@
 package atwoz.atwoz.interview.command.domain.question;
 
 import atwoz.atwoz.interview.command.domain.question.exception.InvalidInterviewCategoryException;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    description = "인터뷰 질문 카테고리",
+    example = "PERSONAL",
+    type = "string"
+)
 public enum InterviewCategory {
     PERSONAL("나"),
     SOCIAL("관계"),

--- a/src/main/java/atwoz/atwoz/interview/presentation/answer/InterviewAnswerController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/answer/InterviewAnswerController.java
@@ -20,7 +20,8 @@ public class InterviewAnswerController {
     private final InterviewAnswerService interviewAnswerService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Void>> saveAnswer(@Valid @RequestBody InterviewAnswerSaveRequest request,
+    public ResponseEntity<BaseResponse<Void>> saveAnswer(
+        @Valid @RequestBody InterviewAnswerSaveRequest request,
         @AuthPrincipal AuthContext authContext
     ) {
         interviewAnswerService.saveAnswer(request, authContext.getId());

--- a/src/main/java/atwoz/atwoz/interview/presentation/answer/InterviewAnswerController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/answer/InterviewAnswerController.java
@@ -2,14 +2,15 @@ package atwoz.atwoz.interview.presentation.answer;
 
 import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.interview.command.application.answer.InterviewAnswerService;
 import atwoz.atwoz.interview.presentation.answer.dto.InterviewAnswerSaveRequest;
+import atwoz.atwoz.interview.presentation.answer.dto.InterviewAnswerUpdateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/interview/answer")
@@ -19,8 +20,20 @@ public class InterviewAnswerController {
     private final InterviewAnswerService interviewAnswerService;
 
     @PostMapping
-    public void saveAnswer(@Valid @RequestBody InterviewAnswerSaveRequest request,
-        @AuthPrincipal AuthContext authContext) {
+    public ResponseEntity<BaseResponse<Void>> saveAnswer(@Valid @RequestBody InterviewAnswerSaveRequest request,
+        @AuthPrincipal AuthContext authContext
+    ) {
         interviewAnswerService.saveAnswer(request, authContext.getId());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<BaseResponse<Void>> updateAnswer(
+        @PathVariable Long id,
+        @Valid @RequestBody InterviewAnswerUpdateRequest request,
+        @AuthPrincipal AuthContext authContext
+    ) {
+        interviewAnswerService.updateAnswer(id, request, authContext.getId());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/interview/presentation/answer/InterviewAnswerController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/answer/InterviewAnswerController.java
@@ -7,11 +7,14 @@ import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.interview.command.application.answer.InterviewAnswerService;
 import atwoz.atwoz.interview.presentation.answer.dto.InterviewAnswerSaveRequest;
 import atwoz.atwoz.interview.presentation.answer.dto.InterviewAnswerUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "인터뷰 답변 관리 API")
 @RestController
 @RequestMapping("/interview/answer")
 @RequiredArgsConstructor
@@ -19,6 +22,7 @@ public class InterviewAnswerController {
 
     private final InterviewAnswerService interviewAnswerService;
 
+    @Operation(summary = "인터뷰 답변 등록 API")
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> saveAnswer(
         @Valid @RequestBody InterviewAnswerSaveRequest request,
@@ -28,6 +32,7 @@ public class InterviewAnswerController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "인터뷰 답변 수정 API")
     @PatchMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> updateAnswer(
         @PathVariable Long id,

--- a/src/main/java/atwoz/atwoz/interview/presentation/answer/InterviewAnswerExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/answer/InterviewAnswerExceptionHandler.java
@@ -2,7 +2,9 @@ package atwoz.atwoz.interview.presentation.answer;
 
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerAccessDeniedException;
 import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerAlreadyExistsException;
+import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerNotFoundException;
 import atwoz.atwoz.interview.command.application.question.exception.InterviewQuestionIsNotPublicException;
 import atwoz.atwoz.interview.command.application.question.exception.InterviewQuestionNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -42,5 +44,23 @@ public class InterviewAnswerExceptionHandler {
 
         return ResponseEntity.badRequest()
             .body(BaseResponse.from(StatusType.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(InterviewAnswerNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleInterviewAnswerNotFoundException(
+        InterviewAnswerNotFoundException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(404)
+            .body(BaseResponse.from(StatusType.NOT_FOUND));
+    }
+
+    @ExceptionHandler(InterviewAnswerAccessDeniedException.class)
+    public ResponseEntity<BaseResponse<Void>> handleInterviewAnswerAccessDeniedException(
+        InterviewAnswerAccessDeniedException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(403)
+            .body(BaseResponse.from(StatusType.FORBIDDEN));
     }
 }

--- a/src/main/java/atwoz/atwoz/interview/presentation/answer/dto/InterviewAnswerUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/answer/dto/InterviewAnswerUpdateRequest.java
@@ -1,0 +1,14 @@
+package atwoz.atwoz.interview.presentation.answer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record InterviewAnswerUpdateRequest(
+    @Schema(
+        description = "인터뷰 답변 내용",
+        example = "저의 취미는 독서입니다."
+    )
+    @NotBlank(message = "인터뷰 답변 내용은 필수입니다.")
+    String answerContent
+) {
+}

--- a/src/main/java/atwoz/atwoz/interview/presentation/question/AdminInterviewQuestionController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/question/AdminInterviewQuestionController.java
@@ -23,14 +23,18 @@ public class AdminInterviewQuestionController {
     private final AdminInterviewQuestionQueryRepository adminInterviewQuestionQueryRepository;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Void>> createQuestion(@Valid @RequestBody InterviewQuestionSaveRequest request) {
+    public ResponseEntity<BaseResponse<Void>> createQuestion(
+        @Valid @RequestBody InterviewQuestionSaveRequest request
+    ) {
         interviewQuestionService.createQuestion(request);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<BaseResponse<Void>> updateQuestion(@PathVariable Long id,
-        @Valid @RequestBody InterviewQuestionSaveRequest request) {
+    public ResponseEntity<BaseResponse<Void>> updateQuestion(
+        @PathVariable Long id,
+        @Valid @RequestBody InterviewQuestionSaveRequest request
+    ) {
         interviewQuestionService.updateQuestion(id, request);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
@@ -45,7 +49,9 @@ public class AdminInterviewQuestionController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<BaseResponse<AdminInterviewQuestionView>> getQuestionById(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<AdminInterviewQuestionView>> getQuestionById(
+        @PathVariable Long id
+    ) {
         AdminInterviewQuestionView view = adminInterviewQuestionQueryRepository.findAdminInterviewQuestionById(id)
             .orElseThrow(InterviewQuestionNotFoundException::new);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, view));

--- a/src/main/java/atwoz/atwoz/interview/presentation/question/AdminInterviewQuestionController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/question/AdminInterviewQuestionController.java
@@ -7,6 +7,8 @@ import atwoz.atwoz.interview.command.application.question.exception.InterviewQue
 import atwoz.atwoz.interview.presentation.question.dto.InterviewQuestionSaveRequest;
 import atwoz.atwoz.interview.query.question.AdminInterviewQuestionQueryRepository;
 import atwoz.atwoz.interview.query.question.view.AdminInterviewQuestionView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +17,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "어드민 인터뷰 질문 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/interview/question")
@@ -22,6 +25,7 @@ public class AdminInterviewQuestionController {
     private final InterviewQuestionService interviewQuestionService;
     private final AdminInterviewQuestionQueryRepository adminInterviewQuestionQueryRepository;
 
+    @Operation(summary = "어드민 인터뷰 질문 생성 API")
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> createQuestion(
         @Valid @RequestBody InterviewQuestionSaveRequest request
@@ -30,6 +34,7 @@ public class AdminInterviewQuestionController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "어드민 인터뷰 질문 수정 API")
     @PatchMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> updateQuestion(
         @PathVariable Long id,
@@ -39,6 +44,7 @@ public class AdminInterviewQuestionController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "어드민 인터뷰 목록 조회 API")
     @GetMapping
     public ResponseEntity<BaseResponse<Page<AdminInterviewQuestionView>>> getQuestionPage(
         @PageableDefault(size = 100) Pageable pageable
@@ -48,6 +54,7 @@ public class AdminInterviewQuestionController {
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, views));
     }
 
+    @Operation(summary = "어드민 인터뷰 상세 조회 API")
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<AdminInterviewQuestionView>> getQuestionById(
         @PathVariable Long id

--- a/src/main/java/atwoz/atwoz/interview/presentation/question/AdminInterviewQuestionController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/question/AdminInterviewQuestionController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,7 +36,9 @@ public class AdminInterviewQuestionController {
     }
 
     @GetMapping
-    public ResponseEntity<BaseResponse<Page<AdminInterviewQuestionView>>> getQuestionPage(Pageable pageable) {
+    public ResponseEntity<BaseResponse<Page<AdminInterviewQuestionView>>> getQuestionPage(
+        @PageableDefault(size = 100) Pageable pageable
+    ) {
         Page<AdminInterviewQuestionView> views = adminInterviewQuestionQueryRepository.findAdminInterviewQuestionPage(
             pageable);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, views));

--- a/src/main/java/atwoz/atwoz/interview/presentation/question/InterviewQuestionController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/question/InterviewQuestionController.java
@@ -4,14 +4,12 @@ import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.interview.command.application.question.exception.InterviewQuestionNotFoundException;
 import atwoz.atwoz.interview.query.question.InterviewQuestionQueryRepository;
 import atwoz.atwoz.interview.query.question.view.InterviewQuestionView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -29,5 +27,16 @@ public class InterviewQuestionController {
         List<InterviewQuestionView> views = interviewQuestionQueryRepository.findAllQuestionByCategoryWithMemberId(
             category, authContext.getId());
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, views));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<InterviewQuestionView>> getQuestionById(
+        @PathVariable Long id,
+        @AuthPrincipal AuthContext authContext
+    ) {
+        InterviewQuestionView view = interviewQuestionQueryRepository
+            .findQuestionByIdWithMemberId(id, authContext.getId())
+            .orElseThrow(InterviewQuestionNotFoundException::new);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, view));
     }
 }

--- a/src/main/java/atwoz/atwoz/interview/presentation/question/InterviewQuestionController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/question/InterviewQuestionController.java
@@ -5,6 +5,7 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.interview.command.application.question.exception.InterviewQuestionNotFoundException;
+import atwoz.atwoz.interview.query.condition.InterviewQuestionSearchCondition;
 import atwoz.atwoz.interview.query.question.InterviewQuestionQueryRepository;
 import atwoz.atwoz.interview.query.question.view.InterviewQuestionView;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +22,11 @@ public class InterviewQuestionController {
 
     @GetMapping
     public ResponseEntity<BaseResponse<List<InterviewQuestionView>>> getQuestionAllByCategory(
-        @RequestParam String category,
+        @ModelAttribute InterviewQuestionSearchCondition condition,
         @AuthPrincipal AuthContext authContext
     ) {
         List<InterviewQuestionView> views = interviewQuestionQueryRepository.findAllQuestionByCategoryWithMemberId(
-            category, authContext.getId());
+            condition.category(), authContext.getId());
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, views));
     }
 

--- a/src/main/java/atwoz/atwoz/interview/presentation/question/InterviewQuestionController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/question/InterviewQuestionController.java
@@ -22,11 +22,11 @@ public class InterviewQuestionController {
 
     @GetMapping
     public ResponseEntity<BaseResponse<List<InterviewQuestionView>>> getQuestionAllByCategory(
-        @ModelAttribute InterviewQuestionSearchCondition condition,
+        @ModelAttribute InterviewQuestionSearchCondition interviewQuestionSearchCondition,
         @AuthPrincipal AuthContext authContext
     ) {
         List<InterviewQuestionView> views = interviewQuestionQueryRepository.findAllQuestionByCategoryWithMemberId(
-            condition.category(), authContext.getId());
+            interviewQuestionSearchCondition, authContext.getId());
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, views));
     }
 

--- a/src/main/java/atwoz/atwoz/interview/presentation/question/InterviewQuestionController.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/question/InterviewQuestionController.java
@@ -8,18 +8,22 @@ import atwoz.atwoz.interview.command.application.question.exception.InterviewQue
 import atwoz.atwoz.interview.query.condition.InterviewQuestionSearchCondition;
 import atwoz.atwoz.interview.query.question.InterviewQuestionQueryRepository;
 import atwoz.atwoz.interview.query.question.view.InterviewQuestionView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "인터뷰 질문 조회 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/interview/question")
 public class InterviewQuestionController {
     private final InterviewQuestionQueryRepository interviewQuestionQueryRepository;
 
+    @Operation(summary = "인터뷰 질문 목록 조회 API")
     @GetMapping
     public ResponseEntity<BaseResponse<List<InterviewQuestionView>>> getQuestionAllByCategory(
         @ModelAttribute InterviewQuestionSearchCondition interviewQuestionSearchCondition,
@@ -30,6 +34,7 @@ public class InterviewQuestionController {
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, views));
     }
 
+    @Operation(summary = "인터뷰 질문 상세 조회 API")
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<InterviewQuestionView>> getQuestionById(
         @PathVariable Long id,

--- a/src/main/java/atwoz/atwoz/interview/presentation/question/dto/InterviewQuestionSaveRequest.java
+++ b/src/main/java/atwoz/atwoz/interview/presentation/question/dto/InterviewQuestionSaveRequest.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.interview.presentation.question.dto;
 
+import atwoz.atwoz.interview.command.domain.question.InterviewCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,11 +13,7 @@ public record InterviewQuestionSaveRequest(
     @NotBlank(message = "인터뷰 질문 내용은 필수입니다.")
     String questionContent,
 
-    @Schema(
-        description = "인터뷰 질문 카테고리",
-        allowableValues = {"PERSONAL", "SOCIAL", "ROMANTIC"},
-        example = "PERSONAL"
-    )
+    @Schema(implementation = InterviewCategory.class)
     @NotBlank(message = "인터뷰 질문 카테고리는 필수입니다.")
     String category,
 

--- a/src/main/java/atwoz/atwoz/interview/query/condition/InterviewQuestionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/interview/query/condition/InterviewQuestionSearchCondition.java
@@ -1,0 +1,12 @@
+package atwoz.atwoz.interview.query.condition;
+
+import atwoz.atwoz.interview.command.domain.question.InterviewCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record InterviewQuestionSearchCondition(
+    @Schema(implementation = InterviewCategory.class)
+    @NotBlank(message = "인터뷰 카테고리를 입력해주세요.")
+    String category
+) {
+}

--- a/src/main/java/atwoz/atwoz/interview/query/question/InterviewQuestionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/interview/query/question/InterviewQuestionQueryRepository.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.interview.query.question;
 
 import atwoz.atwoz.interview.command.domain.question.InterviewCategory;
+import atwoz.atwoz.interview.query.condition.InterviewQuestionSearchCondition;
 import atwoz.atwoz.interview.query.question.view.InterviewQuestionView;
 import atwoz.atwoz.interview.query.question.view.QInterviewQuestionView;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -20,7 +21,7 @@ public class InterviewQuestionQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     public List<InterviewQuestionView> findAllQuestionByCategoryWithMemberId(
-        String category,
+        InterviewQuestionSearchCondition condition,
         Long memberId
     ) {
         return queryFactory
@@ -36,7 +37,7 @@ public class InterviewQuestionQueryRepository {
             .leftJoin(interviewAnswer)
             .on(interviewAnswer.questionId.eq(interviewQuestion.id).and(interviewAnswer.memberId.eq(memberId)))
             .where(
-                categoryEq(category),
+                categoryEq(condition.category()),
                 isPublic()
             )
             .fetch();

--- a/src/main/java/atwoz/atwoz/interview/query/question/view/AdminInterviewQuestionView.java
+++ b/src/main/java/atwoz/atwoz/interview/query/question/view/AdminInterviewQuestionView.java
@@ -1,12 +1,15 @@
 package atwoz.atwoz.interview.query.question.view;
 
+import atwoz.atwoz.interview.command.domain.question.InterviewCategory;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
 public record AdminInterviewQuestionView(
     Long id,
     String content,
+    @Schema(implementation = InterviewCategory.class)
     String category,
     Boolean isPublic,
     LocalDateTime createdAt

--- a/src/main/java/atwoz/atwoz/interview/query/question/view/InterviewQuestionView.java
+++ b/src/main/java/atwoz/atwoz/interview/query/question/view/InterviewQuestionView.java
@@ -1,10 +1,13 @@
 package atwoz.atwoz.interview.query.question.view;
 
+import atwoz.atwoz.interview.command.domain.question.InterviewCategory;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record InterviewQuestionView(
     Long questionId,
     String questionContent,
+    @Schema(implementation = InterviewCategory.class)
     String category,
     boolean isAnswered,
     Long answerId,

--- a/src/test/java/atwoz/atwoz/interview/command/application/answer/InterviewAnswerServiceTest.java
+++ b/src/test/java/atwoz/atwoz/interview/command/application/answer/InterviewAnswerServiceTest.java
@@ -1,6 +1,8 @@
 package atwoz.atwoz.interview.command.application.answer;
 
+import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerAccessDeniedException;
 import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerAlreadyExistsException;
+import atwoz.atwoz.interview.command.application.answer.exception.InterviewAnswerNotFoundException;
 import atwoz.atwoz.interview.command.application.question.exception.InterviewQuestionIsNotPublicException;
 import atwoz.atwoz.interview.command.application.question.exception.InterviewQuestionNotFoundException;
 import atwoz.atwoz.interview.command.domain.answer.InterviewAnswer;
@@ -8,7 +10,9 @@ import atwoz.atwoz.interview.command.domain.answer.InterviewAnswerCommandReposit
 import atwoz.atwoz.interview.command.domain.question.InterviewQuestion;
 import atwoz.atwoz.interview.command.domain.question.InterviewQuestionCommandRepository;
 import atwoz.atwoz.interview.presentation.answer.dto.InterviewAnswerSaveRequest;
+import atwoz.atwoz.interview.presentation.answer.dto.InterviewAnswerUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,123 +36,187 @@ class InterviewAnswerServiceTest {
     @InjectMocks
     private InterviewAnswerService interviewAnswerService;
 
-    @Test
-    @DisplayName("인터뷰 질문이 존재하지 않으면 예외를 던진다.")
-    void throwsExceptionWhenInterviewQuestionDoesNotExist() {
-        // given
-        Long interviewQuestionId = 1L;
-        String answerContent = "content";
-        InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
-        Long memberId = 2L;
+    @Nested
+    @DisplayName("saveAnswer 메서드 테스트")
+    class SaveAnswerMethodTest {
+        @Test
+        @DisplayName("인터뷰 질문이 존재하지 않으면 예외를 던진다.")
+        void throwsExceptionWhenInterviewQuestionDoesNotExist() {
+            // given
+            Long interviewQuestionId = 1L;
+            String answerContent = "content";
+            InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
+            Long memberId = 2L;
 
-        when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(Optional.empty());
+            when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> interviewAnswerService.saveAnswer(request, memberId))
-            .isInstanceOf(InterviewQuestionNotFoundException.class);
+            // when & then
+            assertThatThrownBy(() -> interviewAnswerService.saveAnswer(request, memberId))
+                .isInstanceOf(InterviewQuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("인터뷰 질문이 공개되어 있지 않다면 예외를 던진다.")
+        void throwsExceptionWhenInterviewQuestionIsNotPublic() {
+            // given
+            Long interviewQuestionId = 1L;
+            String answerContent = "content";
+            InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
+            Long memberId = 2L;
+
+            InterviewQuestion interviewQuestion = mock(InterviewQuestion.class);
+            when(interviewQuestion.isPublic()).thenReturn(false);
+            when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(
+                Optional.of(interviewQuestion));
+
+            // when & then
+            assertThatThrownBy(() -> interviewAnswerService.saveAnswer(request, memberId))
+                .isInstanceOf(InterviewQuestionIsNotPublicException.class);
+        }
+
+        @Test
+        @DisplayName("인터뷰 답변이 이미 존재한다면 예외를 던진다.")
+        void throwsExceptionWhenInterviewAnswerAlreadyExists() {
+            // given
+            Long interviewQuestionId = 1L;
+            String answerContent = "content";
+            InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
+            Long memberId = 2L;
+
+            InterviewQuestion interviewQuestion = mock(InterviewQuestion.class);
+            when(interviewQuestion.isPublic()).thenReturn(true);
+            when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(
+                Optional.of(interviewQuestion));
+            when(interviewAnswerCommandRepository.existsByQuestionIdAndMemberId(interviewQuestionId,
+                memberId)).thenReturn(
+                true);
+
+            // when & then
+            assertThatThrownBy(() -> interviewAnswerService.saveAnswer(request, memberId))
+                .isInstanceOf(InterviewAnswerAlreadyExistsException.class);
+        }
+
+        @Test
+        @DisplayName("다른 인터뷰 답변이 존재하지 않으면 submitFirstInterviewAnswer를 호출한다.")
+        void callsSubmitFirstInterviewAnswerWhenOtherInterviewAnswerDoesNotExist() {
+            // given
+            Long interviewQuestionId = 1L;
+            String answerContent = "content";
+            InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
+            Long memberId = 2L;
+
+            InterviewQuestion interviewQuestion = mock(InterviewQuestion.class);
+            when(interviewQuestion.isPublic()).thenReturn(true);
+            when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(
+                Optional.of(interviewQuestion));
+            when(interviewAnswerCommandRepository.existsByMemberId(memberId)).thenReturn(false);
+            when(interviewAnswerCommandRepository.existsByQuestionIdAndMemberId(interviewQuestionId,
+                memberId)).thenReturn(
+                false);
+
+            InterviewAnswer interviewAnswer = mock(InterviewAnswer.class);
+            try (MockedStatic<InterviewAnswer> mockedStatic = mockStatic(InterviewAnswer.class)) {
+                mockedStatic.when(() -> InterviewAnswer.of(eq(interviewQuestionId), eq(memberId), eq(answerContent)))
+                    .thenReturn(interviewAnswer);
+
+                // when
+                interviewAnswerService.saveAnswer(request, memberId);
+
+                // then
+                verify(interviewAnswer, times(1)).submitFirstInterviewAnswer();
+            }
+            verify(interviewAnswerCommandRepository).save(interviewAnswer);
+
+        }
+
+        @Test
+        @DisplayName("다른 인터뷰 답변이 존재하면 submitFirstInterviewAnswer를 호출하지 않는다.")
+        void doesNotCallSubmitFirstInterviewAnswerWhenOtherInterviewAnswerExists() {
+            // given
+            Long interviewQuestionId = 1L;
+            String answerContent = "content";
+            InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
+            Long memberId = 2L;
+
+            InterviewQuestion interviewQuestion = mock(InterviewQuestion.class);
+            when(interviewQuestion.isPublic()).thenReturn(true);
+            when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(
+                Optional.of(interviewQuestion));
+            when(interviewAnswerCommandRepository.existsByMemberId(memberId)).thenReturn(true);
+            when(interviewAnswerCommandRepository.existsByQuestionIdAndMemberId(interviewQuestionId,
+                memberId)).thenReturn(
+                false);
+
+            InterviewAnswer interviewAnswer = mock(InterviewAnswer.class);
+            try (MockedStatic<InterviewAnswer> mockedStatic = mockStatic(InterviewAnswer.class)) {
+                mockedStatic.when(() -> InterviewAnswer.of(eq(interviewQuestionId), eq(memberId), eq(answerContent)))
+                    .thenReturn(interviewAnswer);
+
+                // when
+                interviewAnswerService.saveAnswer(request, memberId);
+
+                // then
+                verify(interviewAnswer, never()).submitFirstInterviewAnswer();
+            }
+            verify(interviewAnswerCommandRepository).save(interviewAnswer);
+        }
     }
 
-    @Test
-    @DisplayName("인터뷰 질문이 공개되어 있지 않다면 예외를 던진다.")
-    void throwsExceptionWhenInterviewQuestionIsNotPublic() {
-        // given
-        Long interviewQuestionId = 1L;
-        String answerContent = "content";
-        InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
-        Long memberId = 2L;
+    @Nested
+    @DisplayName("updateAnswer 메서드 테스트")
+    class UpdateAnswerMethodTest {
+        @Test
+        @DisplayName("인터뷰 답변이 존재하지 않으면 예외를 던진다.")
+        void throwsExceptionWhenInterviewAnswerDoesNotExist() {
+            // given
+            Long answerId = 1L;
+            String answerContent = "content";
+            InterviewAnswerUpdateRequest request = new InterviewAnswerUpdateRequest(answerContent);
+            Long memberId = 2L;
 
-        InterviewQuestion interviewQuestion = mock(InterviewQuestion.class);
-        when(interviewQuestion.isPublic()).thenReturn(false);
-        when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(
-            Optional.of(interviewQuestion));
+            when(interviewAnswerCommandRepository.findById(answerId)).thenReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> interviewAnswerService.saveAnswer(request, memberId))
-            .isInstanceOf(InterviewQuestionIsNotPublicException.class);
-    }
+            // when & then
+            assertThatThrownBy(() -> interviewAnswerService.updateAnswer(answerId, request, memberId))
+                .isInstanceOf(InterviewAnswerNotFoundException.class);
+        }
 
-    @Test
-    @DisplayName("인터뷰 답변이 이미 존재한다면 예외를 던진다.")
-    void throwsExceptionWhenInterviewAnswerAlreadyExists() {
-        // given
-        Long interviewQuestionId = 1L;
-        String answerContent = "content";
-        InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
-        Long memberId = 2L;
+        @Test
+        @DisplayName("인터뷰 답변이 본인이 작성한 것이 아니라면 예외를 던진다.")
+        void throwsExceptionWhenInterviewAnswerIsNotWrittenByMember() {
+            // given
+            Long answerId = 1L;
+            String answerContent = "content";
+            InterviewAnswerUpdateRequest request = new InterviewAnswerUpdateRequest(answerContent);
+            Long memberId = 2L;
 
-        InterviewQuestion interviewQuestion = mock(InterviewQuestion.class);
-        when(interviewQuestion.isPublic()).thenReturn(true);
-        when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(
-            Optional.of(interviewQuestion));
-        when(interviewAnswerCommandRepository.existsByQuestionIdAndMemberId(interviewQuestionId, memberId)).thenReturn(
-            true);
+            InterviewAnswer interviewAnswer = mock(InterviewAnswer.class);
+            when(interviewAnswer.isAnsweredBy(memberId)).thenReturn(false);
+            when(interviewAnswerCommandRepository.findById(answerId)).thenReturn(Optional.of(interviewAnswer));
 
-        // when & then
-        assertThatThrownBy(() -> interviewAnswerService.saveAnswer(request, memberId))
-            .isInstanceOf(InterviewAnswerAlreadyExistsException.class);
-    }
+            // when & then
+            assertThatThrownBy(() -> interviewAnswerService.updateAnswer(answerId, request, memberId))
+                .isInstanceOf(InterviewAnswerAccessDeniedException.class);
+        }
 
-    @Test
-    @DisplayName("다른 인터뷰 답변이 존재하지 않으면 submitFirstInterviewAnswer를 호출한다.")
-    void callsSubmitFirstInterviewAnswerWhenOtherInterviewAnswerDoesNotExist() {
-        // given
-        Long interviewQuestionId = 1L;
-        String answerContent = "content";
-        InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
-        Long memberId = 2L;
+        @Test
+        @DisplayName("인터뷰 답변을 업데이트 한다.")
+        void updatesInterviewAnswer() {
+            // given
+            Long answerId = 1L;
+            String answerContent = "content";
+            InterviewAnswerUpdateRequest request = new InterviewAnswerUpdateRequest(answerContent);
+            Long memberId = 2L;
 
-        InterviewQuestion interviewQuestion = mock(InterviewQuestion.class);
-        when(interviewQuestion.isPublic()).thenReturn(true);
-        when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(
-            Optional.of(interviewQuestion));
-        when(interviewAnswerCommandRepository.existsByMemberId(memberId)).thenReturn(false);
-        when(interviewAnswerCommandRepository.existsByQuestionIdAndMemberId(interviewQuestionId, memberId)).thenReturn(
-            false);
-
-        InterviewAnswer interviewAnswer = mock(InterviewAnswer.class);
-        try (MockedStatic<InterviewAnswer> mockedStatic = mockStatic(InterviewAnswer.class)) {
-            mockedStatic.when(() -> InterviewAnswer.of(eq(interviewQuestionId), eq(memberId), eq(answerContent)))
-                .thenReturn(interviewAnswer);
+            InterviewAnswer interviewAnswer = mock(InterviewAnswer.class);
+            when(interviewAnswer.isAnsweredBy(memberId)).thenReturn(true);
+            when(interviewAnswerCommandRepository.findById(answerId)).thenReturn(Optional.of(interviewAnswer));
 
             // when
-            interviewAnswerService.saveAnswer(request, memberId);
+            interviewAnswerService.updateAnswer(answerId, request, memberId);
 
             // then
-            verify(interviewAnswer, times(1)).submitFirstInterviewAnswer();
+            verify(interviewAnswer).updateContent(answerContent);
         }
-        verify(interviewAnswerCommandRepository).save(interviewAnswer);
-
     }
-
-    @Test
-    @DisplayName("다른 인터뷰 답변이 존재하면 submitFirstInterviewAnswer를 호출하지 않는다.")
-    void doesNotCallSubmitFirstInterviewAnswerWhenOtherInterviewAnswerExists() {
-        // given
-        Long interviewQuestionId = 1L;
-        String answerContent = "content";
-        InterviewAnswerSaveRequest request = new InterviewAnswerSaveRequest(interviewQuestionId, answerContent);
-        Long memberId = 2L;
-
-        InterviewQuestion interviewQuestion = mock(InterviewQuestion.class);
-        when(interviewQuestion.isPublic()).thenReturn(true);
-        when(interviewQuestionCommandRepository.findById(interviewQuestionId)).thenReturn(
-            Optional.of(interviewQuestion));
-        when(interviewAnswerCommandRepository.existsByMemberId(memberId)).thenReturn(true);
-        when(interviewAnswerCommandRepository.existsByQuestionIdAndMemberId(interviewQuestionId, memberId)).thenReturn(
-            false);
-
-        InterviewAnswer interviewAnswer = mock(InterviewAnswer.class);
-        try (MockedStatic<InterviewAnswer> mockedStatic = mockStatic(InterviewAnswer.class)) {
-            mockedStatic.when(() -> InterviewAnswer.of(eq(interviewQuestionId), eq(memberId), eq(answerContent)))
-                .thenReturn(interviewAnswer);
-
-            // when
-            interviewAnswerService.saveAnswer(request, memberId);
-
-            // then
-            verify(interviewAnswer, never()).submitFirstInterviewAnswer();
-        }
-        verify(interviewAnswerCommandRepository).save(interviewAnswer);
-    }
-
 }

--- a/src/test/java/atwoz/atwoz/interview/command/domain/answer/InterviewAnswerTest.java
+++ b/src/test/java/atwoz/atwoz/interview/command/domain/answer/InterviewAnswerTest.java
@@ -20,7 +20,7 @@ class InterviewAnswerTest {
 
     @Nested
     @DisplayName("of 메서드 테스트")
-    class ofMethodTest {
+    class OfMethodTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"content is null", "questionId is null", "memberId is null"})
@@ -67,7 +67,7 @@ class InterviewAnswerTest {
 
     @Nested
     @DisplayName("submitFirstInterviewAnswer 메서드 테스트")
-    class submitFirstInterviewAnswerMethodTest {
+    class SubmitFirstInterviewAnswerMethodTest {
 
         @Test
         @DisplayName("첫 번째 면접 답변을 제출하면 FirstInterviewSubmittedEvent를 발생시킨다.")

--- a/src/test/java/atwoz/atwoz/interview/command/domain/answer/InterviewAnswerTest.java
+++ b/src/test/java/atwoz/atwoz/interview/command/domain/answer/InterviewAnswerTest.java
@@ -89,4 +89,101 @@ class InterviewAnswerTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("updateContent 메서드 테스트")
+    class UpdateContentMethodTest {
+
+        @Test
+        @DisplayName("updateContent 메서드에서 content가 null이면 예외를 던집니다.")
+        void throwsExceptionWhenContentIsNull() {
+            // given
+            Long questionId = 1L;
+            Long memberId = 2L;
+            InterviewAnswer interviewAnswer = InterviewAnswer.of(questionId, memberId, "content");
+
+            // when & then
+            assertThatThrownBy(() -> interviewAnswer.updateContent(null))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("updateContent 메서드에서 content가 blank이면 예외를 던집니다.")
+        void throwsExceptionWhenContentIsBlank() {
+            // given
+            Long questionId = 1L;
+            Long memberId = 2L;
+            InterviewAnswer interviewAnswer = InterviewAnswer.of(questionId, memberId, "content");
+
+            // when & then
+            assertThatThrownBy(() -> interviewAnswer.updateContent(" "))
+                .isInstanceOf(InvalidInterviewAnswerContentException.class);
+        }
+
+        @Test
+        @DisplayName("updateContent 메서드에서 content가 정상이면 content를 업데이트합니다.")
+        void updateContentWhenContentIsValid() {
+            // given
+            Long questionId = 1L;
+            Long memberId = 2L;
+            String prevContent = "content";
+            InterviewAnswer interviewAnswer = InterviewAnswer.of(questionId, memberId, prevContent);
+
+            // when
+            String updatedContent = "updated content";
+            interviewAnswer.updateContent(updatedContent);
+
+            // then
+            assertThat(interviewAnswer.getContent()).isEqualTo(updatedContent);
+        }
+    }
+
+    @Nested
+    @DisplayName("isAnsweredBy 메서드 테스트")
+    class IsAnsweredByMethodTest {
+
+        @Test
+        @DisplayName("isAnsweredBy 메서드에서 memberId가 null이면 예외를 던집니다.")
+        void throwsExceptionWhenMemberIdIsNull() {
+            // given
+            Long questionId = 1L;
+            Long memberId = 2L;
+            InterviewAnswer interviewAnswer = InterviewAnswer.of(questionId, memberId, "content");
+
+            // when & then
+            Long nullMemberId = null;
+            assertThatThrownBy(() -> interviewAnswer.isAnsweredBy(nullMemberId))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("isAnsweredBy 메서드에서 memberId가 interviewAnswer.memberId와 일치하면 true를 반환합니다.")
+        void returnTrueWhenMemberIdIsValid() {
+            // given
+            Long questionId = 1L;
+            Long memberId = 2L;
+            InterviewAnswer interviewAnswer = InterviewAnswer.of(questionId, memberId, "content");
+
+            // when
+            boolean result = interviewAnswer.isAnsweredBy(memberId);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("isAnsweredBy 메서드에서 memberId가 interviewAnswer.memberId와 일치하지 않으면 false를 반환합니다.")
+        void returnFalseWhenMemberIdIsInvalid() {
+            // given
+            Long questionId = 1L;
+            Long memberId = 2L;
+            InterviewAnswer interviewAnswer = InterviewAnswer.of(questionId, memberId, "content");
+
+            // when
+            boolean result = interviewAnswer.isAnsweredBy(3L);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
 }

--- a/src/test/java/atwoz/atwoz/interview/query/question/InterviewQuestionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/interview/query/question/InterviewQuestionQueryRepositoryTest.java
@@ -28,6 +28,24 @@ class InterviewQuestionQueryRepositoryTest {
     @Autowired
     private TestEntityManager entityManager;
 
+    private Member createMember(String phoneNumber) {
+        Member member = Member.fromPhoneNumber(phoneNumber);
+        entityManager.persist(member);
+        return member;
+    }
+
+    private InterviewQuestion createInterviewQuestion(String content, InterviewCategory category, boolean isPublic) {
+        InterviewQuestion question = InterviewQuestion.of(content, category, isPublic);
+        entityManager.persist(question);
+        return question;
+    }
+
+    private InterviewAnswer createInterviewAnswer(Long questionId, Long memberId, String content) {
+        InterviewAnswer answer = InterviewAnswer.of(questionId, memberId, content);
+        entityManager.persist(answer);
+        return answer;
+    }
+
     @Nested
     @DisplayName("멤버 인터뷰 질문 조회 테스트")
     class MemberInterviewQuestionTest {
@@ -36,13 +54,9 @@ class InterviewQuestionQueryRepositoryTest {
         @DisplayName("멤버 인터뷰 질문 조회 파라미터 테스트")
         void findAllQuestionByCategoryWithMemberId() {
             // given
-            Member member = Member.fromPhoneNumber("01012345678");
-            entityManager.persist(member);
-            InterviewQuestion question = InterviewQuestion.of("질문1", InterviewCategory.PERSONAL, true);
-            entityManager.persist(question);
-            entityManager.flush();
-            InterviewAnswer answer = InterviewAnswer.of(question.getId(), member.getId(), "답변1");
-            entityManager.persist(answer);
+            Member member = createMember("01012345678");
+            InterviewQuestion question = createInterviewQuestion("질문1", InterviewCategory.PERSONAL, true);
+            InterviewAnswer answer = createInterviewAnswer(question.getId(), member.getId(), "답변1");
             entityManager.flush();
 
             // when
@@ -64,10 +78,8 @@ class InterviewQuestionQueryRepositoryTest {
         @DisplayName("답변 안한 질문 조회 테스트")
         void findAllQuestionByCategoryWithMemberIdWithoutAnswer() {
             // given
-            Member member = Member.fromPhoneNumber("01012345678");
-            entityManager.persist(member);
-            InterviewQuestion question = InterviewQuestion.of("질문1", InterviewCategory.PERSONAL, true);
-            entityManager.persist(question);
+            Member member = createMember("01012345678");
+            InterviewQuestion question = createInterviewQuestion("질문1", InterviewCategory.PERSONAL, true);
             entityManager.flush();
 
             // when
@@ -89,10 +101,8 @@ class InterviewQuestionQueryRepositoryTest {
         @DisplayName("isPublic이 false인 질문 조회 테스트")
         void findAllQuestionByCategoryWithMemberIdWithoutPublic() {
             // given
-            Member member = Member.fromPhoneNumber("01012345678");
-            entityManager.persist(member);
-            InterviewQuestion question = InterviewQuestion.of("질문1", InterviewCategory.PERSONAL, false);
-            entityManager.persist(question);
+            Member member = createMember("01012345678");
+            InterviewQuestion question = createInterviewQuestion("질문1", InterviewCategory.PERSONAL, false);
             entityManager.flush();
 
             // when
@@ -107,10 +117,8 @@ class InterviewQuestionQueryRepositoryTest {
         @DisplayName("다른 카테고리 조회 테스트")
         void findAllQuestionByCategoryWithMemberIdWithDifferentCategory() {
             // given
-            Member member = Member.fromPhoneNumber("01012345678");
-            entityManager.persist(member);
-            InterviewQuestion question = InterviewQuestion.of("질문1", InterviewCategory.PERSONAL, true);
-            entityManager.persist(question);
+            Member member = createMember("01012345678");
+            InterviewQuestion question = createInterviewQuestion("질문1", InterviewCategory.PERSONAL, true);
             entityManager.flush();
 
             // when

--- a/src/test/java/atwoz/atwoz/interview/query/question/InterviewQuestionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/interview/query/question/InterviewQuestionQueryRepositoryTest.java
@@ -4,6 +4,7 @@ import atwoz.atwoz.QuerydslConfig;
 import atwoz.atwoz.interview.command.domain.answer.InterviewAnswer;
 import atwoz.atwoz.interview.command.domain.question.InterviewCategory;
 import atwoz.atwoz.interview.command.domain.question.InterviewQuestion;
+import atwoz.atwoz.interview.query.condition.InterviewQuestionSearchCondition;
 import atwoz.atwoz.interview.query.question.view.InterviewQuestionView;
 import atwoz.atwoz.member.command.domain.member.Member;
 import org.junit.jupiter.api.DisplayName;
@@ -60,9 +61,12 @@ class InterviewQuestionQueryRepositoryTest {
             InterviewAnswer answer = createInterviewAnswer(question.getId(), member.getId(), "답변1");
             entityManager.flush();
 
+            InterviewQuestionSearchCondition condition = new InterviewQuestionSearchCondition(
+                question.getCategory().name());
+
             // when
             List<InterviewQuestionView> views = interviewQuestionQueryRepository.findAllQuestionByCategoryWithMemberId(
-                question.getCategory().name(), member.getId());
+                condition, member.getId());
 
             // then
             assertThat(views).hasSize(1);
@@ -83,9 +87,12 @@ class InterviewQuestionQueryRepositoryTest {
             InterviewQuestion question = createInterviewQuestion("질문1", InterviewCategory.PERSONAL, true);
             entityManager.flush();
 
+            InterviewQuestionSearchCondition condition = new InterviewQuestionSearchCondition(
+                question.getCategory().name());
+
             // when
             List<InterviewQuestionView> views = interviewQuestionQueryRepository.findAllQuestionByCategoryWithMemberId(
-                question.getCategory().name(), member.getId());
+                condition, member.getId());
 
             // then
             assertThat(views).hasSize(1);
@@ -106,9 +113,12 @@ class InterviewQuestionQueryRepositoryTest {
             InterviewQuestion question = createInterviewQuestion("질문1", InterviewCategory.PERSONAL, false);
             entityManager.flush();
 
+            InterviewQuestionSearchCondition condition = new InterviewQuestionSearchCondition(
+                question.getCategory().name());
+
             // when
             List<InterviewQuestionView> views = interviewQuestionQueryRepository.findAllQuestionByCategoryWithMemberId(
-                question.getCategory().name(), member.getId());
+                condition, member.getId());
 
             // then
             assertThat(views).isEmpty();
@@ -122,9 +132,12 @@ class InterviewQuestionQueryRepositoryTest {
             createInterviewQuestion("질문1", InterviewCategory.PERSONAL, true);
             entityManager.flush();
 
+            InterviewQuestionSearchCondition condition = new InterviewQuestionSearchCondition(
+                InterviewCategory.SOCIAL.name());
+
             // when
             List<InterviewQuestionView> views = interviewQuestionQueryRepository.findAllQuestionByCategoryWithMemberId(
-                InterviewCategory.SOCIAL.name(), member.getId());
+                condition, member.getId());
 
             // then
             assertThat(views).isEmpty();


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 인터뷰 답변 수정 기능이 추가되었습니다.
  - 인터뷰 질문을 ID로 조회하는 기능이 추가되었습니다.

- **버그 수정**
  - 인터뷰 답변 접근 권한 및 존재하지 않는 답변에 대한 예외 처리가 개선되었습니다.

- **문서화**
  - Swagger 문서에 카테고리 및 요청/응답 DTO의 스키마 정보가 추가되었습니다.

- **테스트**
  - 답변 저장 및 수정, 질문 조회 관련 테스트가 대폭 보강되었습니다.

- **스타일/리팩터링**
  - 일부 컨트롤러 파라미터 포맷 및 내부 코드 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- https://github.com/atwoz-dev/atwoz_server/wiki/Swagger-Schema-%EC%BB%A8%EB%B2%A4%EC%85%98

## 노트
- FE 분들이 enum 값을 swagger에서 확인하고 싶다고 하셔서 위 참고 자료에서 swagger schema 컨벤션 정의해뒀어요
- 이 PR도 정의한 컨벤션에 맞게 작업을 했고요
- `@Schema` 작성 시 `allowableValues `를 직접 작성하면 오타나, 유지보수 누락으로 실제 enum값과 불일치할 수 있어서 `@Schema 의 implementation`을 사용해서 간편하게 enum값을 swagger UI에 노출할 수 있도록 했어요
- 컨벤션 확인해보시고 의견주시면 좋을 것 같네요
- 컨벤션 최종 정의 완료되면 전체적으로 적용해볼게요!
