### PR TITLE
프로필 공개 여부 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/command/domain/screening/Screening.java
+++ b/src/main/java/atwoz/atwoz/admin/command/domain/screening/Screening.java
@@ -1,6 +1,8 @@
 package atwoz.atwoz.admin.command.domain.screening;
 
+import atwoz.atwoz.admin.command.domain.screening.event.ScreeningApprovedEvent;
 import atwoz.atwoz.common.entity.BaseEntity;
+import atwoz.atwoz.common.event.Events;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -52,6 +54,7 @@ public class Screening extends BaseEntity {
         setAdminId(adminId);
         changeScreeningStatus(ScreeningStatus.APPROVED);
         setRejectionReason(null);
+        Events.raise(ScreeningApprovedEvent.from(memberId));
     }
 
     public void reject(long adminId, RejectionReasonType rejectionReason) {

--- a/src/main/java/atwoz/atwoz/admin/command/domain/screening/event/ScreeningApprovedEvent.java
+++ b/src/main/java/atwoz/atwoz/admin/command/domain/screening/event/ScreeningApprovedEvent.java
@@ -1,0 +1,16 @@
+package atwoz.atwoz.admin.command.domain.screening.event;
+
+import atwoz.atwoz.common.event.Event;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScreeningApprovedEvent extends Event {
+    private final long memberId;
+
+    public static ScreeningApprovedEvent from(long memberId) {
+        return new ScreeningApprovedEvent(memberId);
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/command/application/member/AdminMemberService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/AdminMemberService.java
@@ -23,6 +23,7 @@ public class AdminMemberService {
         Member member = getMember(memberId);
         member.updateSetting(
             grade,
+            request.isProfilePublic(),
             activityStatus,
             request.isVip(),
             request.isPushNotificationEnabled()

--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberProfileService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberProfileService.java
@@ -38,6 +38,12 @@ public class MemberProfileService {
         }
     }
 
+    @Transactional
+    public void publishProfile(Long memberId) {
+        Member member = getMemberById(memberId);
+        member.publishProfile();
+    }
+
     private Member getMemberById(Long memberId) {
         return memberCommandRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
     }

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
@@ -141,11 +141,13 @@ public class Member extends SoftDeleteBaseEntity {
 
     public void updateSetting(
         @NonNull Grade grade,
+        boolean isProfilePublic,
         @NonNull ActivityStatus activityStatus,
         boolean isVip,
         boolean isPushNotificationEnabled
     ) {
         this.grade = grade;
+        this.isProfilePublic = isProfilePublic;
         this.activityStatus = activityStatus;
         this.isVip = isVip;
         Events.raise(MemberSettingUpdatedEvent.of(id, isPushNotificationEnabled));

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
@@ -39,6 +39,7 @@ public class Member extends SoftDeleteBaseEntity {
     private boolean isVip;
 
     @Getter
+    @Builder.Default
     private boolean isProfilePublic = false;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
@@ -38,6 +38,9 @@ public class Member extends SoftDeleteBaseEntity {
     @Getter
     private boolean isVip;
 
+    @Getter
+    private boolean isProfilePublic = false;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)")
     @Getter
@@ -146,5 +149,9 @@ public class Member extends SoftDeleteBaseEntity {
         this.activityStatus = activityStatus;
         this.isVip = isVip;
         Events.raise(MemberSettingUpdatedEvent.of(id, isPushNotificationEnabled));
+    }
+
+    public void publishProfile() {
+        isProfilePublic = true;
     }
 }

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/MemberCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/MemberCommandRepository.java
@@ -21,4 +21,6 @@ public interface MemberCommandRepository {
     List<Member> findAllById(Set<Long> memberIds);
 
     List<Member> saveAll(List<Member> members);
+
+    Set<Long> findAllIdByIsProfilePublicFalse();
 }

--- a/src/main/java/atwoz/atwoz/member/command/infra/member/MemberCommandJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/member/command/infra/member/MemberCommandJpaRepository.java
@@ -6,6 +6,7 @@ import atwoz.atwoz.member.command.domain.member.vo.PhoneNumber;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.Set;
 
 public interface MemberCommandJpaRepository extends JpaRepository<Member, Long> {
     Member save(Member member);
@@ -16,4 +17,5 @@ public interface MemberCommandJpaRepository extends JpaRepository<Member, Long> 
 
     boolean existsByKakaoIdAndIdNot(KakaoId kakaoId, Long id);
 
+    Set<Long> findAllIdByIsProfilePublicFalse();
 }

--- a/src/main/java/atwoz/atwoz/member/command/infra/member/MemberCommandRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/member/command/infra/member/MemberCommandRepositoryImpl.java
@@ -56,4 +56,9 @@ public class MemberCommandRepositoryImpl implements MemberCommandRepository {
     public List<Member> saveAll(List<Member> members) {
         return memberCommandJpaRepository.saveAll(members);
     }
+
+    @Override
+    public Set<Long> findAllIdByIsProfilePublicFalse() {
+        return memberCommandJpaRepository.findAllIdByIsProfilePublicFalse();
+    }
 }

--- a/src/main/java/atwoz/atwoz/member/command/infra/member/ScreeningApprovedEventHandler.java
+++ b/src/main/java/atwoz/atwoz/member/command/infra/member/ScreeningApprovedEventHandler.java
@@ -1,0 +1,27 @@
+package atwoz.atwoz.member.command.infra.member;
+
+import atwoz.atwoz.admin.command.domain.screening.event.ScreeningApprovedEvent;
+import atwoz.atwoz.member.command.application.member.MemberProfileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScreeningApprovedEventHandler {
+    private final MemberProfileService memberProfileService;
+
+    @Async
+    @TransactionalEventListener(value = ScreeningApprovedEvent.class, phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ScreeningApprovedEvent event) {
+        try {
+            memberProfileService.publishProfile(event.getMemberId());
+        } catch (Exception e) {
+            log.error("Member(id: {})의 프로필 업데이트 중 예외가 발생했습니다.", event.getMemberId(), e);
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/presentation/member/dto/AdminMemberSettingUpdateRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/dto/AdminMemberSettingUpdateRequest.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record AdminMemberSettingUpdateRequest(
     @Schema(implementation = Grade.class)
     String grade,
+    boolean isProfilePublic,
     @Schema(implementation = ActivityStatus.class)
     String activityStatus,
     boolean isVip,

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcher.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcher.java
@@ -50,6 +50,7 @@ public class IntroductionMemberIdFetcher {
     private Set<Long> findExcludedMemberIds(long memberId) {
         Set<Long> excludedMemberIds = new HashSet<>();
         excludedMemberIds.add(memberId);
+        excludedMemberIds.addAll(memberCommandRepository.findAllIdByIsProfilePublicFalse());
         excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestedMemberId(memberId));
         excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestingMemberId(memberId));
         excludedMemberIds.addAll(introductionQueryRepository.findAllIntroducedMemberId(memberId));

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/TodayCardMemberIdFetcher.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/TodayCardMemberIdFetcher.java
@@ -63,6 +63,7 @@ public class TodayCardMemberIdFetcher {
     private Set<Long> findExcludedMemberIds(long memberId) {
         Set<Long> excludedMemberIds = new HashSet<>();
         excludedMemberIds.add(memberId);
+        excludedMemberIds.addAll(memberCommandRepository.findAllIdByIsProfilePublicFalse());
         excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestedMemberId(memberId));
         excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestingMemberId(memberId));
         excludedMemberIds.addAll(introductionQueryRepository.findAllIntroducedMemberId(memberId));

--- a/src/main/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepository.java
@@ -140,6 +140,7 @@ public class AdminMemberQueryRepository {
                 groupBy(member.id).as(new QAdminMemberDetailView(
                     new QAdminMemberSettingInfo(
                         member.grade.stringValue(),
+                        member.isProfilePublic,
                         member.activityStatus.stringValue(),
                         member.isVip,
                         notificationPreference.isEnabledGlobally

--- a/src/main/java/atwoz/atwoz/member/query/member/view/AdminMemberSettingInfo.java
+++ b/src/main/java/atwoz/atwoz/member/query/member/view/AdminMemberSettingInfo.java
@@ -5,10 +5,10 @@ import atwoz.atwoz.member.command.domain.member.Grade;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-// TODO : 프로필 공개 여부 추가
 public record AdminMemberSettingInfo(
     @Schema(implementation = Grade.class)
     String grade,
+    boolean isProfilePublic,
     @Schema(implementation = ActivityStatus.class)
     String activityStatus,
     boolean isVip,

--- a/src/test/java/atwoz/atwoz/member/command/application/member/AdminMemberServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/AdminMemberServiceTest.java
@@ -33,7 +33,7 @@ class AdminMemberServiceTest {
         // given
         long memberId = 1L;
         AdminMemberSettingUpdateRequest request = new AdminMemberSettingUpdateRequest(
-            Grade.SILVER.name(), ActivityStatus.ACTIVE.name(), true, true
+            Grade.SILVER.name(), true, ActivityStatus.ACTIVE.name(), true, true
         );
         final Member member = mock(Member.class);
         when(memberCommandRepository.findById(memberId)).thenReturn(Optional.of(member));
@@ -42,8 +42,8 @@ class AdminMemberServiceTest {
         adminMemberService.updateMemberSetting(memberId, request);
 
         // then
-        verify(member).updateSetting(Grade.from(request.grade()), ActivityStatus.from(request.activityStatus()),
-            request.isVip(), request.isPushNotificationEnabled());
+        verify(member).updateSetting(Grade.from(request.grade()), request.isProfilePublic(),
+            ActivityStatus.from(request.activityStatus()), request.isVip(), request.isPushNotificationEnabled());
     }
 
     @Test
@@ -52,7 +52,7 @@ class AdminMemberServiceTest {
         // given
         long memberId = 1L;
         AdminMemberSettingUpdateRequest request = new AdminMemberSettingUpdateRequest(
-            Grade.SILVER.name(), ActivityStatus.ACTIVE.name(), true, true
+            Grade.SILVER.name(), true, ActivityStatus.ACTIVE.name(), true, true
         );
         when(memberCommandRepository.findById(memberId)).thenReturn(Optional.empty());
 

--- a/src/test/java/atwoz/atwoz/member/command/application/member/MemberProfileServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/MemberProfileServiceTest.java
@@ -5,6 +5,7 @@ import atwoz.atwoz.member.command.domain.member.*;
 import atwoz.atwoz.member.command.domain.member.exception.InvalidMemberEnumValueException;
 import atwoz.atwoz.member.presentation.member.dto.MemberProfileUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,7 +19,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberProfileServiceTest {
@@ -93,7 +94,7 @@ class MemberProfileServiceTest {
         assertThat(existingMember.getProfile().getNickname().getValue()).isEqualTo("nickname");
         assertThat(existingMember.getProfile().getGender()).isEqualTo(Gender.MALE);
         assertThat(existingMember.getProfile().getJob()).isEqualTo(job);
-        assertThat(existingMember.getProfile().getHobbies().size()).isEqualTo(hobbies.size());
+        assertThat(existingMember.getProfile().getHobbies()).hasSameSizeAs(hobbies.size());
         assertThat(existingMember.getProfile().getHeight()).isEqualTo(180);
         assertThat(existingMember.getProfile().getRegion().getCity()).isEqualTo(City.DAEJEON);
         assertThat(existingMember.getProfile().getReligion()).isEqualTo(Religion.BUDDHIST);
@@ -127,5 +128,37 @@ class MemberProfileServiceTest {
         assertThat(existingMember.getProfile().getHeight()).isEqualTo(180);
         assertThat(existingMember.getProfile().getRegion()).isNull();
         assertThat(existingMember.getProfile().getReligion()).isEqualTo(Religion.BUDDHIST);
+    }
+
+    @Nested
+    @DisplayName("publishProfile 메서드 테스트")
+    class PublishProfileMethodTest {
+
+        @Test
+        @DisplayName("멤버가 존재하지 않으면 예외를 던집니다.")
+        void changeProfilePublicToTrueWhenMemberNotFound() {
+            // Given
+            final long memberId = 1L;
+            when(memberCommandRepository.findById(memberId)).thenReturn(Optional.empty());
+
+            // When
+            assertThatThrownBy(() -> memberProfileService.publishProfile(memberId))
+                .isInstanceOf(MemberNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("멤버가 존재하면 member.publishProfile() 메서드를 호출합니다.")
+        void changeProfilePublicToTrue() {
+            // Given
+            final long memberId = 1L;
+            Member member = mock(Member.class);
+            when(memberCommandRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+            // When
+            memberProfileService.publishProfile(memberId);
+
+            // Then
+            verify(member, times(1)).publishProfile();
+        }
     }
 }

--- a/src/test/java/atwoz/atwoz/member/command/application/member/MemberProfileServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/MemberProfileServiceTest.java
@@ -136,7 +136,7 @@ class MemberProfileServiceTest {
 
         @Test
         @DisplayName("멤버가 존재하지 않으면 예외를 던집니다.")
-        void changeProfilePublicToTrueWhenMemberNotFound() {
+        void throwsExceptionWhenMemberNotFound() {
             // Given
             final long memberId = 1L;
             when(memberCommandRepository.findById(memberId)).thenReturn(Optional.empty());
@@ -148,7 +148,7 @@ class MemberProfileServiceTest {
 
         @Test
         @DisplayName("멤버가 존재하면 member.publishProfile() 메서드를 호출합니다.")
-        void changeProfilePublicToTrue() {
+        void callsPublishProfileMethodWhenMemberExists() {
             // Given
             final long memberId = 1L;
             Member member = mock(Member.class);

--- a/src/test/java/atwoz/atwoz/member/command/application/member/MemberProfileServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/MemberProfileServiceTest.java
@@ -94,7 +94,7 @@ class MemberProfileServiceTest {
         assertThat(existingMember.getProfile().getNickname().getValue()).isEqualTo("nickname");
         assertThat(existingMember.getProfile().getGender()).isEqualTo(Gender.MALE);
         assertThat(existingMember.getProfile().getJob()).isEqualTo(job);
-        assertThat(existingMember.getProfile().getHobbies()).hasSameSizeAs(hobbies.size());
+        assertThat(existingMember.getProfile().getHobbies()).hasSameSizeAs(hobbies);
         assertThat(existingMember.getProfile().getHeight()).isEqualTo(180);
         assertThat(existingMember.getProfile().getRegion().getCity()).isEqualTo(City.DAEJEON);
         assertThat(existingMember.getProfile().getReligion()).isEqualTo(Religion.BUDDHIST);

--- a/src/test/java/atwoz/atwoz/member/command/domain/member/MemberTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/domain/member/MemberTest.java
@@ -32,6 +32,12 @@ class MemberTest {
         Assertions.assertThat(member).isNotNull();
         Assertions.assertThat(member.isProfileSettingNeeded()).isTrue();
         Assertions.assertThat(member.isPermanentlySuspended()).isFalse();
+        Assertions.assertThat(member.getPhoneNumber()).isEqualTo(phoneNumber);
+        Assertions.assertThat(member.getPrimaryContactType()).isEqualTo(PrimaryContactType.NONE);
+        Assertions.assertThat(member.getHeartBalance()).isEqualTo(HeartBalance.init());
+        Assertions.assertThat(member.getActivityStatus()).isEqualTo(ActivityStatus.ACTIVE);
+        Assertions.assertThat(member.isVip()).isFalse();
+        Assertions.assertThat(member.isProfilePublic()).isFalse();
     }
 
     @Nested
@@ -181,6 +187,24 @@ class MemberTest {
                 Assertions.assertThat(member.getActivityStatus()).isEqualTo(activityStatus);
                 Assertions.assertThat(member.isVip()).isEqualTo(isVip);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("publishProfile 메서드 테스트")
+    class PublishProfileMethodTest {
+
+        @Test
+        @DisplayName("멤버의 프로필을 공개합니다.")
+        void shouldPublishMemberProfile() {
+            // Given
+            Member member = Member.fromPhoneNumber("01012345678");
+
+            // When
+            member.publishProfile();
+
+            // Then
+            Assertions.assertThat(member.isProfilePublic()).isTrue();
         }
     }
 }

--- a/src/test/java/atwoz/atwoz/member/command/domain/member/MemberTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/domain/member/MemberTest.java
@@ -168,13 +168,14 @@ class MemberTest {
             Long memberId = 1L;
             setField(member, "id", memberId);
             Grade grade = Grade.GOLD;
+            final boolean isProfilePublic = true;
             ActivityStatus activityStatus = ActivityStatus.ACTIVE;
-            boolean isVip = true;
-            boolean isPushNotificationEnabled = false;
+            final boolean isVip = true;
+            final boolean isPushNotificationEnabled = false;
 
             try (MockedStatic<Events> eventsMockedStatic = mockStatic(Events.class)) {
                 // When
-                member.updateSetting(grade, activityStatus, isVip, isPushNotificationEnabled);
+                member.updateSetting(grade, isProfilePublic, activityStatus, isVip, isPushNotificationEnabled);
 
                 // Then
                 eventsMockedStatic.verify(() ->
@@ -184,6 +185,7 @@ class MemberTest {
                     )), times(1));
 
                 Assertions.assertThat(member.getGrade()).isEqualTo(grade);
+                Assertions.assertThat(member.isProfilePublic()).isEqualTo(isProfilePublic);
                 Assertions.assertThat(member.getActivityStatus()).isEqualTo(activityStatus);
                 Assertions.assertThat(member.isVip()).isEqualTo(isVip);
             }

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcherTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcherTest.java
@@ -77,6 +77,8 @@ class IntroductionMemberIdFetcherTest {
         when(introductionRedisRepository.findIntroductionMemberIds(key))
             .thenReturn(Set.of());
 
+        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
+        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -86,6 +88,7 @@ class IntroductionMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
+        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);
@@ -124,6 +127,8 @@ class IntroductionMemberIdFetcherTest {
         when(introductionRedisRepository.findIntroductionMemberIds(key))
             .thenReturn(Set.of());
 
+        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
+        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -133,6 +138,7 @@ class IntroductionMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
+        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);
@@ -163,6 +169,8 @@ class IntroductionMemberIdFetcherTest {
         when(introductionRedisRepository.findIntroductionMemberIds(key))
             .thenReturn(Set.of());
 
+        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
+        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -172,6 +180,7 @@ class IntroductionMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
+        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/TodayCardMemberIdFetcherTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/TodayCardMemberIdFetcherTest.java
@@ -115,6 +115,8 @@ class TodayCardMemberIdFetcherTest {
         Gender memberGender = Gender.MALE;
         when(member.getGender()).thenReturn(memberGender);
 
+        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
+        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -124,6 +126,7 @@ class TodayCardMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
+        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);
@@ -166,6 +169,8 @@ class TodayCardMemberIdFetcherTest {
         Gender memberGender = Gender.MALE;
         when(member.getGender()).thenReturn(memberGender);
 
+        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
+        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -175,6 +180,7 @@ class TodayCardMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
+        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);

--- a/src/test/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/member/infra/AdminMemberQueryRepositoryTest.java
@@ -325,6 +325,7 @@ class AdminMemberQueryRepositoryTest {
         private void assertAdminMemberSettingInfo(AdminMemberSettingInfo settingInfo, Member member,
             NotificationPreference notificationPreference) {
             assertThat(settingInfo.grade()).isEqualTo(member.getGrade().name());
+            assertThat(settingInfo.isProfilePublic()).isEqualTo(member.isProfilePublic());
             assertThat(settingInfo.activityStatus()).isEqualTo(member.getActivityStatus().name());
             assertThat(settingInfo.isVip()).isEqualTo(member.isVip());
             assertThat(settingInfo.isPushNotificationEnabled()).isEqualTo(notificationPreference.isEnabledGlobally());


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원 프로필 공개 여부(isProfilePublic) 관리 기능이 추가되었습니다.
    - 관리자가 회원의 프로필 공개 상태를 직접 설정할 수 있습니다.
    - 심사 승인 시, 해당 회원의 프로필이 자동으로 공개로 전환됩니다.
    - 심사 승인 이벤트 발생 시 프로필 공개 처리를 비동기로 수행합니다.

- **버그 수정**
    - 회원 소개 및 추천 대상에서 비공개 프로필 회원이 제외되도록 개선되었습니다.

- **테스트**
    - 프로필 공개 기능 및 심사 승인 이벤트 관련 테스트가 추가 및 보강되었습니다.

- **문서화**
    - 관리자용 상세 정보에 프로필 공개 여부가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
