### PR TITLE
소개받고 싶은 이성 API 500에러

### DIFF
--- a/src/main/java/atwoz/atwoz/member/command/domain/member/MemberCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/MemberCommandRepository.java
@@ -24,6 +24,4 @@ public interface MemberCommandRepository {
     List<Member> saveAll(List<Member> members);
 
     void deleteBefore(LocalDateTime dateTime);
-
-    Set<Long> findAllIdByIsProfilePublicFalse();
 }

--- a/src/main/java/atwoz/atwoz/member/command/infra/member/MemberCommandJpaRepository.java
+++ b/src/main/java/atwoz/atwoz/member/command/infra/member/MemberCommandJpaRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.Set;
 
 public interface MemberCommandJpaRepository extends JpaRepository<Member, Long> {
     Member save(Member member);
@@ -23,6 +22,4 @@ public interface MemberCommandJpaRepository extends JpaRepository<Member, Long> 
     @Query("DELETE FROM Member m WHERE m.deletedAt <= :deletedAt")
     @Modifying(clearAutomatically = true)
     void deleteAllBefore(LocalDateTime deletedAt);
-
-    Set<Long> findAllIdByIsProfilePublicFalse();
 }

--- a/src/main/java/atwoz/atwoz/member/command/infra/member/MemberCommandRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/member/command/infra/member/MemberCommandRepositoryImpl.java
@@ -62,8 +62,4 @@ public class MemberCommandRepositoryImpl implements MemberCommandRepository {
     public void deleteBefore(final LocalDateTime dateTime) {
         memberCommandJpaRepository.deleteAllBefore(dateTime);
     }
-
-    public Set<Long> findAllIdByIsProfilePublicFalse() {
-        return memberCommandJpaRepository.findAllIdByIsProfilePublicFalse();
-    }
 }

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcher.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcher.java
@@ -50,7 +50,6 @@ public class IntroductionMemberIdFetcher {
     private Set<Long> findExcludedMemberIds(long memberId) {
         Set<Long> excludedMemberIds = new HashSet<>();
         excludedMemberIds.add(memberId);
-        excludedMemberIds.addAll(memberCommandRepository.findAllIdByIsProfilePublicFalse());
         excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestedMemberId(memberId));
         excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestingMemberId(memberId));
         excludedMemberIds.addAll(introductionQueryRepository.findAllIntroducedMemberId(memberId));

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/TodayCardMemberIdFetcher.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/TodayCardMemberIdFetcher.java
@@ -63,7 +63,6 @@ public class TodayCardMemberIdFetcher {
     private Set<Long> findExcludedMemberIds(long memberId) {
         Set<Long> excludedMemberIds = new HashSet<>();
         excludedMemberIds.add(memberId);
-        excludedMemberIds.addAll(memberCommandRepository.findAllIdByIsProfilePublicFalse());
         excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestedMemberId(memberId));
         excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestingMemberId(memberId));
         excludedMemberIds.addAll(introductionQueryRepository.findAllIntroducedMemberId(memberId));

--- a/src/main/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepository.java
@@ -63,7 +63,8 @@ public class IntroductionQueryRepository {
                 drinkingStatusEq(condition.getDrinkingStatus()),
                 gradeEq(condition.getMemberGrade()),
                 genderEq(condition.getGender()),
-                createdAtGoe(condition.getJoinedAfter())
+                createdAtGoe(condition.getJoinedAfter()),
+                isProfilePublicIsTrue()
             )
             .orderBy(member.id.desc())
             .limit(limit);
@@ -180,6 +181,10 @@ public class IntroductionQueryRepository {
             return null;
         }
         return member.createdAt.goe(createdAt);
