### PR TITLE
로그인 예외 상세 정의 및 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/common/entity/SoftDeleteBaseEntity.java
+++ b/src/main/java/atwoz/atwoz/common/entity/SoftDeleteBaseEntity.java
@@ -12,7 +12,9 @@ public abstract class SoftDeleteBaseEntity extends BaseEntity {
     private LocalDateTime deletedAt;
 
     public void delete() {
-        deletedAt = LocalDateTime.now();
+        if (deletedAt == null) {
+            deletedAt = LocalDateTime.now();
+        }
     }
 
     public boolean isDeleted() {

--- a/src/main/java/atwoz/atwoz/common/entity/SoftDeleteBaseEntity.java
+++ b/src/main/java/atwoz/atwoz/common/entity/SoftDeleteBaseEntity.java
@@ -11,6 +11,10 @@ public abstract class SoftDeleteBaseEntity extends BaseEntity {
     @Getter
     private LocalDateTime deletedAt;
 
+    public void delete() {
+        deletedAt = LocalDateTime.now();
+    }
+
     public boolean isDeleted() {
         return this.deletedAt != null;
     }

--- a/src/main/java/atwoz/atwoz/common/enums/StatusType.java
+++ b/src/main/java/atwoz/atwoz/common/enums/StatusType.java
@@ -37,6 +37,7 @@ public enum StatusType {
     FORBIDDEN(403, "403", "Forbidden"),
     HANDLE_ACCESS_DENIED(403, "403001", "Access is Denied"),
     ADMIN_ACCESS_DENIED(403, "403002", "Manager Access Denied"),
+    DELETED_TARGET(403, "403003", "Deleted Target"),
 
     NOT_FOUND(404, "404", "Not Found"),
 

--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
@@ -5,6 +5,7 @@ import atwoz.atwoz.auth.domain.TokenRepository;
 import atwoz.atwoz.common.enums.Role;
 import atwoz.atwoz.common.event.Events;
 import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
+import atwoz.atwoz.member.command.application.member.exception.MemberDeletedException;
 import atwoz.atwoz.member.command.application.member.exception.MemberLoginConflictException;
 import atwoz.atwoz.member.command.application.member.exception.PermanentlySuspendedMemberException;
 import atwoz.atwoz.member.command.application.member.sms.AuthMessageService;
@@ -35,7 +36,11 @@ public class MemberAuthService {
         if (member.isPermanentlySuspended()) {
             throw new PermanentlySuspendedMemberException();
         }
-        
+
+        if (member.isDeleted()) {
+            throw new MemberDeletedException();
+        }
+
         String accessToken = tokenProvider.createAccessToken(member.getId(), Role.MEMBER, Instant.now());
         String refreshToken = tokenProvider.createRefreshToken(member.getId(), Role.MEMBER, Instant.now());
         tokenRepository.save(refreshToken);

--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
@@ -7,6 +7,7 @@ import atwoz.atwoz.common.event.Events;
 import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
 import atwoz.atwoz.member.command.application.member.exception.MemberDeletedException;
 import atwoz.atwoz.member.command.application.member.exception.MemberLoginConflictException;
+import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
 import atwoz.atwoz.member.command.application.member.exception.PermanentlySuspendedMemberException;
 import atwoz.atwoz.member.command.application.member.sms.AuthMessageService;
 import atwoz.atwoz.member.command.domain.member.Member;
@@ -49,15 +50,30 @@ public class MemberAuthService {
     }
 
     public void logout(String token) {
-        tokenRepository.delete(token);
+        deleteToken(token);
+    }
+
+    @Transactional
+    public void delete(Long memberId, String token) {
+        Member member = getMemberById(memberId);
+        member.delete();
+        deleteToken(token);
     }
 
     public void sendAuthCode(String phoneNumber) {
         authMessageService.sendAndSaveCode(phoneNumber);
     }
 
+    private void deleteToken(String token) {
+        tokenRepository.delete(token);
+    }
+
     private Member createOrFindMemberByPhoneNumber(String phoneNumber) {
         return memberCommandRepository.findByPhoneNumber(phoneNumber).orElseGet(() -> create(phoneNumber));
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberCommandRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
     }
 
     private Member create(String phoneNumber) {

--- a/src/main/java/atwoz/atwoz/member/command/application/member/exception/MemberDeletedException.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/exception/MemberDeletedException.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.member.command.application.member.exception;
+
+public class MemberDeletedException extends RuntimeException {
+    public MemberDeletedException() {
+        super("삭제된 회원입니다.");
+    }
+}

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
@@ -34,13 +34,7 @@ public class MemberAuthController {
         MemberLoginServiceDto loginServiceDto = memberAuthService.login(request.phoneNumber(), request.code());
 
         HttpHeaders headers = new HttpHeaders();
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", loginServiceDto.refreshToken())
-            .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
-            .path("/")
-            .maxAge(60 * 60 * 24 * 7 * 4)
-            .build();
+        ResponseCookie refreshTokenCookie = getResponseCookieCreatedRefreshToken(loginServiceDto.refreshToken());
         headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
         MemberLoginResponse loginResponse = MemberDtoMapper.toMemberLoginResponse(loginServiceDto);
@@ -66,7 +60,7 @@ public class MemberAuthController {
     }
 
     @Operation(summary = "멤버 탈퇴")
-    @GetMapping("/delete")
+    @DeleteMapping
     public ResponseEntity<BaseResponse<Void>> delete(
         @CookieValue(value = "refresh_token", required = false) String refreshToken,
         @AuthPrincipal AuthContext authContext) {
@@ -94,6 +88,16 @@ public class MemberAuthController {
 
     private ResponseCookie getResponseCookieDeletedRefreshToken() {
         return ResponseCookie.from(refreshTokenCookieProperties.name(), "")
+            .httpOnly(refreshTokenCookieProperties.httpOnly())
+            .secure(refreshTokenCookieProperties.secure())
+            .sameSite(refreshTokenCookieProperties.sameSite())
+            .path(refreshTokenCookieProperties.path())
+            .maxAge(0)
+            .build();
+    }
+
+    private ResponseCookie getResponseCookieCreatedRefreshToken(String refreshToken) {
+        return ResponseCookie.from(refreshTokenCookieProperties.name(), refreshToken)
             .httpOnly(refreshTokenCookieProperties.httpOnly())
             .secure(refreshTokenCookieProperties.secure())
             .sameSite(refreshTokenCookieProperties.sameSite())

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
@@ -73,8 +73,6 @@ public class MemberAuthController {
         return ResponseEntity.ok()
             .headers(headers)
             .body(BaseResponse.from(StatusType.OK));
-
-
     }
 
     @Operation(summary = "휴대폰 번호 인증 코드 발송")
@@ -84,7 +82,6 @@ public class MemberAuthController {
         return ResponseEntity.ok()
             .body(BaseResponse.from(StatusType.OK));
     }
-
 
     private ResponseCookie getResponseCookieDeletedRefreshToken() {
         return ResponseCookie.from(refreshTokenCookieProperties.name(), "")

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberExceptionHandler.java
@@ -23,6 +23,14 @@ public class MemberExceptionHandler {
             .body(BaseResponse.from(StatusType.FORBIDDEN));
     }
 
+    @ExceptionHandler(MemberDeletedException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMemberDeletedException(MemberDeletedException e) {
+        log.warn("멤버 로그인에 실패하였습니다. {}", e.getMessage());
+
+        return ResponseEntity.status(403)
+            .body(BaseResponse.from(StatusType.DELETED_TARGET));
+    }
+
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity<BaseResponse<Void>> handleMemberNotFoundException(MemberNotFoundException e) {
         log.warn("멤버 조회에 실패하였습니다. {}", e.getMessage());

--- a/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
@@ -6,6 +6,7 @@ import atwoz.atwoz.common.enums.Role;
 import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
 import atwoz.atwoz.member.command.application.member.exception.MemberDeletedException;
 import atwoz.atwoz.member.command.application.member.exception.MemberLoginConflictException;
+import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
 import atwoz.atwoz.member.command.application.member.exception.PermanentlySuspendedMemberException;
 import atwoz.atwoz.member.command.application.member.sms.AuthMessageService;
 import atwoz.atwoz.member.command.domain.member.ActivityStatus;
@@ -14,6 +15,7 @@ import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,9 +31,7 @@ import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class MemberAuthServiceTest {
-    private Member permanentStoppedMember;
-    private Member member;
-    private Long memberId;
+
 
     @Mock
     private MemberCommandRepository memberCommandRepository;
@@ -48,120 +48,165 @@ class MemberAuthServiceTest {
     @InjectMocks
     private MemberAuthService memberAuthService;
 
-    @BeforeEach
-    void setUp() {
-        member = Member.fromPhoneNumber("01012345678");
-        memberId = 1L;
-        ReflectionTestUtils.setField(member, "id", memberId);
-        ReflectionTestUtils.setField(member, "activityStatus", ActivityStatus.ACTIVE);
 
-        permanentStoppedMember = Member.fromPhoneNumber("01012345678");
-        ReflectionTestUtils.setField(permanentStoppedMember, "id", 2L);
-        ReflectionTestUtils.setField(permanentStoppedMember, "activityStatus", ActivityStatus.SUSPENDED_PERMANENTLY);
+    @Nested
+    @DisplayName("로그인 및 회원가입 테스트")
+    class Login {
+        private Member permanentStoppedMember;
+        private Member member;
+        private Long memberId;
 
-    }
+        @BeforeEach
+        void setUp() {
+            member = Member.fromPhoneNumber("01012345678");
+            memberId = 1L;
+            ReflectionTestUtils.setField(member, "id", memberId);
+            ReflectionTestUtils.setField(member, "activityStatus", ActivityStatus.ACTIVE);
 
-    @Test
-    @DisplayName("영구 정지된 사용자가 로그인할 경우 예외 처리")
-    void shouldThrowExceptionWhenLoginAttemptedByPermanentStoppedMember() {
-        // Given
-        String phoneNumber = "01012345678";
-        String code = "01012345678";
+            permanentStoppedMember = Member.fromPhoneNumber("01012345678");
+            ReflectionTestUtils.setField(permanentStoppedMember, "id", 2L);
+            ReflectionTestUtils.setField(permanentStoppedMember, "activityStatus",
+                ActivityStatus.SUSPENDED_PERMANENTLY);
 
-        Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber))
-            .thenReturn(Optional.of(permanentStoppedMember));
-        Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
+        }
 
-        // When & Then
-        Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
-            .isInstanceOf(PermanentlySuspendedMemberException.class);
-    }
+        @Test
+        @DisplayName("영구 정지된 사용자가 로그인할 경우 예외 처리")
+        void shouldThrowExceptionWhenLoginAttemptedByPermanentStoppedMember() {
+            // Given
+            String phoneNumber = "01012345678";
+            String code = "01012345678";
 
-    @Test
-    @DisplayName("회원 탈퇴한 사용자가 로그인할 경우 예외 처리")
-    void shouldThrowExceptionWhenLoginAttemptedByDeletedMember() {
-        // Given
-        String phoneNumber = "01012345678";
-        String code = "01012345678";
-        Member deletedMember = Member.fromPhoneNumber("01012345678");
-        deletedMember.delete();
-
-        Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber))
-            .thenReturn(Optional.of(deletedMember));
-        Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
-
-        // When & Then
-        Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
-            .isInstanceOf(MemberDeletedException.class);
-    }
-
-    @Test
-    @DisplayName("기존 유저가 로그인할 경우, 토큰 발급")
-    void shouldCreateTokenWhenUserIsRegistered() {
-        String phoneNumber = "01012345678";
-        String code = "01012345678";
-        Instant fixedInstant = Instant.parse("2024-01-01T00:00:00Z");
-
-        try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class)) {
-            mockedInstant.when(Instant::now).thenReturn(fixedInstant);
-
-            Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.of(member));
-            Mockito.when(
-                    jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
-                .thenReturn("accessToken");
+            Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber))
+                .thenReturn(Optional.of(permanentStoppedMember));
             Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
 
-            // When
-            String token = memberAuthService.login(phoneNumber, code).accessToken();
-
-            // Then
-            Assertions.assertThat(token).isNotNull();
-            Assertions.assertThat(token).isEqualTo("accessToken");
+            // When & Then
+            Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
+                .isInstanceOf(PermanentlySuspendedMemberException.class);
         }
-    }
 
-    @Test
-    @DisplayName("등록되지 않은 유저가 로그인할 경우, 새롭게 생성하여 토큰 발급")
-    void shouldCreateNewMemberAndTokenWhenUserIsNotRegistered() {
-        // Given
-        String phoneNumber = "01012345678";
-        String code = "01012345678";
-        Instant fixedInstant = Instant.parse("2024-01-01T00:00:00Z");
+        @Test
+        @DisplayName("회원 탈퇴한 사용자가 로그인할 경우 예외 처리")
+        void shouldThrowExceptionWhenLoginAttemptedByDeletedMember() {
+            // Given
+            String phoneNumber = "01012345678";
+            String code = "01012345678";
+            Member deletedMember = Member.fromPhoneNumber("01012345678");
+            deletedMember.delete();
 
-        try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class)) {
-            mockedInstant.when(Instant::now).thenReturn(fixedInstant);
+            Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber))
+                .thenReturn(Optional.of(deletedMember));
+            Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
 
+            // When & Then
+            Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
+                .isInstanceOf(MemberDeletedException.class);
+        }
+
+        @Test
+        @DisplayName("기존 유저가 로그인할 경우, 토큰 발급")
+        void shouldCreateTokenWhenUserIsRegistered() {
+            String phoneNumber = "01012345678";
+            String code = "01012345678";
+            Instant fixedInstant = Instant.parse("2024-01-01T00:00:00Z");
+
+            try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class)) {
+                mockedInstant.when(Instant::now).thenReturn(fixedInstant);
+
+                Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.of(member));
+                Mockito.when(
+                        jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
+                    .thenReturn("accessToken");
+                Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
+
+                // When
+                String token = memberAuthService.login(phoneNumber, code).accessToken();
+
+                // Then
+                Assertions.assertThat(token).isNotNull();
+                Assertions.assertThat(token).isEqualTo("accessToken");
+            }
+        }
+
+        @Test
+        @DisplayName("등록되지 않은 유저가 로그인할 경우, 새롭게 생성하여 토큰 발급")
+        void shouldCreateNewMemberAndTokenWhenUserIsNotRegistered() {
+            // Given
+            String phoneNumber = "01012345678";
+            String code = "01012345678";
+            Instant fixedInstant = Instant.parse("2024-01-01T00:00:00Z");
+
+            try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class)) {
+                mockedInstant.when(Instant::now).thenReturn(fixedInstant);
+
+                Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.empty());
+                Mockito.when(
+                        jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
+                    .thenReturn("accessToken");
+                Mockito.when(memberCommandRepository.save(Mockito.any())).thenReturn(member);
+                Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
+
+                // When
+                MemberLoginServiceDto response = memberAuthService.login(phoneNumber, code);
+
+                // Then
+                Assertions.assertThat(response.accessToken()).isNotNull();
+                Assertions.assertThat(response.accessToken()).isEqualTo("accessToken");
+                Assertions.assertThat(response.isProfileSettingNeeded()).isTrue();
+            }
+        }
+
+        @Test
+        @DisplayName("동시 로그인으로 인해, 유니크 제약조건에 걸린 경우 예외 반환")
+        void shouldThrowExceptionWhenUniqueConstraint() {
+            // Given
+            String phoneNumber = "01012345678";
+            String code = "01012345678";
+
+            // When
             Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.empty());
-            Mockito.when(
-                    jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
-                .thenReturn("accessToken");
-            Mockito.when(memberCommandRepository.save(Mockito.any())).thenReturn(member);
+            Mockito.when(memberCommandRepository.save(Mockito.any())).thenThrow(DataIntegrityViolationException.class);
             Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
 
-            // When
-            MemberLoginServiceDto response = memberAuthService.login(phoneNumber, code);
-
-            // Then
-            Assertions.assertThat(response.accessToken()).isNotNull();
-            Assertions.assertThat(response.accessToken()).isEqualTo("accessToken");
-            Assertions.assertThat(response.isProfileSettingNeeded()).isTrue();
+            // When & Then
+            Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
+                .isInstanceOf(MemberLoginConflictException.class);
         }
     }
 
-    @Test
-    @DisplayName("동시 로그인으로 인해, 유니크 제약조건에 걸린 경우 예외 반환")
-    void shouldThrowExceptionWhenUniqueConstraint() {
-        // Given
-        String phoneNumber = "01012345678";
-        String code = "01012345678";
+    @Nested
+    @DisplayName("회원 탈퇴 테스트.")
+    class Delete {
+        @DisplayName("회원으로 존재하지 않는 경우, 예외 발생.")
+        @Test
+        void throwExceptionWhenMemberIsNotFound() {
+            // Given
+            Long memberId = 1L;
+            String refreshToken = "refreshToken";
+            Mockito.when(memberCommandRepository.findById(memberId)).thenReturn(Optional.empty());
 
-        // When
-        Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.empty());
-        Mockito.when(memberCommandRepository.save(Mockito.any())).thenThrow(DataIntegrityViolationException.class);
-        Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
+            // When & Then
+            Assertions.assertThatThrownBy(() -> memberAuthService.delete(memberId, refreshToken))
+                .isInstanceOf(MemberNotFoundException.class);
+        }
 
-        // When & Then
-        Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
-            .isInstanceOf(MemberLoginConflictException.class);
+        @DisplayName("존재하는 경우, 회원을 SoftDelete 한다.")
+        @Test
+        void softDeleteWhenMemberIsFound() {
+            // Given
+            Long memberId = 1L;
+            String refreshToken = "refreshToken";
+            Member member = Member.fromPhoneNumber("01012345678");
+            Mockito.when(memberCommandRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+            // When
+            memberAuthService.delete(memberId, refreshToken);
+
+            // Then
+            Assertions.assertThat(member.isDeleted()).isTrue();
+        }
     }
+
+
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원 탈퇴(삭제) 기능이 추가되었습니다.
    - 탈퇴된 회원의 로그인 시도가 차단됩니다.
    - 탈퇴된 회원에 대한 별도의 상태 코드 및 안내 메시지가 제공됩니다.
    - 회원 탈퇴를 위한 API 엔드포인트가 추가되었습니다.
    - 리프레시 토큰 쿠키 생성 및 삭제 로직이 중앙화되었습니다.

- **버그 수정**
    - 회원 탈퇴 시 관련 토큰이 함께 삭제됩니다.

- **문서화**
    - 회원 탈퇴 및 휴대폰 인증 코드 발송 API에 설명이 추가되었습니다.

- **테스트**
    - 회원 탈퇴 및 탈퇴 회원 로그인 차단에 대한 테스트가 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 


## 노트
<img width="639" alt="image" src="https://github.com/user-attachments/assets/e4e26c48-e37f-45d6-a5ed-0470413fdcbb" />

* 단순히 HttpStatus Code 로 구분하기에는 불가능할 것 같아서, Body에 담기는 Code 로 분기를 구분하도록 추가로 StatusType 을 정의하였습니다.
* 
* 회원 탈퇴 기능을 구현했었던 것으로 기억하고 있었는데, 존재하지 않아서 추가로 구현하였습니다. 이와 관련해서 `SoftDeleteBaseEntity` 에 추가적인 delete() 메서드를 정의하였습니다.