### PR TITLE
멤버 하트 사용 내역 조회 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/heart/presentation/hearttransaction/AdminHeartTransactionController.java
+++ b/src/main/java/atwoz/atwoz/heart/presentation/hearttransaction/AdminHeartTransactionController.java
@@ -2,9 +2,9 @@ package atwoz.atwoz.heart.presentation.hearttransaction;
 
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
-import atwoz.atwoz.heart.query.hearttransaction.HeartTransactionQueryRepository;
-import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
-import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import atwoz.atwoz.heart.query.hearttransaction.AdminHeartTransactionQueryRepository;
+import atwoz.atwoz.heart.query.hearttransaction.condition.AdminHeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.AdminHeartTransactionView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,15 +22,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/admin/heart-transactions")
 public class AdminHeartTransactionController {
-    private final HeartTransactionQueryRepository heartTransactionQueryRepository;
+    private final AdminHeartTransactionQueryRepository adminHeartTransactionQueryRepository;
 
     @Operation(summary = "하트 트랜잭션 목록 조회 API")
     @GetMapping
-    public ResponseEntity<BaseResponse<Page<HeartTransactionView>>> getPage(
-        @ModelAttribute HeartTransactionSearchCondition condition,
+    public ResponseEntity<BaseResponse<Page<AdminHeartTransactionView>>> getPage(
+        @ModelAttribute AdminHeartTransactionSearchCondition condition,
         @PageableDefault(size = 100) Pageable pageable
     ) {
-        Page<HeartTransactionView> page = heartTransactionQueryRepository.findPage(condition, pageable);
+        Page<AdminHeartTransactionView> page = adminHeartTransactionQueryRepository.findPage(condition, pageable);
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, page));
     }
 }