+    }
+
+    private BooleanExpression isProfilePublicIsTrue() {
+        return member.isProfilePublic.isTrue();
     }
 
     private void applyHobbiesCondition(JPAQuery<?> query, IntroductionSearchCondition condition) {

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcherTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/IntroductionMemberIdFetcherTest.java
@@ -77,8 +77,6 @@ class IntroductionMemberIdFetcherTest {
         when(introductionRedisRepository.findIntroductionMemberIds(key))
             .thenReturn(Set.of());
 
-        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
-        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -88,7 +86,6 @@ class IntroductionMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
-        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);
@@ -127,8 +124,6 @@ class IntroductionMemberIdFetcherTest {
         when(introductionRedisRepository.findIntroductionMemberIds(key))
             .thenReturn(Set.of());
 
-        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
-        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -138,7 +133,6 @@ class IntroductionMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
-        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);
@@ -169,8 +163,6 @@ class IntroductionMemberIdFetcherTest {
         when(introductionRedisRepository.findIntroductionMemberIds(key))
             .thenReturn(Set.of());
 
-        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
-        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -180,7 +172,6 @@ class IntroductionMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
-        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);

--- a/src/test/java/atwoz/atwoz/member/query/introduction/application/TodayCardMemberIdFetcherTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/application/TodayCardMemberIdFetcherTest.java
@@ -115,8 +115,6 @@ class TodayCardMemberIdFetcherTest {
         Gender memberGender = Gender.MALE;
         when(member.getGender()).thenReturn(memberGender);
 
-        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
-        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -126,7 +124,6 @@ class TodayCardMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
-        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);
@@ -169,8 +166,6 @@ class TodayCardMemberIdFetcherTest {
         Gender memberGender = Gender.MALE;
         when(member.getGender()).thenReturn(memberGender);
 
-        Set<Long> profilePublicFalseMemberIds = Set.of(12L, 13L);
-        when(memberCommandRepository.findAllIdByIsProfilePublicFalse()).thenReturn(profilePublicFalseMemberIds);
         Set<Long> matchedRequestedMemberIds = Set.of(memberId, 12L);
         when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(matchedRequestedMemberIds);
         Set<Long> matchedRequestingMemberIds = Set.of(memberId, 12L);
@@ -180,7 +175,6 @@ class TodayCardMemberIdFetcherTest {
         when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(introducedMemberIds);
 
         Set<Long> excludedMemberIds = new HashSet<>(Set.of(memberId));
-        excludedMemberIds.addAll(profilePublicFalseMemberIds);
         excludedMemberIds.addAll(matchedRequestedMemberIds);
         excludedMemberIds.addAll(matchedRequestingMemberIds);
         excludedMemberIds.addAll(introducedMemberIds);

--- a/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/member/query/introduction/intra/IntroductionQueryRepositoryTest.java
@@ -49,7 +49,7 @@ class IntroductionQueryRepositoryTest {
     @DisplayName("findAllIntroductionMemberId 메서드 테스트")
     class FindAllIntroductionMemberIdTest {
         @ParameterizedTest
-        @ValueSource(strings = {"excludedIds", "minAge", "maxAge", "hobbies", "religion", "cities", "smokingStatus", "drinkingStatus", "memberGrade", "gender", "joinedAfter", "null"})
+        @ValueSource(strings = {"excludedIds", "minAge", "maxAge", "hobbies", "religion", "cities", "smokingStatus", "drinkingStatus", "memberGrade", "gender", "joinedAfter", "isProfilePublic", "null"})
         @DisplayName("search condition에 대한 검증")
         void findIntroductionMemberIdsWhenSuccess(String fieldName) {
             // given
@@ -72,6 +72,7 @@ class IntroductionQueryRepositoryTest {
                 .gender(Gender.MALE)
                 .build();
             member1.updateProfile(profile1);
+            member1.publishProfile();
 
             entityManager.persist(member1);
             entityManager.flush();
@@ -87,6 +88,9 @@ class IntroductionQueryRepositoryTest {
                 .gender(Gender.FEMALE)
                 .build();
             member2.updateProfile(profile2);
+            if (!fieldName.equals("isProfilePublic")) {
+                member2.publishProfile();
+            }
 
             entityManager.persist(member2);
             entityManager.flush();
@@ -140,6 +144,7 @@ class IntroductionQueryRepositoryTest {
                 case "memberGrade" -> assertThat(result).isEmpty();
                 case "gender" -> assertThat(result).containsExactly(member1.getId());
                 case "joinedAfter" -> assertThat(result).isEmpty();
+                case "isProfilePublic" -> assertThat(result).containsExactly(member1.getId());
                 default -> assertThat(result).containsExactlyInAnyOrder(member1.getId(), member2.getId());
             }
         }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 비공개 프로필 회원이 더 이상 추천 제외 대상에 포함되지 않도록 변경되었습니다.
	- 추천 대상 조회 시 프로필이 공개된 회원만 포함되도록 필터링이 개선되었습니다.

- **테스트**
	- 비공개 프로필 회원 관련 테스트 코드가 업데이트되어 실제 동작과 일치하도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- JPARepository로 정의해서 사용한 메서드명이 잘못되어서 500에러가 발생했어요
- 멤버 아이디 조회시 프로필 공개 여부 필터링 하도록 QueryRepository 수정하고 JPARepository 프로필 비공개 멤버 아이디 조회 메서드 제거했어요!
