### PR TITLE
RestClient TimeOut 명시.

### DIFF
--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
@@ -51,6 +51,25 @@ public class MemberAuthService {
         return new MemberLoginServiceDto(accessToken, refreshToken, member.isProfileSettingNeeded());
     }
 
+    @Transactional
+    public MemberLoginServiceDto test(String phoneNumber) {
+        Member member = createOrFindMemberByPhoneNumber(phoneNumber);
+
+        if (member.isPermanentlySuspended()) {
+            throw new PermanentlySuspendedMemberException();
+        }
+
+        if (member.isDeleted()) {
+            throw new MemberDeletedException();
+        }
+
+        String accessToken = tokenProvider.createAccessToken(member.getId(), Role.MEMBER, Instant.now());
+        String refreshToken = tokenProvider.createRefreshToken(member.getId(), Role.MEMBER, Instant.now());
+        tokenRepository.save(refreshToken);
+
+        return new MemberLoginServiceDto(accessToken, refreshToken, member.isProfileSettingNeeded());
+    }
+
     public void logout(String token) {
         deleteToken(token);
     }

--- a/src/main/java/atwoz/atwoz/member/command/infra/member/sms/BizgoTokenHandler.java
+++ b/src/main/java/atwoz/atwoz/member/command/infra/member/sms/BizgoTokenHandler.java
@@ -15,7 +15,7 @@ import java.util.concurrent.locks.ReentrantLock;
 @Service
 @RequiredArgsConstructor
 public class BizgoTokenHandler {
-    private static final long HOURS23 = 23L * 60L * 60L * 1000L;
+    private static final long HOURS23 = 1000L;
     private final ReentrantLock lock = new ReentrantLock();
     private final RestClient restClient;
     @Value("${bizgo.client-id}")

--- a/src/main/java/atwoz/atwoz/member/command/infra/member/sms/RestClientConfig.java
+++ b/src/main/java/atwoz/atwoz/member/command/infra/member/sms/RestClientConfig.java
@@ -2,13 +2,20 @@ package atwoz.atwoz.member.command.infra.member.sms;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
 
 @Configuration
 public class RestClientConfig {
 
     @Bean
     public RestClient restClient() {
-        return RestClient.create();
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(2));
+        requestFactory.setReadTimeout(Duration.ofSeconds(3));
+
+        return RestClient.builder().requestFactory(requestFactory).build();
     }
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
@@ -10,6 +10,7 @@ import atwoz.atwoz.member.command.application.member.dto.MemberLoginServiceDto;
 import atwoz.atwoz.member.presentation.member.dto.MemberCodeRequest;
 import atwoz.atwoz.member.presentation.member.dto.MemberLoginRequest;
 import atwoz.atwoz.member.presentation.member.dto.MemberLoginResponse;
+import atwoz.atwoz.member.presentation.member.dto.MemberTestLoginRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -32,6 +33,22 @@ public class MemberAuthController {
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<MemberLoginResponse>> login(@Valid @RequestBody MemberLoginRequest request) {
         MemberLoginServiceDto loginServiceDto = memberAuthService.login(request.phoneNumber(), request.code());
+
+        HttpHeaders headers = new HttpHeaders();
+        ResponseCookie refreshTokenCookie = getResponseCookieCreatedRefreshToken(loginServiceDto.refreshToken());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        MemberLoginResponse loginResponse = MemberDtoMapper.toMemberLoginResponse(loginServiceDto);
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(BaseResponse.of(StatusType.OK, loginResponse));
+    }
+
+    @Operation(summary = "멤버 로그인 (테스트용, 인증번호X)")
+    @PostMapping("/login/test")
+    public ResponseEntity<BaseResponse<MemberLoginResponse>> test(@Valid @RequestBody MemberTestLoginRequest request) {
+        MemberLoginServiceDto loginServiceDto = memberAuthService.test(request.phoneNumber());
 
         HttpHeaders headers = new HttpHeaders();
         ResponseCookie refreshTokenCookie = getResponseCookieCreatedRefreshToken(loginServiceDto.refreshToken());

--- a/src/main/java/atwoz/atwoz/member/presentation/member/dto/MemberTestLoginRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/dto/MemberTestLoginRequest.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.member.presentation.member.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+public record MemberTestLoginRequest(
+    @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하고 8자리의 숫자가 와야합니다.")
+    String phoneNumber
+) {
+}


### PR DESCRIPTION
@coderabbitai summary

## 참고 자료
- 

## 노트
기존 RestClient 에서는 응답 대기 시간이 약 3분으로 설정되어 있어, 해당 응답을 대기하는 경우 클라이언트 측에서는 504 (TimeOut)에러를 보게 됩니다. 이를 해결하고자 Connection 을 설정하는데 약 2초, 데이터를 전송하고 읽는데 약 3초의 타임아웃을 설정하였습니다.

* 추가로, 테스트의 용이성을 위해서 이전 로그인 방식을 함께 추가하였습니다. (현재 방식은 문자 인증으로 인해 여러 계정을 테스트하지 못하고 있습니다..!)