### PR TITLE
관리자 회원 상세 관리 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/member/command/application/AdminMemberService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/AdminMemberService.java
@@ -1,0 +1,35 @@
+package atwoz.atwoz.member.command.application;
+
+import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
+import atwoz.atwoz.member.command.domain.member.ActivityStatus;
+import atwoz.atwoz.member.command.domain.member.Grade;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import atwoz.atwoz.member.presentation.member.dto.AdminMemberSettingUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberService {
+
+    private final MemberCommandRepository memberCommandRepository;
+
+    @Transactional
+    public void updateMemberSetting(long memberId, AdminMemberSettingUpdateRequest request) {
+        Grade grade = Grade.from(request.grade());
+        ActivityStatus activityStatus = ActivityStatus.from(request.activityStatus());
+        Member member = getMember(memberId);
+        member.updateSetting(
+            grade,
+            activityStatus,
+            request.isVip(),
+            request.isPushNotificationEnabled()
+        );
+    }
+
+    private Member getMember(long memberId) {
+        return memberCommandRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/application/member/AdminMemberService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/AdminMemberService.java
@@ -1,4 +1,4 @@
-package atwoz.atwoz.member.command.application;
+package atwoz.atwoz.member.command.application.member;
 
 import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
 import atwoz.atwoz.member.command.domain.member.ActivityStatus;

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/ActivityStatus.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/ActivityStatus.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.member.command.domain.member;
 
+import atwoz.atwoz.member.command.domain.member.exception.InvalidMemberEnumValueException;
 import lombok.Getter;
 
 @Getter
@@ -13,5 +14,13 @@ public enum ActivityStatus {
 
     ActivityStatus(String description) {
         this.description = description;
+    }
+
+    public static ActivityStatus from(String activityStatus) {
+        try {
+            return ActivityStatus.valueOf(activityStatus.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidMemberEnumValueException("Invalid activity status: " + activityStatus);
+        }
     }
 }

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Grade.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Grade.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.member.command.domain.member;
 
+import atwoz.atwoz.member.command.domain.member.exception.InvalidMemberEnumValueException;
 import lombok.Getter;
 
 @Getter
@@ -12,5 +13,13 @@ public enum Grade {
 
     Grade(String description) {
         this.description = description;
+    }
+
+    public static Grade from(String grade) {
+        try {
+            return Grade.valueOf(grade.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidMemberEnumValueException("Invalid grade value: " + grade);
+        }
     }
 }

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
@@ -4,6 +4,7 @@ import atwoz.atwoz.common.entity.SoftDeleteBaseEntity;
 import atwoz.atwoz.common.event.Events;
 import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartAmount;
 import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartBalance;
+import atwoz.atwoz.member.command.domain.member.event.MemberSettingUpdatedEvent;
 import atwoz.atwoz.member.command.domain.member.event.PurchaseHeartGainedEvent;
 import atwoz.atwoz.member.command.domain.member.exception.MemberNotActiveException;
 import atwoz.atwoz.member.command.domain.member.vo.KakaoId;
@@ -133,5 +134,17 @@ public class Member extends SoftDeleteBaseEntity {
 
     public void updateGrade(@NonNull Grade grade) {
         this.grade = grade;
+    }
+
+    public void updateSetting(
+        @NonNull Grade grade,
+        @NonNull ActivityStatus activityStatus,
+        boolean isVip,
+        boolean isPushNotificationEnabled
+    ) {
+        this.grade = grade;
+        this.activityStatus = activityStatus;
+        this.isVip = isVip;
+        Events.raise(MemberSettingUpdatedEvent.of(id, isPushNotificationEnabled));
     }
 }

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/event/MemberSettingUpdatedEvent.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/event/MemberSettingUpdatedEvent.java
@@ -1,0 +1,16 @@
+package atwoz.atwoz.member.command.domain.member.event;
+
+import atwoz.atwoz.common.event.Event;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@Getter
+public class MemberSettingUpdatedEvent extends Event {
+    private final long memberId;
+    private final boolean isPushNotificationEnabled;
+
+    public static MemberSettingUpdatedEvent of(long memberId, boolean isPushNotificationEnabled) {
+        return new MemberSettingUpdatedEvent(memberId, isPushNotificationEnabled);
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/presentation/member/AdminMemberController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/AdminMemberController.java
@@ -1,7 +1,7 @@
 package atwoz.atwoz.member.presentation.member;
 
 import atwoz.atwoz.common.response.BaseResponse;
-import atwoz.atwoz.member.command.application.AdminMemberService;
+import atwoz.atwoz.member.command.application.member.AdminMemberService;
 import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
 import atwoz.atwoz.member.presentation.member.dto.AdminMemberSettingUpdateRequest;
 import atwoz.atwoz.member.query.member.condition.AdminMemberSearchCondition;

--- a/src/main/java/atwoz/atwoz/member/presentation/member/AdminMemberController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/AdminMemberController.java
@@ -1,7 +1,9 @@
 package atwoz.atwoz.member.presentation.member;
 
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.member.command.application.AdminMemberService;
 import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
+import atwoz.atwoz.member.presentation.member.dto.AdminMemberSettingUpdateRequest;
 import atwoz.atwoz.member.query.member.condition.AdminMemberSearchCondition;
 import atwoz.atwoz.member.query.member.infra.AdminMemberQueryRepository;
 import atwoz.atwoz.member.query.member.view.AdminMemberDetailView;
@@ -24,6 +26,7 @@ import static atwoz.atwoz.common.enums.StatusType.OK;
 @RequiredArgsConstructor
 public class AdminMemberController {
 
+    private final AdminMemberService adminMemberService;
     private final AdminMemberQueryRepository adminMemberQueryRepository;
 
     @Operation(summary = "멤버 목록 조회")
@@ -41,5 +44,15 @@ public class AdminMemberController {
         AdminMemberDetailView view = adminMemberQueryRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
         return ResponseEntity.ok(BaseResponse.of(OK, view));
+    }
+
+    @Operation(summary = "멤버 설정 업데이트")
+    @PutMapping("/{memberId}/settings")
+    public ResponseEntity<BaseResponse<Void>> updateMemberSetting(
+        @Valid @RequestBody AdminMemberSettingUpdateRequest request,
+        @PathVariable long memberId
+    ) {
+        adminMemberService.updateMemberSetting(memberId, request);
+        return ResponseEntity.ok(BaseResponse.from(OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/member/dto/AdminMemberSettingUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/dto/AdminMemberSettingUpdateRequest.java
@@ -1,0 +1,15 @@
+package atwoz.atwoz.member.presentation.member.dto;
+
+import atwoz.atwoz.member.command.domain.member.ActivityStatus;
+import atwoz.atwoz.member.command.domain.member.Grade;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminMemberSettingUpdateRequest(
+    @Schema(implementation = Grade.class)
+    String grade,
+    @Schema(implementation = ActivityStatus.class)
+    String activityStatus,
+    boolean isVip,
+    boolean isPushNotificationEnabled
+) {
+}

--- a/src/main/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepository.java
@@ -141,11 +141,11 @@ public class AdminMemberQueryRepository {
                     new QAdminMemberSettingInfo(
                         member.grade.stringValue(),
                         member.activityStatus.stringValue(),
-                        member.isVip
+                        member.isVip,
+                        notificationPreference.isEnabledGlobally
                     ),
                     new QAdminMemberStatusInfo(
                         member.primaryContactType.stringValue(),
-                        notificationPreference.isEnabledGlobally,
                         constant(hasInterviewAnswers),
                         constant(warningCount)
                     ),

--- a/src/main/java/atwoz/atwoz/member/query/member/view/AdminMemberSettingInfo.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/view/AdminMemberSettingInfo.java
@@ -11,7 +11,8 @@ public record AdminMemberSettingInfo(
     String grade,
     @Schema(implementation = ActivityStatus.class)
     String activityStatus,
-    boolean isVip
+    boolean isVip,
+    boolean isPushNotificationEnabled
 ) {
     @QueryProjection
     public AdminMemberSettingInfo {

--- a/src/main/java/atwoz/atwoz/member/query/member/view/AdminMemberStatusInfo.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/view/AdminMemberStatusInfo.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record AdminMemberStatusInfo(
     @Schema(implementation = PrimaryContactType.class)
     String primaryContactType,
-    boolean isPushNotificationEnabled,
     boolean hasInterviewAnswer,
     int warningCount
 ) {

--- a/src/main/java/atwoz/atwoz/notification/command/infra/MemberSettingUpdatedEventHandler.java
+++ b/src/main/java/atwoz/atwoz/notification/command/infra/MemberSettingUpdatedEventHandler.java
@@ -1,0 +1,34 @@
+package atwoz.atwoz.notification.command.infra;
+
+import atwoz.atwoz.member.command.domain.member.event.MemberSettingUpdatedEvent;
+import atwoz.atwoz.notification.command.application.NotificationPreferenceNotFoundException;
+import atwoz.atwoz.notification.command.application.NotificationPreferenceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberSettingUpdatedEventHandler {
+    private final NotificationPreferenceService notificationPreferenceService;
+
+    @Async
+    @TransactionalEventListener(value = MemberSettingUpdatedEvent.class, phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(MemberSettingUpdatedEvent event) {
+        try {
+            if (event.isPushNotificationEnabled()) {
+                notificationPreferenceService.enableGlobally(event.getMemberId());
+            } else {
+                notificationPreferenceService.disableGlobally(event.getMemberId());
+            }
+        } catch (NotificationPreferenceNotFoundException e) {
+            log.warn(e.getMessage());
+        } catch (Exception e) {
+            log.error("Member(id: {})의 NotificationPreference 업데이트 중 예외가 발생했습니다.", event.getMemberId(), e);
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/command/application/member/AdminMemberServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/AdminMemberServiceTest.java
@@ -1,0 +1,63 @@
+package atwoz.atwoz.member.command.application.member;
+
+import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
+import atwoz.atwoz.member.command.domain.member.ActivityStatus;
+import atwoz.atwoz.member.command.domain.member.Grade;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import atwoz.atwoz.member.presentation.member.dto.AdminMemberSettingUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMemberServiceTest {
+
+    @InjectMocks
+    AdminMemberService adminMemberService;
+
+    @Mock
+    MemberCommandRepository memberCommandRepository;
+
+    @Test
+    @DisplayName("관리자 회원 설정 업데이트 테스트")
+    void updateMemberSetting() {
+        // given
+        long memberId = 1L;
+        AdminMemberSettingUpdateRequest request = new AdminMemberSettingUpdateRequest(
+            Grade.SILVER.name(), ActivityStatus.ACTIVE.name(), true, true
+        );
+        final Member member = mock(Member.class);
+        when(memberCommandRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // when
+        adminMemberService.updateMemberSetting(memberId, request);
+
+        // then
+        verify(member).updateSetting(Grade.from(request.grade()), ActivityStatus.from(request.activityStatus()),
+            request.isVip(), request.isPushNotificationEnabled());
+    }
+
+    @Test
+    @DisplayName("회원 설정 업데이트 시 회원이 존재하지 않을 경우 예외 발생 테스트")
+    void updateMemberSetting_MemberNotFound() {
+        // given
+        long memberId = 1L;
+        AdminMemberSettingUpdateRequest request = new AdminMemberSettingUpdateRequest(
+            Grade.SILVER.name(), ActivityStatus.ACTIVE.name(), true, true
+        );
+        when(memberCommandRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminMemberService.updateMemberSetting(memberId, request))
+            .isInstanceOf(MemberNotFoundException.class);
+    }
+}

--- a/src/test/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepositoryTest.java
@@ -248,8 +248,8 @@ class AdminMemberQueryRepositoryTest {
             assertHeartBalanceView(result.heartBalanceInfo(), member);
             assertProfileImageUrls(result.profileImageUrls(), profileImages);
             assertProfileInfo(result.profileInfo(), member);
-            assertAdminMemberSettingInfo(result.settingInfo(), member);
-            assertAdminMemberStatusInfo(result.statusInfo(), member, 2, notificationPreference, true);
+            assertAdminMemberSettingInfo(result.settingInfo(), member, notificationPreference);
+            assertAdminMemberStatusInfo(result.statusInfo(), member, 2, true);
             assertDateInfo(result, member);
         }
 

--- a/src/test/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepositoryTest.java
@@ -322,16 +322,17 @@ class AdminMemberQueryRepositoryTest {
             assertThat(profileInfo.hobbies()).containsExactlyInAnyOrderElementsOf(hobbies);
         }
 
-        private void assertAdminMemberSettingInfo(AdminMemberSettingInfo settingInfo, Member member) {
+        private void assertAdminMemberSettingInfo(AdminMemberSettingInfo settingInfo, Member member,
+            NotificationPreference notificationPreference) {
             assertThat(settingInfo.grade()).isEqualTo(member.getGrade().name());
             assertThat(settingInfo.activityStatus()).isEqualTo(member.getActivityStatus().name());
             assertThat(settingInfo.isVip()).isEqualTo(member.isVip());
+            assertThat(settingInfo.isPushNotificationEnabled()).isEqualTo(notificationPreference.isEnabledGlobally());
         }
 
         private void assertAdminMemberStatusInfo(AdminMemberStatusInfo statusInfo, Member member, int warningCount,
-            NotificationPreference notificationPreference, boolean hasInterviewAnswers) {
+            boolean hasInterviewAnswers) {
             assertThat(statusInfo.primaryContactType()).isEqualTo(member.getPrimaryContactType().name());
-            assertThat(statusInfo.isPushNotificationEnabled()).isEqualTo(notificationPreference.isEnabledGlobally());
             assertThat(statusInfo.hasInterviewAnswer()).isEqualTo(hasInterviewAnswers);
             assertThat(statusInfo.warningCount()).isEqualTo(warningCount);
         }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 관리자가 회원의 등급, 활동 상태, VIP 여부, 푸시 알림 설정을 한 번에 수정할 수 있는 API가 추가되었습니다.
  - 회원 정보 수정 시 푸시 알림 설정 변경이 반영되며, 관련 이벤트가 발행됩니다.

- **개선 사항**
  - 회원 정보 조회 시 푸시 알림 설정 여부가 별도의 정보로 제공됩니다.

- **버그 수정**
  - 회원 상태 정보에서 푸시 알림 설정 필드가 제거되어 중복 정보가 해소되었습니다.

- **테스트**
  - 관리자 회원 설정 변경 및 회원 정보 변경 이벤트 관련 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- 관리자 회원 상세 조회 API 구현 당시에 멤버의 푸시 알림 여부 설정을 관리자가 수정하는게 부적절하다고 생각해서 `isPushNotificationEnabled` 를 Setting dto가 아닌 status dto에 뒀는데 민호님과 이야기 해보니 푸시 알림 설정을 찾지 못해서 푸시 알림 꺼달라는 요구 사항이 자주 발생하기 때문에 관리자 페이지에서 수정이 필요하다 하여 다시 Setting dto로 이동 시켰어요