### PR TITLE
Swagger 컨벤션 적용

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/presentation/admin/AdminAuthController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/admin/AdminAuthController.java
@@ -8,6 +8,8 @@ import atwoz.atwoz.admin.presentation.admin.dto.AdminSignupResponse;
 import atwoz.atwoz.auth.presentation.RefreshTokenCookieProperties;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -15,6 +17,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "관리자 인증 API")
 @RestController
 @RequestMapping("/admin")
 @RequiredArgsConstructor
@@ -25,12 +28,14 @@ public class AdminAuthController {
     private final RefreshTokenCookieProperties refreshTokenCookieProperties;
     private final AdminAuthService adminAuthService;
 
+    @Operation(summary = "관리자 회원가입")
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<AdminSignupResponse>> signup(@Valid @RequestBody AdminSignupRequest request) {
         AdminSignupResponse data = adminAuthService.signup(request);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, data));
     }
 
+    @Operation(summary = "관리자 로그인")
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<Void>> login(@Valid @RequestBody AdminLoginRequest request) {
         AdminLoginResponse response = adminAuthService.login(request);
@@ -52,6 +57,7 @@ public class AdminAuthController {
             .body(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "관리자 로그아웃")
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<Void>> logout(
         @CookieValue(value = "refresh_token", required = false) String refreshToken

--- a/src/main/java/atwoz/atwoz/admin/presentation/member/AdminMemberController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/member/AdminMemberController.java
@@ -5,6 +5,8 @@ import atwoz.atwoz.admin.query.member.MemberDetailView;
 import atwoz.atwoz.admin.query.member.MemberSearchCondition;
 import atwoz.atwoz.admin.query.member.MemberView;
 import atwoz.atwoz.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import static atwoz.atwoz.common.enums.StatusType.OK;
 
+@Tag(name = "관리자 페이지 멤버 관리 API")
 @RestController
 @RequestMapping("/admin/members")
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class AdminMemberController {
 
     private final AdminMemberQueryRepository adminMemberQueryRepository;
 
+    @Operation(summary = "멤버 목록 조회")
     @GetMapping
     public ResponseEntity<BaseResponse<Page<MemberView>>> getMembers(
         @Valid @ModelAttribute MemberSearchCondition condition,
@@ -30,6 +34,7 @@ public class AdminMemberController {
         return ResponseEntity.ok(BaseResponse.of(OK, adminMemberQueryRepository.findMembers(condition, pageable)));
     }
 
+    @Operation(summary = "멤버 상세 조회")
     @GetMapping("/{memberId}")
     public ResponseEntity<BaseResponse<MemberDetailView>> getMemberDetail(@PathVariable long memberId) {
         return ResponseEntity.ok(BaseResponse.of(OK, adminMemberQueryRepository.findById(memberId)));

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningController.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningController.java
@@ -5,6 +5,8 @@ import atwoz.atwoz.admin.query.screening.*;
 import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import static atwoz.atwoz.common.enums.StatusType.OK;
 
+@Tag(name = "관리자 페이지 심사 관리 API")
 @RestController
 @RequestMapping("/admin/screenings")
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ public class ScreeningController {
     private final ScreeningQueryRepository screeningQueryRepository;
     private final ScreeningDetailQueryRepository screeningDetailQueryRepository;
 
+    @Operation(summary = "심사 목록 조회")
     @GetMapping
     public ResponseEntity<BaseResponse<Page<ScreeningView>>> getScreenings(
         @Valid @ModelAttribute ScreeningSearchCondition condition,
@@ -32,11 +36,13 @@ public class ScreeningController {
         return ResponseEntity.ok(BaseResponse.of(OK, screeningQueryRepository.findScreenings(condition, pageable)));
     }
 
+    @Operation(summary = "심사 상세 조회")
     @GetMapping("/{screeningId}")
     public ResponseEntity<BaseResponse<ScreeningDetailView>> getScreeningDetail(@PathVariable long screeningId) {
         return ResponseEntity.ok(BaseResponse.of(OK, screeningDetailQueryRepository.findById(screeningId)));
     }
 
+    @Operation(summary = "심사 승인")
     @PostMapping("/{screeningId}/approve")
     public ResponseEntity<BaseResponse<Void>> approve(
         @PathVariable long screeningId,
@@ -47,6 +53,7 @@ public class ScreeningController {
         return ResponseEntity.ok(BaseResponse.from(OK));
     }
 
+    @Operation(summary = "심사 거절")
     @PostMapping("/{screeningId}/reject")
     public ResponseEntity<BaseResponse<Void>> reject(
         @PathVariable long screeningId,

--- a/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningRejectRequest.java
+++ b/src/main/java/atwoz/atwoz/admin/presentation/screening/ScreeningRejectRequest.java
@@ -1,12 +1,13 @@
 package atwoz.atwoz.admin.presentation.screening;
 
+import atwoz.atwoz.admin.command.domain.screening.RejectionReasonType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record ScreeningRejectRequest(
     @Schema(
         description = "반려 사유",
-        allowableValues = {"STOLEN_IMAGE", "INAPPROPRIATE_IMAGE", "EXPLICIT_CONTENT", "OFFENSIVE_LANGUAGE", "CONTACT_IN_PROFILE"},
+        implementation = RejectionReasonType.class,
         example = "STOLEN_IMAGE"
     )
     @NotBlank(message = "반려 사유를 선택해주세요.")

--- a/src/main/java/atwoz/atwoz/admin/query/member/MemberSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/admin/query/member/MemberSearchCondition.java
@@ -1,5 +1,8 @@
 package atwoz.atwoz.admin.query.member;
 
+import atwoz.atwoz.member.command.domain.member.ActivityStatus;
+import atwoz.atwoz.member.command.domain.member.Gender;
+import atwoz.atwoz.member.command.domain.member.Grade;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -9,21 +12,21 @@ import java.time.LocalDate;
 public record MemberSearchCondition(
     @Schema(
         description = "활동 상태",
-        allowableValues = {"ACTIVE", "BANNED", "SUSPENDED", "DORMANT"},
+        implementation = ActivityStatus.class,
         example = "ACTIVE"
     )
     String activityStatus,
 
     @Schema(
         description = "성별",
-        allowableValues = {"MALE", "FEMALE"},
+        implementation = Gender.class,
         example = "MALE"
     )
     String gender,
 
     @Schema(
         description = "등급",
-        allowableValues = {"DIAMOND", "GOLD", "SILVER"},
+        implementation = Grade.class,
         example = "DIAMOND"
     )
     String grade,

--- a/src/main/java/atwoz/atwoz/admin/query/member/MemberView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/member/MemberView.java
@@ -1,11 +1,16 @@
 package atwoz.atwoz.admin.query.member;
 
+import atwoz.atwoz.member.command.domain.member.ActivityStatus;
+import atwoz.atwoz.member.command.domain.member.Gender;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberView(
     long memberId,
     String nickname,
+    @Schema(implementation = Gender.class)
     String gender,
+    @Schema(implementation = ActivityStatus.class)
     String activityStatus,
     String joinedAt,
     int warningCount,

--- a/src/main/java/atwoz/atwoz/admin/query/screening/ScreeningDetailProfileView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/screening/ScreeningDetailProfileView.java
@@ -1,13 +1,20 @@
 package atwoz.atwoz.admin.query.screening;
 
+import atwoz.atwoz.admin.command.domain.screening.RejectionReasonType;
+import atwoz.atwoz.admin.command.domain.screening.ScreeningStatus;
+import atwoz.atwoz.member.command.domain.member.Gender;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ScreeningDetailProfileView(
     long memberId,
+    @Schema(implementation = ScreeningStatus.class)
     String screeningStatus,
+    @Schema(implementation = RejectionReasonType.class)
     String rejectionReason,
     String nickname,
     int age,
+    @Schema(implementation = Gender.class)
     String gender,
     String joinedDate
 ) {

--- a/src/main/java/atwoz/atwoz/admin/query/screening/ScreeningSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/admin/query/screening/ScreeningSearchCondition.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.admin.query.screening;
 
+import atwoz.atwoz.admin.command.domain.screening.ScreeningStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -9,7 +10,7 @@ import java.time.LocalDate;
 public record ScreeningSearchCondition(
     @Schema(
         description = "심사 상태",
-        allowableValues = {"PENDING", "APPROVED", "REJECTED"},
+        implementation = ScreeningStatus.class,
         example = "PENDING"
     )
     String screeningStatus,

--- a/src/main/java/atwoz/atwoz/admin/query/screening/ScreeningView.java
+++ b/src/main/java/atwoz/atwoz/admin/query/screening/ScreeningView.java
@@ -1,13 +1,20 @@
 package atwoz.atwoz.admin.query.screening;
 
+import atwoz.atwoz.admin.command.domain.screening.RejectionReasonType;
+import atwoz.atwoz.admin.command.domain.screening.ScreeningStatus;
+import atwoz.atwoz.member.command.domain.member.Gender;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ScreeningView(
     long screeningId,
     String nickname,
+    @Schema(implementation = Gender.class)
     String gender,
     String joinedDate,
+    @Schema(implementation = ScreeningStatus.class)
     String screeningStatus,
+    @Schema(implementation = RejectionReasonType.class)
     String rejectionReason
 ) {
     @QueryProjection

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionController.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionController.java
@@ -11,12 +11,15 @@ import atwoz.atwoz.community.presentation.selfintroduction.dto.SelfIntroductionW
 import atwoz.atwoz.community.query.selfintroduction.SelfIntroductionQueryRepository;
 import atwoz.atwoz.community.query.selfintroduction.view.SelfIntroductionSummaryView;
 import atwoz.atwoz.community.query.selfintroduction.view.SelfIntroductionView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "셀프 소개 API")
 @RestController
 @RequestMapping("/self-introduction")
 @RequiredArgsConstructor
@@ -25,6 +28,7 @@ public class SelfIntroductionController {
     private final SelfIntroductionService selfIntroductionService;
     private final SelfIntroductionQueryRepository selfIntroductionQueryRepository;
 
+    @Operation(summary = "셀프 소개 작성 API")
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> write(@RequestBody SelfIntroductionWriteRequest request,
         @AuthPrincipal AuthContext authContext) {
@@ -32,6 +36,7 @@ public class SelfIntroductionController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "셀프 소개 수정 API")
     @PatchMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> update(@PathVariable Long id,
         @RequestBody SelfIntroductionWriteRequest request, @AuthPrincipal AuthContext authContext) {
@@ -39,12 +44,14 @@ public class SelfIntroductionController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "셀프 소개 삭제 API")
     @DeleteMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long id, @AuthPrincipal AuthContext authContext) {
         selfIntroductionService.delete(id, authContext.getId());
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "셀프 소개 목록 조회 API")
     @GetMapping
     public ResponseEntity<BaseResponse<List<SelfIntroductionSummaryView>>> getIntroductions(
         @ModelAttribute SelfIntroductionSearchRequest searchRequest, Long lastId) {
@@ -54,6 +61,7 @@ public class SelfIntroductionController {
             selfIntroductionQueryRepository.findSelfIntroductions(searchCondition, lastId)));
     }
 
+    @Operation(summary = "셀프 소개 상세 조회 API")
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<SelfIntroductionView>> getIntroduction(@PathVariable Long id,
         @AuthPrincipal AuthContext authContext) {

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchRequest.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchRequest.java
@@ -1,13 +1,18 @@
 package atwoz.atwoz.community.presentation.selfintroduction.dto;
 
 import atwoz.atwoz.member.command.domain.member.City;
+import atwoz.atwoz.member.command.domain.member.Gender;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
 public record SelfIntroductionSearchRequest(
+    @ArraySchema(schema = @Schema(implementation = City.class))
     List<City> preferredCities,
     Integer fromAge,
     Integer toAge,
+    @Schema(implementation = Gender.class)
     String gender
 ) {
 }

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/AdminSelfIntroductionView.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/AdminSelfIntroductionView.java
@@ -1,6 +1,8 @@
 package atwoz.atwoz.community.query.selfintroduction.view;
 
+import atwoz.atwoz.member.command.domain.member.Gender;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -8,6 +10,7 @@ import java.time.format.DateTimeFormatter;
 public record AdminSelfIntroductionView(
     long selfIntroductionId,
     String nickname,
+    @Schema(implementation = Gender.class)
     String gender,
     boolean isOpened,
     String content,

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/MemberBasicInfo.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/MemberBasicInfo.java
@@ -1,6 +1,11 @@
 package atwoz.atwoz.community.query.selfintroduction.view;
 
+import atwoz.atwoz.member.command.domain.member.City;
+import atwoz.atwoz.member.command.domain.member.District;
+import atwoz.atwoz.member.command.domain.member.Hobby;
 import atwoz.atwoz.member.query.member.AgeConverter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Set;
 
@@ -9,9 +14,13 @@ public record MemberBasicInfo(
     String nickname,
     Integer age,
     String profileImageUrl,
+    @Schema(implementation = City.class)
     String city,
+    @Schema(implementation = District.class)
     String district,
+    @Schema(implementation = String.class)
     String mbti,
+    @ArraySchema(schema = @Schema(implementation = Hobby.class))
     Set<String> hobbies
 ) {
     public MemberBasicInfo {

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/SelfIntroductionView.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/view/SelfIntroductionView.java
@@ -1,11 +1,14 @@
 package atwoz.atwoz.community.query.selfintroduction.view;
 
+import atwoz.atwoz.like.command.domain.LikeLevel;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Set;
 
 public record SelfIntroductionView(
     MemberBasicInfo memberBasicInfo,
+    @Schema(implementation = LikeLevel.class)
     String like,
     String title,
     String content

--- a/src/main/java/atwoz/atwoz/heart/presentation/hearttransaction/AdminHeartTransactionController.java
+++ b/src/main/java/atwoz/atwoz/heart/presentation/hearttransaction/AdminHeartTransactionController.java
@@ -5,6 +5,8 @@ import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.heart.query.hearttransaction.HeartTransactionQueryRepository;
 import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
 import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,12 +17,14 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "어드민 하트 트랜잭션 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/heart-transactions")
 public class AdminHeartTransactionController {
     private final HeartTransactionQueryRepository heartTransactionQueryRepository;
 
+    @Operation(summary = "하트 트랜잭션 목록 조회 API")
     @GetMapping
     public ResponseEntity<BaseResponse<Page<HeartTransactionView>>> getPage(
         @ModelAttribute HeartTransactionSearchCondition condition,

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/HeartTransactionView.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/HeartTransactionView.java
@@ -1,12 +1,15 @@
 package atwoz.atwoz.heart.query.hearttransaction.view;
 
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
 public record HeartTransactionView(
     Long id,
     LocalDateTime createdAt,
+    @Schema(implementation = TransactionType.class)
     String transactionType,
     String content,
     Long heartAmount,

--- a/src/main/java/atwoz/atwoz/like/presentation/LikeController.java
+++ b/src/main/java/atwoz/atwoz/like/presentation/LikeController.java
@@ -5,6 +5,8 @@ import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.like.command.application.LikeSendService;
 import atwoz.atwoz.like.query.LikeQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import static atwoz.atwoz.common.enums.StatusType.OK;
 
+@Tag(name = "좋아요 관리 API")
 @RestController
 @RequestMapping("/likes")
 @RequiredArgsConstructor
@@ -19,6 +22,7 @@ public class LikeController {
     private final LikeSendService likeSendService;
     private final LikeQueryService likeQueryService;
 
+    @Operation(summary = "좋아요 보내기")
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> send(
         @Valid @RequestBody LikeSendRequest request,
@@ -29,6 +33,7 @@ public class LikeController {
         return ResponseEntity.ok(BaseResponse.from(OK));
     }
 
+    @Operation(summary = "내가 보낸 좋아요 목록 조회")
     @GetMapping("/sent")
     public ResponseEntity<BaseResponse<LikeViews>> getSentLikes(
         @ModelAttribute LikeListRequest request,
@@ -38,6 +43,7 @@ public class LikeController {
         return ResponseEntity.ok(BaseResponse.of(OK, sentLikes));
     }
 
+    @Operation(summary = "내가 받은 좋아요 목록 조회")
     @GetMapping("/received")
     public ResponseEntity<BaseResponse<LikeViews>> getReceivedLikes(
         @ModelAttribute LikeListRequest request,

--- a/src/main/java/atwoz/atwoz/like/presentation/LikeSendRequest.java
+++ b/src/main/java/atwoz/atwoz/like/presentation/LikeSendRequest.java
@@ -1,6 +1,12 @@
 package atwoz.atwoz.like.presentation;
 
+import atwoz.atwoz.like.command.domain.LikeLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record LikeSendRequest(long receiverId, @NotNull LikeLevelRequest likeLevel) {
+public record LikeSendRequest(
+    long receiverId,
+    @Schema(implementation = LikeLevel.class)
+    @NotNull LikeLevelRequest likeLevel
+) {
 }

--- a/src/main/java/atwoz/atwoz/like/query/LikeView.java
+++ b/src/main/java/atwoz/atwoz/like/query/LikeView.java
@@ -1,5 +1,8 @@
 package atwoz.atwoz.like.query;
 
+import atwoz.atwoz.member.command.domain.member.City;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
 public record LikeView(
@@ -7,6 +10,7 @@ public record LikeView(
     long opponentId,
     String profileImageUrl,
     String nickname,
+    @Schema(implementation = City.class)
     String city,
     int age,
     boolean isMutualLike,

--- a/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
+++ b/src/main/java/atwoz/atwoz/match/presentation/MatchController.java
@@ -7,16 +7,20 @@ import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.match.command.application.match.MatchService;
 import atwoz.atwoz.match.presentation.dto.MatchRequestDto;
 import atwoz.atwoz.match.presentation.dto.MatchResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "메시지(매칭) 관리 API")
 @RestController
 @RequestMapping("/match")
 @RequiredArgsConstructor
 public class MatchController {
     private final MatchService matchService;
 
+    @Operation(summary = "메시지 전송 (매칭 요청)")
     @PostMapping("/request")
     public ResponseEntity<BaseResponse<Void>> requestMatch(@RequestBody MatchRequestDto matchRequestDto,
         @AuthPrincipal AuthContext authContext) {
@@ -24,6 +28,7 @@ public class MatchController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "메시지 응답 (매칭 수락)")
     @PatchMapping("/{matchId}/approve")
     public ResponseEntity<BaseResponse<Void>> approveMatch(@PathVariable Long matchId,
         @RequestBody MatchResponseDto matchResponseDto, @AuthPrincipal AuthContext authContext) {
@@ -31,6 +36,7 @@ public class MatchController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "메시지 거절 (매칭 거절)")
     @PatchMapping("/{matchId}/reject")
     public ResponseEntity<BaseResponse<Void>> rejectMatch(@PathVariable Long matchId,
         @AuthPrincipal AuthContext authContext) {
@@ -38,6 +44,7 @@ public class MatchController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "메시지 읽음 처리 (매칭 읽음 처리)")
     @PatchMapping("/{matchId}/check")
     public ResponseEntity<BaseResponse<Void>> check(@PathVariable Long matchId,
         @AuthPrincipal AuthContext authContext) {

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIdealController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIdealController.java
@@ -9,11 +9,14 @@ import atwoz.atwoz.member.command.application.introduction.exception.MemberIdeal
 import atwoz.atwoz.member.presentation.introduction.dto.MemberIdealUpdateRequest;
 import atwoz.atwoz.member.query.introduction.application.MemberIdealView;
 import atwoz.atwoz.member.query.introduction.intra.MemberIdealQueryRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "멤버 이상형 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/member/ideal")
@@ -21,6 +24,7 @@ public class MemberIdealController {
     private final MemberIdealService idealService;
     private final MemberIdealQueryRepository memberIdealQueryRepository;
 
+    @Operation(summary = "멤버 이상형 설정 조회")
     @GetMapping
     public ResponseEntity<BaseResponse<MemberIdealView>> getMemberIdeal(@AuthPrincipal AuthContext authContext) {
         long memberId = authContext.getId();
@@ -29,6 +33,7 @@ public class MemberIdealController {
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, memberIdealView));
     }
 
+    @Operation(summary = "멤버 이상형 설정 수정")
     @PatchMapping
     public ResponseEntity<BaseResponse<Void>> updateIdeal(@Valid @RequestBody MemberIdealUpdateRequest request,
         @AuthPrincipal AuthContext authContext) {

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIdealUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/dto/MemberIdealUpdateRequest.java
@@ -1,5 +1,8 @@
 package atwoz.atwoz.member.presentation.introduction.dto;
 
+import atwoz.atwoz.member.command.domain.member.*;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -15,11 +18,16 @@ public record MemberIdealUpdateRequest(
     @Min(value = 20, message = "최대 나이는 20보다 작을 수 없습니다.")
     @Max(value = 46, message = "최대 나이는 46보다 작을 수 없습니다.")
     Integer maxAge,
+    @ArraySchema(schema = @Schema(implementation = City.class))
     @NotNull(message = "지역을 입력해주세요.")
     Set<String> cities,
+    @Schema(implementation = Religion.class)
     String religion,
+    @Schema(implementation = SmokingStatus.class)
     String smokingStatus,
+    @Schema(implementation = DrinkingStatus.class)
     String drinkingStatus,
+    @ArraySchema(schema = @Schema(implementation = Hobby.class))
     @NotNull(message = "취미를 입력해주세요.")
     Set<String> hobbies
 ) {

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
@@ -7,6 +7,8 @@ import atwoz.atwoz.member.command.application.member.MemberAuthService;
 import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
 import atwoz.atwoz.member.presentation.member.dto.MemberLoginRequest;
 import atwoz.atwoz.member.presentation.member.dto.MemberLoginResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -14,6 +16,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "멤버 인증 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/member")
@@ -22,6 +25,7 @@ public class MemberAuthController {
     private final RefreshTokenCookieProperties refreshTokenCookieProperties;
     private final MemberAuthService memberAuthService;
 
+    @Operation(summary = "멤버 로그인 및 회원가입")
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<MemberLoginResponse>> login(@Valid @RequestBody MemberLoginRequest request) {
         MemberLoginServiceDto loginServiceDto = memberAuthService.login(request.phoneNumber());
@@ -43,6 +47,7 @@ public class MemberAuthController {
             .body(BaseResponse.of(StatusType.OK, loginResponse));
     }
 
+    @Operation(summary = "멤버 로그아웃")
     @GetMapping("/logout")
     public ResponseEntity<BaseResponse<Void>> logout(
         @CookieValue(value = "refresh_token", required = false) String refreshToken) {

--- a/src/main/java/atwoz/atwoz/member/presentation/member/dto/MemberProfileUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/dto/MemberProfileUpdateRequest.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.member.presentation.member.dto;
 
 import atwoz.atwoz.member.command.domain.member.*;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Set;
@@ -23,7 +24,7 @@ public record MemberProfileUpdateRequest(
     String drinkingStatus,
     @Schema(implementation = Religion.class)
     String religion,
-    @Schema(implementation = Hobby.class)
+    @ArraySchema(schema = @Schema(implementation = Hobby.class))
     Set<String> hobbies,
     @Schema(implementation = Job.class)
     String job

--- a/src/main/java/atwoz/atwoz/member/presentation/profileimage/ProfileImageController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/profileimage/ProfileImageController.java
@@ -9,6 +9,8 @@ import atwoz.atwoz.member.command.application.profileImage.dto.ProfileImageUploa
 import atwoz.atwoz.member.presentation.profileimage.dto.ProfileImageUploadRequestWrapper;
 import atwoz.atwoz.member.query.profileimage.ProfileImageQueryRepository;
 import atwoz.atwoz.member.query.profileimage.view.ProfileImageView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "프로필 이미지 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/profileimage")
@@ -25,6 +28,7 @@ public class ProfileImageController {
     private final ProfileImageService profileImageService;
     private final ProfileImageQueryRepository profileImageQueryRepository;
 
+    @Operation(summary = "프로필 이미지 업로드")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<BaseResponse<List<ProfileImageUploadResponse>>> updateProfileImage(
         @ModelAttribute @Valid ProfileImageUploadRequestWrapper request, @AuthPrincipal AuthContext authContext) {
@@ -32,6 +36,7 @@ public class ProfileImageController {
             BaseResponse.of(StatusType.OK, profileImageService.save(authContext.getId(), request.getRequests())));
     }
 
+    @Operation(summary = "프로필 이미지 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> deleteProfileImage(@PathVariable Long id,
         @AuthPrincipal AuthContext authContext) {
@@ -39,6 +44,7 @@ public class ProfileImageController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "내 프로필 이미지 조회")
     @GetMapping
     public ResponseEntity<BaseResponse<List<ProfileImageView>>> getMyProfileImages(
         @AuthPrincipal AuthContext authContext) {

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/MemberIntroductionProfileView.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/MemberIntroductionProfileView.java
@@ -4,6 +4,7 @@ import atwoz.atwoz.like.command.domain.LikeLevel;
 import atwoz.atwoz.member.command.domain.member.Hobby;
 import atwoz.atwoz.member.command.domain.member.Mbti;
 import atwoz.atwoz.member.command.domain.member.Religion;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.List;
 public record MemberIntroductionProfileView(
     long memberId,
     String profileImageUrl,
-    @Schema(implementation = Hobby.class)
+    @ArraySchema(schema = @Schema(implementation = Hobby.class))
     List<String> hobbies,
     @Schema(implementation = Mbti.class)
     String mbti,

--- a/src/main/java/atwoz/atwoz/member/query/member/view/ProfileInfo.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/view/ProfileInfo.java
@@ -1,6 +1,7 @@
 package atwoz.atwoz.member.query.member.view;
 
 import atwoz.atwoz.member.command.domain.member.*;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Set;
@@ -22,7 +23,7 @@ public record ProfileInfo(
     String drinkingStatus,
     @Schema(implementation = Religion.class)
     String religion,
-    @Schema(implementation = Hobby.class)
+    @ArraySchema(schema = @Schema(implementation = Hobby.class))
     Set<String> hobbies
 ) {
 }

--- a/src/main/java/atwoz/atwoz/notification/query/NotificationView.java
+++ b/src/main/java/atwoz/atwoz/notification/query/NotificationView.java
@@ -1,10 +1,13 @@
 package atwoz.atwoz.notification.query;
 
+import atwoz.atwoz.notification.command.domain.NotificationType;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record NotificationView(
     long notificationId,
     long senderId,
+    @Schema(implementation = NotificationType.class)
     String notificationType,
     String title,
     String body

--- a/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/heartpurchaseoption/AdminHeartPurchaseOptionController.java
@@ -7,6 +7,8 @@ import atwoz.atwoz.payment.presentation.heartpurchaseoption.dto.HeartPurchaseOpt
 import atwoz.atwoz.payment.query.heartpurchaseoption.HeartPurchaseOptionQueryRepository;
 import atwoz.atwoz.payment.query.heartpurchaseoption.condition.HeartPurchaseOptionSearchCondition;
 import atwoz.atwoz.payment.query.heartpurchaseoption.view.HeartPurchaseOptionView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +17,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "어드민 하트 구매 옵션 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/heart-purchase-options")
@@ -22,19 +25,21 @@ public class AdminHeartPurchaseOptionController {
     private final HeartPurchaseOptionService heartPurchaseOptionService;
     private final HeartPurchaseOptionQueryRepository heartPurchaseOptionQueryRepository;
 
+    @Operation(summary = "하트 구매 옵션 생성")
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> create(@Valid @RequestBody HeartPurchaseOptionCreateRequest request) {
         heartPurchaseOptionService.create(request);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
-
+    @Operation(summary = "하트 구매 옵션 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long id) {
         heartPurchaseOptionService.delete(id);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "하트 구매 옵션 목록 조회")
     @GetMapping
     public ResponseEntity<BaseResponse<Page<HeartPurchaseOptionView>>> getPage(
         @ModelAttribute HeartPurchaseOptionSearchCondition condition,

--- a/src/main/java/atwoz/atwoz/payment/presentation/order/PaymentController.java
+++ b/src/main/java/atwoz/atwoz/payment/presentation/order/PaymentController.java
@@ -6,6 +6,8 @@ import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.payment.command.application.order.AppStorePaymentService;
 import atwoz.atwoz.payment.presentation.order.dto.VerifyReceiptRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -15,12 +17,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "앱스토어 결제 영수증 인증 API")
 @RestController
 @RequestMapping("/payment")
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class PaymentController {
     private final AppStorePaymentService appStorePaymentService;
 
+    @Operation(summary = "앱스토어 결제 영수증 인증")
     @PostMapping("/app-store/verify-receipt")
     public ResponseEntity<BaseResponse<Void>> verifyReceipt(@Valid @RequestBody VerifyReceiptRequest request,
         @AuthPrincipal AuthContext authContext) {

--- a/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/AdminReportController.java
@@ -11,6 +11,8 @@ import atwoz.atwoz.report.query.ReportQueryRepository;
 import atwoz.atwoz.report.query.condition.ReportSearchCondition;
 import atwoz.atwoz.report.query.view.ReportDetailView;
 import atwoz.atwoz.report.query.view.ReportView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,6 +21,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "어드민 신고 관리 API")
 @RestController
 @RequestMapping("/admin/reports")
 @RequiredArgsConstructor
@@ -26,6 +29,7 @@ public class AdminReportController {
     private final AdminReportService adminReportService;
     private final ReportQueryRepository reportQueryRepository;
 
+    @Operation(summary = "신고 처리 결정")
     @PatchMapping("/{id}/result")
     public ResponseEntity<BaseResponse<Void>> updateResult(
         @PathVariable long id,
@@ -36,6 +40,7 @@ public class AdminReportController {
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 
+    @Operation(summary = "신고 목록 조회")
     @GetMapping
     public ResponseEntity<BaseResponse<Page<ReportView>>> getPage(
         @ModelAttribute ReportSearchCondition condition,
@@ -45,6 +50,7 @@ public class AdminReportController {
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, page));
     }
 
+    @Operation(summary = "신고 상세 조회")
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<ReportDetailView>> getReport(@PathVariable long id) {
         ReportDetailView view = reportQueryRepository.findReportDetailView(id)

--- a/src/main/java/atwoz/atwoz/report/presentation/ReportController.java
+++ b/src/main/java/atwoz/atwoz/report/presentation/ReportController.java
@@ -6,6 +6,8 @@ import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.report.command.application.ReportService;
 import atwoz.atwoz.report.presentation.dto.ReportCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +16,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "신고 API")
 @RestController
 @RequestMapping("/reports")
 @RequiredArgsConstructor
 public class ReportController {
     private final ReportService reportService;
 
+    @Operation(summary = "신고하기")
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> report(@Valid @RequestBody ReportCreateRequest request,
         @AuthPrincipal AuthContext authContext) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - 관리자, 멤버, 커뮤니티, 하트, 매칭, 결제, 신고 등 주요 API 컨트롤러에 Swagger(OpenAPI) 태그 및 설명이 추가되어 API 문서가 개선되었습니다.
  - 여러 DTO 및 뷰 객체의 필드에 Swagger 스키마/배열 어노테이션이 추가되어, enum 및 컬렉션 타입이 명확하게 문서화되었습니다.
  - 허용 값이 enum 클래스로 연결되어 API 문서의 신뢰성과 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- API 설명 + `@Schema(implementation)`적용했어요
- List로 되어있는건 그냥 `@Schema` 만 사용하면 List로 노출이 안되어서 `@ArraySchema(schema = @Schema(implementation))` 으로 처리했어요
- API 설명이 어색하거나 부정확한게 있는지 위주로 확인해주시면 될 것 같아요!
