### PR TITLE
자기 자신 프로필 조회 API 복원

### DIFF
--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberController.java
@@ -10,12 +10,15 @@ import atwoz.atwoz.member.presentation.member.dto.MemberProfileResponse;
 import atwoz.atwoz.member.presentation.member.dto.MemberProfileUpdateRequest;
 import atwoz.atwoz.member.query.member.MemberQueryRepository;
 import atwoz.atwoz.member.query.member.view.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "회원 정보 조회 및 변경 API")
 @RestController
 @RequestMapping("/member")
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ public class MemberController {
     private final MemberProfileService memberProfileService;
     private final MemberQueryRepository memberQueryRepository;
 
+    @Operation(summary = "프로필 정보 업데이트 API")
     @PutMapping("/profile")
     public ResponseEntity<BaseResponse<Void>> updateProfile(@RequestBody MemberProfileUpdateRequest request,
         @AuthPrincipal AuthContext authContext) {
@@ -31,8 +35,9 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
-    @GetMapping("/profile")
-    public ResponseEntity<BaseResponse<MemberInfoView>> getMyProfile(@AuthPrincipal AuthContext authContext) {
+    @Operation(summary = "회원(자기 자신) 정보 캐싱용 API")
+    @GetMapping("/cache")
+    public ResponseEntity<BaseResponse<MemberInfoView>> getMyInfoCache(@AuthPrincipal AuthContext authContext) {
         MemberInfoView response = memberQueryRepository.findInfoByMemberId(authContext.getId()).orElse(null);
         if (response == null) {
             return ResponseEntity.status(404)
@@ -41,6 +46,19 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, response));
     }
 
+    @Operation(summary = "회원(자기 자신) 프로필 정보 조회 API")
+    @GetMapping("/profile")
+    public ResponseEntity<BaseResponse<MemberProfileView>> getMyProfile(@AuthPrincipal AuthContext authContext) {
+        MemberProfileView response = memberQueryRepository.findProfileByMemberId(authContext.getId()).orElse(null);
+        if (response == null) {
+            return ResponseEntity.status(404)
+                .body(BaseResponse.from(StatusType.NOT_FOUND));
+        }
+
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, response));
+    }
+
+    @Operation(summary = "상대방 프로필 조회 API")
     @GetMapping("/{memberId}")
     public ResponseEntity<BaseResponse<MemberProfileResponse>> getOtherProfile(@AuthPrincipal AuthContext authContext,
         @PathVariable Long memberId) {
@@ -58,12 +76,14 @@ public class MemberController {
                 interviewResultViews)));
     }
 
+    @Operation(summary = "휴면 계정 전환 API")
     @PostMapping("/profile/dormant")
     public ResponseEntity<BaseResponse<Void>> changeToDormant(@AuthPrincipal AuthContext authContext) {
         memberProfileService.changeToDormant(authContext.getId());
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "연락처(자기 자신) 정보 조회 API")
     @GetMapping("/profile/contact")
     public ResponseEntity<BaseResponse<MemberContactView>> getMyContact(@AuthPrincipal AuthContext authContext) {
         MemberContactView response = memberQueryRepository.findContactsByMemberId(authContext.getId()).orElse(null);
@@ -74,6 +94,7 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, response));
     }
 
+    @Operation(summary = "주요 연락처 수단(Kakao) 변경 API")
     @PatchMapping("/profile/contact/kakao")
     public ResponseEntity<BaseResponse<Void>> updateKakaoId(@AuthPrincipal AuthContext authContext,
         @RequestBody String kakaoId) {
@@ -81,6 +102,7 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "주요 연락처 수단 변경(Phone) API")
     @PatchMapping("/profile/contact/phone")
     public ResponseEntity<BaseResponse<Void>> updatePhoneNumber(@AuthPrincipal AuthContext authContext,
         @RequestBody String phone) {
@@ -88,6 +110,7 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "보유 하트 조회 API")
     @GetMapping("/heartbalance")
     public ResponseEntity<BaseResponse<HeartBalanceView>> getHeartBalance(@AuthPrincipal AuthContext authContext) {
         HeartBalanceView view = memberQueryRepository.findHeartBalanceByMemberId(authContext.getId());

--- a/src/main/java/atwoz/atwoz/member/query/member/MemberQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/MemberQueryRepository.java
@@ -66,6 +66,34 @@ public class MemberQueryRepository {
         return Optional.ofNullable(memberInfoView);
     }
 
+    public Optional<MemberProfileView> findProfileByMemberId(Long memberId) {
+        EnumPath<Hobby> hobby = enumPath(Hobby.class, "hobbyAlias");
+
+        MemberProfileView memberProfileView = queryFactory
+            .from(member)
+            .leftJoin(member.profile.hobbies, hobby)
+            .transform(
+                groupBy(member.id).as(
+                    new QMemberProfileView(
+                        member.profile.nickname.value,
+                        member.profile.yearOfBirth.value,
+                        member.profile.gender.stringValue(),
+                        member.profile.height,
+                        member.profile.job.stringValue(),
+                        set(hobby.stringValue()),
+                        member.profile.mbti.stringValue(),
+                        member.profile.region.city.stringValue(),
+                        member.profile.region.district.stringValue(),
+                        member.profile.smokingStatus.stringValue(),
+                        member.profile.drinkingStatus.stringValue(),
+                        member.profile.highestEducation.stringValue(),
+                        member.profile.religion.stringValue()
+                    )
+                )
+            ).get(memberId);
+        return Optional.ofNullable(memberProfileView);
+    }
+
     public Optional<MemberContactView> findContactsByMemberId(Long memberId) {
         MemberContactView memberContactView = queryFactory
             .select(new QMemberContactView(


### PR DESCRIPTION
- 추가된 프로필 조회 및 업데이트 API 엔드포인트 정의
- MemberQueryRepository에 회원 프로필 조회 로직 추가
- API 메서드별 Swagger Operation 애노테이션 적용
- 관련 단위 테스트 및 테스트 케이스 보강

@coderabbitai summary

## 참고 자료
- 

## 노트