--- a/src/main/java/atwoz/atwoz/heart/presentation/hearttransaction/HeartTransactionController.java
+++ b/src/main/java/atwoz/atwoz/heart/presentation/hearttransaction/HeartTransactionController.java
@@ -1,0 +1,36 @@
+package atwoz.atwoz.heart.presentation.hearttransaction;
+
+import atwoz.atwoz.auth.presentation.AuthContext;
+import atwoz.atwoz.auth.presentation.AuthPrincipal;
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.heart.query.hearttransaction.HeartTransactionQueryService;
+import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionViews;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "하트 내역 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/heart-transactions")
+public class HeartTransactionController {
+    private final HeartTransactionQueryService heartTransactionQueryService;
+
+    @Operation(summary = "하트 내역 조회")
+    @GetMapping
+    public ResponseEntity<BaseResponse<HeartTransactionViews>> getHeartTransactions(
+        @ModelAttribute HeartTransactionSearchCondition condition,
+        @AuthPrincipal AuthContext authContext
+    ) {
+        final HeartTransactionViews views = heartTransactionQueryService.findHeartTransactions(
+            authContext.getId(), condition);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, views));
+    }
+}

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/AdminHeartTransactionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/AdminHeartTransactionQueryRepository.java
@@ -1,0 +1,112 @@
+package atwoz.atwoz.heart.query.hearttransaction;
+
+import atwoz.atwoz.heart.query.hearttransaction.condition.AdminHeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.AdminHeartTransactionView;
+import atwoz.atwoz.heart.query.hearttransaction.view.QAdminHeartTransactionView;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static atwoz.atwoz.heart.command.domain.hearttransaction.QHeartTransaction.heartTransaction;
+import static atwoz.atwoz.member.command.domain.member.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminHeartTransactionQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public Page<AdminHeartTransactionView> findPage(AdminHeartTransactionSearchCondition condition, Pageable pageable) {
+        Set<Long> memberIds = getMemberIds(condition.nickname(), condition.phoneNumber());
+        if (memberIds != null && memberIds.isEmpty()) {
+            // nickname과 phoneNumber 검색 결과 대상 멤버가 없는 경우 빈 페이지를 반환합니다.
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        List<AdminHeartTransactionView> views = queryFactory
+            .select(
+                new QAdminHeartTransactionView(
+                    heartTransaction.id,
+                    heartTransaction.createdAt,
+                    heartTransaction.transactionType.stringValue(),
+                    heartTransaction.content,
+                    heartTransaction.heartAmount.amount,
+                    getHeartBalance()
+                ))
+            .from(heartTransaction)
+            .where(
+                memberIdIn(memberIds),
+                createdAtGoe(condition.createdDateGoe()),
+                createdAtLoe(condition.createdDateLoe())
+            )
+            .orderBy(heartTransaction.id.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long totalCount = queryFactory
+            .select(heartTransaction.count())
+            .from(heartTransaction)
+            .where(
+                memberIdIn(memberIds),
+                createdAtGoe(condition.createdDateGoe()),
+                createdAtLoe(condition.createdDateLoe())
+            )
+            .fetchOne();
+
+        return new PageImpl<>(views, pageable, totalCount);
+    }
+
+    private Set<Long> getMemberIds(String nickname, String phoneNumber) {
+        if (nickname == null && phoneNumber == null) {
+            // nickname과 phoneNumber가 모두 null인 경우 null을 반환하여 memberId 조건을 무시합니다.
+            return null;
+        }
+
+        List<Long> list = queryFactory
+            .select(member.id)
+            .from(member)
+            .where(
+                nicknameContains(nickname),
+                phoneNumberEq(phoneNumber)
+            )
+            .fetch();
+
+        return new HashSet<>(list);
+    }
+
+    private BooleanExpression nicknameContains(String nickname) {
+        return nickname != null ? member.profile.nickname.value.contains(nickname) : null;
+    }
+
+    private BooleanExpression phoneNumberEq(String phoneNumber) {
+        return phoneNumber != null ? member.phoneNumber.value.eq(phoneNumber) : null;
+    }
+
+    private NumberExpression<Long> getHeartBalance() {
+        return heartTransaction.heartBalance.missionHeartBalance.add(
+            heartTransaction.heartBalance.purchaseHeartBalance);
+    }
+
+    private BooleanExpression memberIdIn(Set<Long> memberIds) {
+        return memberIds != null ? heartTransaction.memberId.in(memberIds) : null;
+    }
+
+    private BooleanExpression createdAtGoe(LocalDate createdDateGoe) {
+        return createdDateGoe != null ? heartTransaction.createdAt.goe(createdDateGoe.atStartOfDay()) : null;
+    }
+
+    private BooleanExpression createdAtLoe(LocalDate createdDateLoe) {
+        return createdDateLoe != null ? heartTransaction.createdAt.loe(
+            createdDateLoe.plusDays(1).atStartOfDay().minusSeconds(1)) : null;
+    }
+}

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryRepository.java
@@ -4,109 +4,45 @@ import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearch
 import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
 import atwoz.atwoz.heart.query.hearttransaction.view.QHeartTransactionView;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static atwoz.atwoz.heart.command.domain.hearttransaction.QHeartTransaction.heartTransaction;
-import static atwoz.atwoz.member.command.domain.member.QMember.member;
 
 @Repository
 @RequiredArgsConstructor
 public class HeartTransactionQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public Page<HeartTransactionView> findPage(HeartTransactionSearchCondition condition, Pageable pageable) {
-        Set<Long> memberIds = getMemberIds(condition.nickname(), condition.phoneNumber());
-        if (memberIds != null && memberIds.isEmpty()) {
-            // nickname과 phoneNumber 검색 결과 대상 멤버가 없는 경우 빈 페이지를 반환합니다.
-            return new PageImpl<>(List.of(), pageable, 0);
-        }
-
-        List<HeartTransactionView> views = queryFactory
-            .select(
-                new QHeartTransactionView(
-                    heartTransaction.id,
-                    heartTransaction.createdAt,
-                    heartTransaction.transactionType.stringValue(),
-                    heartTransaction.content,
-                    heartTransaction.heartAmount.amount,
-                    getHeartBalance()
-                ))
+    public List<HeartTransactionView> findHeartTransactions(long memberId, HeartTransactionSearchCondition condition,
+        int size) {
+        return queryFactory
+            .select(new QHeartTransactionView(
+                heartTransaction.id,
+                heartTransaction.createdAt,
+                heartTransaction.content,
+                heartTransaction.heartAmount.amount
+            ))
             .from(heartTransaction)
             .where(
-                memberIdIn(memberIds),
-                createdAtGoe(condition.createdDateGoe()),
-                createdAtLoe(condition.createdDateLoe())
+                idLt(condition.lastId()),
+                memberIdEq(memberId)
             )
             .orderBy(heartTransaction.id.desc())
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
+            .limit(size)
             .fetch();
-
-        long totalCount = queryFactory
-            .select(heartTransaction.count())
-            .from(heartTransaction)
-            .where(
-                memberIdIn(memberIds),
-                createdAtGoe(condition.createdDateGoe()),
-                createdAtLoe(condition.createdDateLoe())
-            )
-            .fetchOne();
-
-        return new PageImpl<>(views, pageable, totalCount);
     }
 
-    private Set<Long> getMemberIds(String nickname, String phoneNumber) {
-        if (nickname == null && phoneNumber == null) {
-            // nickname과 phoneNumber가 모두 null인 경우 null을 반환하여 memberId 조건을 무시합니다.
-            return null;
-        }
-
-        List<Long> list = queryFactory
-            .select(member.id)
-            .from(member)
-            .where(
-                nicknameContains(nickname),
-                phoneNumberEq(phoneNumber)
-            )
-            .fetch();
-
-        return new HashSet<>(list);
+    private BooleanExpression idLt(Long id) {
+        return id != null ? heartTransaction.id.lt(id) : null;
     }
 
-    private BooleanExpression nicknameContains(String nickname) {
-        return nickname != null ? member.profile.nickname.value.contains(nickname) : null;
+    private BooleanExpression memberIdEq(long memberId) {
+        return heartTransaction.memberId.eq(memberId);
     }
 
-    private BooleanExpression phoneNumberEq(String phoneNumber) {
-        return phoneNumber != null ? member.phoneNumber.value.eq(phoneNumber) : null;
-    }
 
-    private NumberExpression<Long> getHeartBalance() {
-        return heartTransaction.heartBalance.missionHeartBalance.add(
-            heartTransaction.heartBalance.purchaseHeartBalance);
-    }
-
-    private BooleanExpression memberIdIn(Set<Long> memberIds) {
-        return memberIds != null ? heartTransaction.memberId.in(memberIds) : null;
-    }
-
-    private BooleanExpression createdAtGoe(LocalDate createdDateGoe) {
-        return createdDateGoe != null ? heartTransaction.createdAt.goe(createdDateGoe.atStartOfDay()) : null;
-    }
-
-    private BooleanExpression createdAtLoe(LocalDate createdDateLoe) {
-        return createdDateLoe != null ? heartTransaction.createdAt.loe(
-            createdDateLoe.plusDays(1).atStartOfDay().minusSeconds(1)) : null;
-    }
 }

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryService.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryService.java
@@ -1,0 +1,28 @@
+package atwoz.atwoz.heart.query.hearttransaction;
+
+import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionViews;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HeartTransactionQueryService {
+    private static final int CLIENT_PAGE_SIZE = 12;
+
+    private final HeartTransactionQueryRepository heartTransactionQueryRepository;
+
+    public HeartTransactionViews findHeartTransactions(long memberId, HeartTransactionSearchCondition condition) {
+        List<HeartTransactionView> views = heartTransactionQueryRepository.findHeartTransactions(memberId,
+            condition, CLIENT_PAGE_SIZE + 1);
+        boolean hasMore = views.size() > CLIENT_PAGE_SIZE;
+        List<HeartTransactionView> transactions = views.stream()
+            .limit(CLIENT_PAGE_SIZE)
+            .toList();
+
+        return new HeartTransactionViews(transactions, hasMore);
+    }
+}

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/condition/AdminHeartTransactionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/condition/AdminHeartTransactionSearchCondition.java
@@ -1,0 +1,15 @@
+package atwoz.atwoz.heart.query.hearttransaction.condition;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record AdminHeartTransactionSearchCondition(
+    String nickname,
+    String phoneNumber,
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    LocalDate createdDateGoe,
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    LocalDate createdDateLoe
+) {
+}

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/condition/HeartTransactionSearchCondition.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/condition/HeartTransactionSearchCondition.java
@@ -1,15 +1,6 @@
 package atwoz.atwoz.heart.query.hearttransaction.condition;
 
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDate;
-
 public record HeartTransactionSearchCondition(
-    String nickname,
-    String phoneNumber,
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    LocalDate createdDateGoe,
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    LocalDate createdDateLoe
+    Long lastId
 ) {
 }

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/AdminHeartTransactionView.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/AdminHeartTransactionView.java
@@ -1,0 +1,21 @@
+package atwoz.atwoz.heart.query.hearttransaction.view;
+
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record AdminHeartTransactionView(
+    Long id,
+    LocalDateTime createdAt,
+    @Schema(implementation = TransactionType.class)
+    String transactionType,
+    String content,
+    Long heartAmount,
+    Long heartBalance
+) {
+    @QueryProjection
+    public AdminHeartTransactionView {
+    }
+}

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/HeartTransactionView.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/HeartTransactionView.java
@@ -1,19 +1,14 @@
 package atwoz.atwoz.heart.query.hearttransaction.view;
 
-import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
 import com.querydsl.core.annotations.QueryProjection;
-import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
 public record HeartTransactionView(
     Long id,
     LocalDateTime createdAt,
-    @Schema(implementation = TransactionType.class)
-    String transactionType,
     String content,
-    Long heartAmount,
-    Long heartBalance
+    Long heartAmount
 ) {
     @QueryProjection
     public HeartTransactionView {

--- a/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/HeartTransactionViews.java
+++ b/src/main/java/atwoz/atwoz/heart/query/hearttransaction/view/HeartTransactionViews.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.heart.query.hearttransaction.view;
+
+import java.util.List;
+
+public record HeartTransactionViews(
+    List<HeartTransactionView> transactions,
+    boolean hasMore
+) {
+}

--- a/src/test/java/atwoz/atwoz/heart/query/hearttransaction/AdminHeartTransactionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/heart/query/hearttransaction/AdminHeartTransactionQueryRepositoryTest.java
@@ -5,8 +5,8 @@ import atwoz.atwoz.heart.command.domain.hearttransaction.HeartTransaction;
 import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartAmount;
 import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartBalance;
 import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
-import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
-import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import atwoz.atwoz.heart.query.hearttransaction.condition.AdminHeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.AdminHeartTransactionView;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
 import atwoz.atwoz.member.command.domain.member.vo.Nickname;
@@ -26,18 +26,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 @DataJpaTest
-@Import({QueryDslConfig.class, HeartTransactionQueryRepository.class})
-class HeartTransactionQueryRepositoryTest {
+@Import({QueryDslConfig.class, AdminHeartTransactionQueryRepository.class})
+class AdminHeartTransactionQueryRepositoryTest {
     @Autowired
     private TestEntityManager entityManager;
     @Autowired
-    private HeartTransactionQueryRepository heartTransactionQueryRepository;
+    private AdminHeartTransactionQueryRepository adminHeartTransactionQueryRepository;
 
     @Test
     @DisplayName("하트 거래 내역 페이지 조회 파라미터 순서 테스트")
     void findPage() {
         // given
-        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition = new AdminHeartTransactionSearchCondition(
             null,
             null,
             null,
@@ -50,22 +50,23 @@ class HeartTransactionQueryRepositoryTest {
         entityManager.flush();
 
         // when
-        final Page<HeartTransactionView> result = heartTransactionQueryRepository.findPage(condition,
+        final Page<AdminHeartTransactionView> result = adminHeartTransactionQueryRepository.findPage(condition,
             pageRequest);
 
         // then
         assertThat(result).isNotNull();
-        List<HeartTransactionView> heartTransactionViews = result.getContent();
-        assertThat(heartTransactionViews).hasSize(1);
-        HeartTransactionView heartTransactionView = heartTransactionViews.get(0);
-        assertThat(heartTransactionView.id()).isEqualTo(heartTransaction1.getId());
-        assertThat(heartTransactionView.transactionType()).isEqualTo(heartTransaction1.getTransactionType().name());
-        assertThat(heartTransactionView.content()).isEqualTo(heartTransaction1.getContent());
-        assertThat(heartTransactionView.heartAmount()).isEqualTo(heartTransaction1.getHeartAmount().getAmount());
+        List<AdminHeartTransactionView> adminHeartTransactionViews = result.getContent();
+        assertThat(adminHeartTransactionViews).hasSize(1);
+        AdminHeartTransactionView adminHeartTransactionView = adminHeartTransactionViews.get(0);
+        assertThat(adminHeartTransactionView.id()).isEqualTo(heartTransaction1.getId());
+        assertThat(adminHeartTransactionView.transactionType()).isEqualTo(
+            heartTransaction1.getTransactionType().name());
+        assertThat(adminHeartTransactionView.content()).isEqualTo(heartTransaction1.getContent());
+        assertThat(adminHeartTransactionView.heartAmount()).isEqualTo(heartTransaction1.getHeartAmount().getAmount());
         Long heartBalance = heartTransaction1.getHeartBalance().getMissionHeartBalance() +
             heartTransaction1.getHeartBalance().getPurchaseHeartBalance();
-        assertThat(heartTransactionView.heartBalance()).isEqualTo(heartBalance);
-        assertThat(heartTransactionView.createdAt()).isCloseTo(heartTransaction1.getCreatedAt(),
+        assertThat(adminHeartTransactionView.heartBalance()).isEqualTo(heartBalance);
+        assertThat(adminHeartTransactionView.createdAt()).isCloseTo(heartTransaction1.getCreatedAt(),
             within(1, ChronoUnit.MICROS));
     }
 
@@ -73,7 +74,7 @@ class HeartTransactionQueryRepositoryTest {
     @DisplayName("하트 거래 내역 페이지 조회 nickname condition 테스트")
     void findPageWithNicknameCondition() {
         // given
-        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition = new AdminHeartTransactionSearchCondition(
             "name1",
             null,
             null,
@@ -96,22 +97,22 @@ class HeartTransactionQueryRepositoryTest {
         entityManager.flush();
 
         // when
-        final Page<HeartTransactionView> result = heartTransactionQueryRepository.findPage(condition,
+        final Page<AdminHeartTransactionView> result = adminHeartTransactionQueryRepository.findPage(condition,
             pageRequest);
 
         // then
         assertThat(result).isNotNull();
-        List<HeartTransactionView> heartTransactionViews = result.getContent();
-        assertThat(heartTransactionViews).hasSize(1);
-        HeartTransactionView heartTransactionView = heartTransactionViews.get(0);
-        assertThat(heartTransactionView.id()).isEqualTo(heartTransaction1.getId());
+        List<AdminHeartTransactionView> adminHeartTransactionViews = result.getContent();
+        assertThat(adminHeartTransactionViews).hasSize(1);
+        AdminHeartTransactionView adminHeartTransactionView = adminHeartTransactionViews.get(0);
+        assertThat(adminHeartTransactionView.id()).isEqualTo(heartTransaction1.getId());
     }
 
     @Test
     @DisplayName("하트 거래 내역 페이지 조회 phoneNumber condition 테스트")
     void findPageWithPhoneNumberCondition() {
         // given
-        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition = new AdminHeartTransactionSearchCondition(
             null,
             "01000000000",
             null,
@@ -134,28 +135,28 @@ class HeartTransactionQueryRepositoryTest {
         entityManager.flush();
 
         // when
-        final Page<HeartTransactionView> result = heartTransactionQueryRepository.findPage(condition,
+        final Page<AdminHeartTransactionView> result = adminHeartTransactionQueryRepository.findPage(condition,
             pageRequest);
 
         // then
         assertThat(result).isNotNull();
-        List<HeartTransactionView> heartTransactionViews = result.getContent();
-        assertThat(heartTransactionViews).hasSize(1);
-        HeartTransactionView heartTransactionView = heartTransactionViews.get(0);
-        assertThat(heartTransactionView.id()).isEqualTo(heartTransaction1.getId());
+        List<AdminHeartTransactionView> adminHeartTransactionViews = result.getContent();
+        assertThat(adminHeartTransactionViews).hasSize(1);
+        AdminHeartTransactionView adminHeartTransactionView = adminHeartTransactionViews.get(0);
+        assertThat(adminHeartTransactionView.id()).isEqualTo(heartTransaction1.getId());
     }
 
     @Test
     @DisplayName("하트 거래 내역 페이지 조회 nickname and phoneNumber condition 테스트")
     void findPageWithNicknameAndPhoneNumberCondition() {
         // given
-        HeartTransactionSearchCondition condition1 = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition1 = new AdminHeartTransactionSearchCondition(
             "name1",
             "01000000000",
             null,
             null
         );
-        HeartTransactionSearchCondition condition2 = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition2 = new AdminHeartTransactionSearchCondition(
             "name1",
             "01011111111",
             null,
@@ -178,17 +179,17 @@ class HeartTransactionQueryRepositoryTest {
         entityManager.flush();
 
         // when
-        final Page<HeartTransactionView> result1 = heartTransactionQueryRepository.findPage(condition1,
+        final Page<AdminHeartTransactionView> result1 = adminHeartTransactionQueryRepository.findPage(condition1,
             pageRequest);
-        final Page<HeartTransactionView> result2 = heartTransactionQueryRepository.findPage(condition2,
+        final Page<AdminHeartTransactionView> result2 = adminHeartTransactionQueryRepository.findPage(condition2,
             pageRequest);
 
         // then
         assertThat(result1).isNotNull();
-        List<HeartTransactionView> heartTransactionViews = result1.getContent();
-        assertThat(heartTransactionViews).hasSize(1);
-        HeartTransactionView heartTransactionView = heartTransactionViews.get(0);
-        assertThat(heartTransactionView.id()).isEqualTo(heartTransaction1.getId());
+        List<AdminHeartTransactionView> adminHeartTransactionViews = result1.getContent();
+        assertThat(adminHeartTransactionViews).hasSize(1);
+        AdminHeartTransactionView adminHeartTransactionView = adminHeartTransactionViews.get(0);
+        assertThat(adminHeartTransactionView.id()).isEqualTo(heartTransaction1.getId());
 
         assertThat(result2).isEmpty();
     }
@@ -201,14 +202,14 @@ class HeartTransactionQueryRepositoryTest {
         entityManager.persist(heartTransaction1);
         entityManager.flush();
 
-        HeartTransactionSearchCondition condition1 = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition1 = new AdminHeartTransactionSearchCondition(
             null,
             null,
             heartTransaction1.getCreatedAt().toLocalDate(),
             null
         );
 
-        HeartTransactionSearchCondition condition2 = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition2 = new AdminHeartTransactionSearchCondition(
             null,
             null,
             heartTransaction1.getCreatedAt().toLocalDate().plusDays(1),
@@ -218,18 +219,18 @@ class HeartTransactionQueryRepositoryTest {
 
 
         // when
-        final Page<HeartTransactionView> result1 = heartTransactionQueryRepository.findPage(condition1,
+        final Page<AdminHeartTransactionView> result1 = adminHeartTransactionQueryRepository.findPage(condition1,
             pageRequest);
 
-        final Page<HeartTransactionView> result2 = heartTransactionQueryRepository.findPage(condition2,
+        final Page<AdminHeartTransactionView> result2 = adminHeartTransactionQueryRepository.findPage(condition2,
             pageRequest);
 
         // then
         assertThat(result1).isNotNull();
-        List<HeartTransactionView> heartTransactionViews1 = result1.getContent();
-        assertThat(heartTransactionViews1).hasSize(1);
-        HeartTransactionView heartTransactionView1 = heartTransactionViews1.get(0);
-        assertThat(heartTransactionView1.id()).isEqualTo(heartTransaction1.getId());
+        List<AdminHeartTransactionView> adminHeartTransactionViews1 = result1.getContent();
+        assertThat(adminHeartTransactionViews1).hasSize(1);
+        AdminHeartTransactionView adminHeartTransactionView1 = adminHeartTransactionViews1.get(0);
+        assertThat(adminHeartTransactionView1.id()).isEqualTo(heartTransaction1.getId());
 
         assertThat(result2).isEmpty();
     }
@@ -242,14 +243,14 @@ class HeartTransactionQueryRepositoryTest {
         entityManager.persist(heartTransaction1);
         entityManager.flush();
 
-        HeartTransactionSearchCondition condition1 = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition1 = new AdminHeartTransactionSearchCondition(
             null,
             null,
             null,
             heartTransaction1.getCreatedAt().toLocalDate()
         );
 
-        HeartTransactionSearchCondition condition2 = new HeartTransactionSearchCondition(
+        AdminHeartTransactionSearchCondition condition2 = new AdminHeartTransactionSearchCondition(
             null,
             null,
             null,
@@ -258,18 +259,18 @@ class HeartTransactionQueryRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         // when
-        final Page<HeartTransactionView> result1 = heartTransactionQueryRepository.findPage(condition1,
+        final Page<AdminHeartTransactionView> result1 = adminHeartTransactionQueryRepository.findPage(condition1,
             pageRequest);
 
-        final Page<HeartTransactionView> result2 = heartTransactionQueryRepository.findPage(condition2,
+        final Page<AdminHeartTransactionView> result2 = adminHeartTransactionQueryRepository.findPage(condition2,
             pageRequest);
 
         // then
         assertThat(result1).isNotNull();
-        List<HeartTransactionView> heartTransactionViews1 = result1.getContent();
-        assertThat(heartTransactionViews1).hasSize(1);
-        HeartTransactionView heartTransactionView1 = heartTransactionViews1.get(0);
-        assertThat(heartTransactionView1.id()).isEqualTo(heartTransaction1.getId());
+        List<AdminHeartTransactionView> adminHeartTransactionViews1 = result1.getContent();
+        assertThat(adminHeartTransactionViews1).hasSize(1);
+        AdminHeartTransactionView adminHeartTransactionView1 = adminHeartTransactionViews1.get(0);
+        assertThat(adminHeartTransactionView1.id()).isEqualTo(heartTransaction1.getId());
 
         assertThat(result2).isEmpty();
     }

--- a/src/test/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryRepositoryTest.java
+++ b/src/test/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryRepositoryTest.java
@@ -1,0 +1,138 @@
+package atwoz.atwoz.heart.query.hearttransaction;
+
+import atwoz.atwoz.QuerydslConfig;
+import atwoz.atwoz.heart.command.domain.hearttransaction.HeartTransaction;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartAmount;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartBalance;
+import atwoz.atwoz.heart.command.domain.hearttransaction.vo.TransactionType;
+import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, HeartTransactionQueryRepository.class})
+class HeartTransactionQueryRepositoryTest {
+
+    @Autowired
+    private HeartTransactionQueryRepository heartTransactionQueryRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("하트 내역 조회 테스트")
+    void findHeartTransactionsTest() {
+        // Given
+        long memberId = 1L;
+        Long lastId = null;
+        int size = 10;
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(lastId);
+
+        final HeartTransaction heartTransaction = createHeartTransaction(memberId);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        List<HeartTransactionView> result = heartTransactionQueryRepository.findHeartTransactions(memberId, condition,
+            size);
+
+        // Then
+        assertThat(result).hasSize(1);
+        HeartTransactionView view = result.get(0);
+        assertThat(view.id()).isEqualTo(heartTransaction.getId());
+        assertThat(view.content()).isEqualTo(heartTransaction.getContent());
+        assertThat(view.heartAmount()).isEqualTo(heartTransaction.getHeartAmount().getAmount());
+        assertThat(view.createdAt()).isCloseTo(heartTransaction.getCreatedAt(), within(1, ChronoUnit.MICROS));
+    }
+
+    @Test
+    @DisplayName("하트 내역 조회 시 lastId가 주어지면 해당 ID보다 작은 내역만 조회합니다.")
+    void findHeartTransactionsWithLastIdTest() {
+        // Given
+        long memberId = 1L;
+        List<HeartTransaction> heartTransactions = List.of(
+            createHeartTransaction(memberId),
+            createHeartTransaction(memberId),
+            createHeartTransaction(memberId)
+        );
+        entityManager.flush();
+        entityManager.clear();
+        heartTransactions.stream().sorted(Comparator.comparing(HeartTransaction::getId).reversed());
+
+        Long lastId = heartTransactions.getLast().getId();
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(lastId);
+
+        // When
+        List<HeartTransactionView> result = heartTransactionQueryRepository.findHeartTransactions(memberId, condition,
+            10);
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).id()).isEqualTo(heartTransactions.get(1).getId());
+        assertThat(result.get(1).id()).isEqualTo(heartTransactions.get(0).getId());
+    }
+
+    @Test
+    @DisplayName("하트 내역 조회 시 memberId가 일치하지 않으면 빈 리스트를 반환합니다.")
+    void findHeartTransactionsWithNonMatchingMemberIdTest() {
+        // Given
+        long memberId = 1L;
+        createHeartTransaction(memberId);
+        entityManager.flush();
+        entityManager.clear();
+        long nonMatchingMemberId = 2L;
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(null);
+
+        // When
+        List<HeartTransactionView> result = heartTransactionQueryRepository.findHeartTransactions(nonMatchingMemberId,
+            condition,
+            10);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("하트 내역 조회 시 size가 1이면 id값이 가장 큰 1개를 반환합니다.")
+    void findHeartTransactionsWithZeroSizeTest() {
+        // Given
+        long memberId = 1L;
+        List<HeartTransaction> heartTransactions = List.of(
+            createHeartTransaction(memberId),
+            createHeartTransaction(memberId),
+            createHeartTransaction(memberId)
+        );
+        entityManager.flush();
+        entityManager.clear();
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(null);
+
+        // When
+        List<HeartTransactionView> result = heartTransactionQueryRepository.findHeartTransactions(memberId, condition,
+            1);
+
+        // Then
+        assertThat(result).hasSize(1);
+        var view = result.get(0);
+        assertThat(view.id()).isEqualTo(
+            heartTransactions.stream().max(Comparator.comparing(HeartTransaction::getId)).get().getId());
+    }
+
+    private HeartTransaction createHeartTransaction(final long memberId) {
+        final HeartTransaction heartTransaction = HeartTransaction.of(memberId, TransactionType.PURCHASE,
+            TransactionType.PURCHASE.getDescription(), HeartAmount.from(10L), HeartBalance.of(100L, 100L));
+        entityManager.persist(heartTransaction);
+        return heartTransaction;
+    }
+}

--- a/src/test/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryServiceTest.java
+++ b/src/test/java/atwoz/atwoz/heart/query/hearttransaction/HeartTransactionQueryServiceTest.java
@@ -1,0 +1,83 @@
+package atwoz.atwoz.heart.query.hearttransaction;
+
+import atwoz.atwoz.heart.query.hearttransaction.condition.HeartTransactionSearchCondition;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionView;
+import atwoz.atwoz.heart.query.hearttransaction.view.HeartTransactionViews;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HeartTransactionQueryServiceTest {
+
+    @InjectMocks
+    private HeartTransactionQueryService heartTransactionQueryService;
+
+    @Mock
+    private HeartTransactionQueryRepository heartTransactionQueryRepository;
+
+    @Test
+    @DisplayName("하트 내역 조회 서비스 테스트")
+    void findHeartTransactionsTest() {
+        // Given
+        long memberId = 1L;
+        int size = 13;
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(null);
+        List<HeartTransactionView> views = createHeartTransactionViews(size);
+        when(heartTransactionQueryRepository.findHeartTransactions(memberId, condition, size)).thenReturn(views);
+
+        // When
+        final HeartTransactionViews result = heartTransactionQueryService.findHeartTransactions(memberId, condition);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.hasMore()).isTrue();
+        assertThat(result.transactions()).hasSize(size - 1);
+        for (int i = 0; i < size - 1; i++) {
+            HeartTransactionView view = result.transactions().get(i);
+            assertThat(view.id()).isEqualTo((long) i);
+        }
+    }
+
+    @Test
+    @DisplayName("하트 내역이 13개 미만인 경우 테스트")
+    void findHeartTransactionsLessThanThirteenTest() {
+        // Given
+        long memberId = 1L;
+        int size = 13;
+        int actualSize = 12;
+        HeartTransactionSearchCondition condition = new HeartTransactionSearchCondition(null);
+        List<HeartTransactionView> views = createHeartTransactionViews(actualSize);
+        when(heartTransactionQueryRepository.findHeartTransactions(memberId, condition, size)).thenReturn(views);
+
+        // When
+        final HeartTransactionViews result = heartTransactionQueryService.findHeartTransactions(memberId, condition);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.hasMore()).isFalse();
+        assertThat(result.transactions()).hasSize(actualSize);
+        for (int i = 0; i < actualSize; i++) {
+            HeartTransactionView view = result.transactions().get(i);
+            assertThat(view.id()).isEqualTo((long) i);
+        }
+    }
+
+    private List<HeartTransactionView> createHeartTransactionViews(int size) {
+        List<HeartTransactionView> views = new ArrayList<>();
+        for (long i = 0; i < size; i++) {
+            views.add(new HeartTransactionView(i, null, null, null));
+        }
+        return views;
+    }
+
+}


### PR DESCRIPTION
@coderabbitai summary

## 노트
- 호윤님이 작성하신 `LikeQueryService` 참고해서 작성했는데요
- 무한 스크롤 API 는 이처럼 response dto에 `hasMore`을 추가해서 구현하면 클라이언트에서 사용하기 편할 것 같아요
- 셀프 소개 글 조회 API도 참고해서 적용하면 좋을 것 같네요!