### PR TITLE
셀프 소개 글 조회 API 에러

### DIFF
--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionController.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionController.java
@@ -55,11 +55,13 @@ public class SelfIntroductionController {
     @GetMapping
     public ResponseEntity<BaseResponse<List<SelfIntroductionSummaryView>>> getIntroductions(
         @AuthPrincipal AuthContext authContext,
-        @ModelAttribute SelfIntroductionSearchRequest searchRequest, Long lastId) {
+        @ModelAttribute SelfIntroductionSearchRequest searchRequest
+    ) {
         SelfIntroductionSearchCondition searchCondition = SelfIntroductionMapper.toSelfIntroductionSearchCondition(
             searchRequest);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK,
-            selfIntroductionQueryRepository.findSelfIntroductions(searchCondition, lastId, authContext.getId())));
+            selfIntroductionQueryRepository.findSelfIntroductions(searchCondition, searchRequest.lastId(),
+                authContext.getId())));
     }
 
     @Operation(summary = "셀프 소개 상세 조회 API")

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchCondition.java
@@ -1,12 +1,11 @@
 package atwoz.atwoz.community.presentation.selfintroduction.dto;
 
-import atwoz.atwoz.member.command.domain.member.City;
 import atwoz.atwoz.member.command.domain.member.Gender;
 
 import java.util.List;
 
 public record SelfIntroductionSearchCondition(
-    List<City> preferredCities,
+    List<String> preferredCities,
     Integer fromYearOfBirth,
     Integer toYearOfBirth,
     Gender gender

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchRequest.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchRequest.java
@@ -13,6 +13,7 @@ public record SelfIntroductionSearchRequest(
     Integer fromAge,
     Integer toAge,
     @Schema(implementation = Gender.class)
-    String gender
+    String gender,
+    Long lastId
 ) {
 }

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchRequest.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/dto/SelfIntroductionSearchRequest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public record SelfIntroductionSearchRequest(
     @ArraySchema(schema = @Schema(implementation = City.class))
-    List<City> preferredCities,
+    List<String> preferredCities,
     Integer fromAge,
     Integer toAge,
     @Schema(implementation = Gender.class)

--- a/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/community/query/selfintroduction/SelfIntroductionQueryRepository.java
@@ -134,8 +134,9 @@ public class SelfIntroductionQueryRepository {
     private BooleanExpression addPreferredCityCondition(BooleanExpression condition,
         SelfIntroductionSearchCondition searchCondition) {
         if (searchCondition.preferredCities() != null && !searchCondition.preferredCities().isEmpty()) {
-            condition = (condition == null) ? member.profile.region.city.in(searchCondition.preferredCities())
-                : condition.and(member.profile.region.city.in(searchCondition.preferredCities()));
+            condition =
+                (condition == null) ? member.profile.region.city.stringValue().in(searchCondition.preferredCities())
+                    : condition.and(member.profile.region.city.stringValue().in(searchCondition.preferredCities()));
         }
         return condition;
     }

--- a/src/test/java/atwoz/atwoz/community/query/SelfIntroductionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/community/query/SelfIntroductionQueryRepositoryTest.java
@@ -258,7 +258,7 @@ public class SelfIntroductionQueryRepositoryTest {
             // Given
             City city = maleMember.getProfile().getRegion().getCity();
             SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
-                List.of(city), null, null, null
+                List.of(city.name()), null, null, null
             );
 
             List<SelfIntroduction> maleSelfIntroduction = selfIntroductions.stream()
@@ -284,7 +284,7 @@ public class SelfIntroductionQueryRepositoryTest {
         void findSelfIntroductions() {
             // Given
             SelfIntroductionSearchCondition searchCondition = new SelfIntroductionSearchCondition(
-                List.of(City.DAEJEON, City.SEOUL), femaleMember.getProfile().getYearOfBirth().getValue(),
+                List.of(City.DAEJEON.name(), City.SEOUL.name()), femaleMember.getProfile().getYearOfBirth().getValue(),
                 maleMember.getProfile().getYearOfBirth().getValue(), maleMember.getProfile().getGender()
             );
             List<SelfIntroduction> maleSelfIntroduction = selfIntroductions.stream()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 자기소개 검색 요청에 마지막 ID(lastId) 필드가 추가되어, 더 편리한 페이지네이션이 가능합니다.

- **버그 수정**
  - 선호 지역(preferredCities) 필드가 객체 리스트에서 문자열 리스트로 변경되어, 지역 필터링이 더욱 일관성 있게 동작합니다.

- **테스트**
  - 선호 지역 관련 테스트가 문자열 기반으로 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- request dto에서 enum 대신 string 사용하도록 수정
- lastId 필수값이 아닌 선택값으로 사용하도록 수정
