### PR TITLE
프로필 교환 도메인 정의

### DIFF
--- a/src/main/java/atwoz/atwoz/community/command/domain/profileexchange/ProfileExchange.java
+++ b/src/main/java/atwoz/atwoz/community/command/domain/profileexchange/ProfileExchange.java
@@ -1,0 +1,39 @@
+package atwoz.atwoz.community.command.domain.profileexchange;
+
+
+import atwoz.atwoz.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "profile_exchanges", indexes = {
+    @Index(name = "idx_responder_id", columnList = "responderId"),
+    @Index(name = "idx_requester_id_responder_id", columnList = "requesterId, responderId")
+})
+public class ProfileExchange extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private long requesterId;
+
+    private long responderId;
+
+    private ProfileExchangeStatus status;
+
+    private ProfileExchange(long requesterId, long responderId, @NonNull ProfileExchangeStatus status) {
+        this.requesterId = requesterId;
+        this.responderId = responderId;
+        this.status = status;
+    }
+
+    static ProfileExchange request(long requesterId, long responderId) {
+        return new ProfileExchange(requesterId, responderId, ProfileExchangeStatus.WAITING);
+    }
+}

--- a/src/main/java/atwoz/atwoz/community/command/domain/profileexchange/ProfileExchangeStatus.java
+++ b/src/main/java/atwoz/atwoz/community/command/domain/profileexchange/ProfileExchangeStatus.java
@@ -1,0 +1,16 @@
+package atwoz.atwoz.community.command.domain.profileexchange;
+
+import lombok.Getter;
+
+@Getter
+public enum ProfileExchangeStatus {
+    WAITING("응답 대기중"),
+    ACCEPTED("교환 수락"),
+    REJECTED("교환 거절");
+
+    private final String description;
+
+    ProfileExchangeStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/test/java/atwoz/atwoz/community/command/domain/profileexchange/ProfileExchangeTest.java
+++ b/src/test/java/atwoz/atwoz/community/command/domain/profileexchange/ProfileExchangeTest.java
@@ -1,0 +1,24 @@
+package atwoz.atwoz.community.command.domain.profileexchange;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfileExchangeTest {
+    @Test
+    @DisplayName("프로필 교환을 신청할 경우, 신청 대기 상태로 생성한다.")
+    void createProfileExchangeWithWaitingStatus() {
+        // Given
+        long requesterId = 1L;
+        long responderId = 3L;
+
+        // When
+        ProfileExchange profileExchange = ProfileExchange.request(requesterId, responderId);
+
+        // Then
+        assertThat(profileExchange.getRequesterId()).isEqualTo(requesterId);
+        assertThat(profileExchange.getResponderId()).isEqualTo(responderId);
+        assertThat(profileExchange.getStatus()).isEqualTo(ProfileExchangeStatus.WAITING);
+    }
+}


### PR DESCRIPTION
- ProfileExchange 엔티티 및 ProfileExchangeStatus 열거형 추가
- 프로필 교환 로직 요청 메서드 및 상태 관리 기능 구현
- 관련 단위 테스트 추가

@coderabbitai summary

## 참고 자료
- 

## 노트
<img width="466" alt="image" src="https://github.com/user-attachments/assets/708c4777-94ac-4135-8f31-b379d22be22a" />

다음과 같은 플로우를 위해, 프로필 교환 도메인을 정의하였습니다. 