### PR TITLE
알림 핸들링 추가 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/command/domain/warning/Warning.java
+++ b/src/main/java/atwoz/atwoz/admin/command/domain/warning/Warning.java
@@ -18,8 +18,6 @@ import static jakarta.persistence.EnumType.STRING;
 @Getter
 public class Warning {
 
-    private static final int THRESHOLD = 2;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/atwoz/atwoz/community/command/domain/profileexchange/ProfileExchange.java
+++ b/src/main/java/atwoz/atwoz/community/command/domain/profileexchange/ProfileExchange.java
@@ -3,7 +3,7 @@ package atwoz.atwoz.community.command.domain.profileexchange;
 
 import atwoz.atwoz.common.entity.BaseEntity;
 import atwoz.atwoz.common.event.Events;
-import atwoz.atwoz.community.command.domain.profileexchange.event.ProfileExchangeApprovedEvent;
+import atwoz.atwoz.community.command.domain.profileexchange.event.ProfileExchangeAcceptedEvent;
 import atwoz.atwoz.community.command.domain.profileexchange.event.ProfileExchangeRejectedEvent;
 import atwoz.atwoz.community.command.domain.profileexchange.event.ProfileExchangeRequestedEvent;
 import atwoz.atwoz.community.command.domain.profileexchange.exception.InvalidProfileExchangeStatusException;
@@ -49,7 +49,7 @@ public class ProfileExchange extends BaseEntity {
 
     public void approve(String senderName) {
         validateWaitingStatus();
-        Events.raise(ProfileExchangeApprovedEvent.of(requesterId, responderId, senderName));
+        Events.raise(ProfileExchangeAcceptedEvent.of(requesterId, responderId, senderName));
         status = ProfileExchangeStatus.APPROVE;
     }
 

--- a/src/main/java/atwoz/atwoz/community/command/domain/profileexchange/event/ProfileExchangeAcceptedEvent.java
+++ b/src/main/java/atwoz/atwoz/community/command/domain/profileexchange/event/ProfileExchangeAcceptedEvent.java
@@ -7,12 +7,12 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class ProfileExchangeApprovedEvent extends Event {
+public class ProfileExchangeAcceptedEvent extends Event {
     private final long requesterId;
     private final long responderId;
     private final String senderName;
 
-    public static ProfileExchangeApprovedEvent of(long requesterId, long responderId, String senderName) {
-        return new ProfileExchangeApprovedEvent(requesterId, responderId, senderName);
+    public static ProfileExchangeAcceptedEvent of(long requesterId, long responderId, String senderName) {
+        return new ProfileExchangeAcceptedEvent(requesterId, responderId, senderName);
     }
 }

--- a/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRespondedEvent.java
+++ b/src/main/java/atwoz/atwoz/match/command/domain/match/event/MatchRespondedEvent.java
@@ -9,9 +9,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MatchRespondedEvent extends Event {
-    Long requesterId;
-    Long responderId;
-    String matchStatus;
+    private final long requesterId;
+    private final long responderId;
+    private final String matchStatus;
 
     public static MatchRespondedEvent of(Long requesterId, Long responderId, MatchStatus matchStatus) {
         return new MatchRespondedEvent(requesterId, responderId, matchStatus.toString());

--- a/src/main/java/atwoz/atwoz/notification/infra/NotificationEventHandler.java
+++ b/src/main/java/atwoz/atwoz/notification/infra/NotificationEventHandler.java
@@ -43,7 +43,7 @@ public class NotificationEventHandler {
         notificationSendService.send(request);
     }
 
-    // TODO: MatchApprovedEvent, MatchRejectedEvent
+    // TODO: MatchAcceptedEvent, MatchRejectedEvent
 
     @Async
     @TransactionalEventListener(value = ProfileExchangeRequestedEvent.class, phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/java/atwoz/atwoz/notification/presentation/NotificationController.java
+++ b/src/main/java/atwoz/atwoz/notification/presentation/NotificationController.java
@@ -4,6 +4,8 @@ import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.notification.command.application.NotificationReadService;
+import atwoz.atwoz.notification.command.application.NotificationSendRequest;
+import atwoz.atwoz.notification.command.application.NotificationSendService;
 import atwoz.atwoz.notification.query.NotificationQueryRepository;
 import atwoz.atwoz.notification.query.NotificationView;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +27,9 @@ public class NotificationController {
     private final NotificationReadService notificationReadService;
     private final NotificationQueryRepository notificationQueryRepository;
 
+    // TODO: 삭제 필요(테스트 용도)
+    private final NotificationSendService notificationSendService;
+
     @Operation(summary = "알림 읽기")
     @PatchMapping("/{notificationId}")
     public ResponseEntity<BaseResponse<Void>> markAsRead(@PathVariable long notificationId) {
@@ -41,5 +46,15 @@ public class NotificationController {
         return ResponseEntity.ok(
             BaseResponse.of(OK, notificationQueryRepository.findNotifications(authContext.getId(), isRead))
         );
+    }
+
+    // TODO: 삭제 필요(테스트 용도)
+    @Operation(summary = "알림 전송 테스트")
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> send(
+        NotificationSendRequest request
+    ) {
+        notificationSendService.send(request);
+        return ResponseEntity.ok(BaseResponse.from(OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/notification/presentation/NotificationController.java
+++ b/src/main/java/atwoz/atwoz/notification/presentation/NotificationController.java
@@ -52,7 +52,7 @@ public class NotificationController {
     @Operation(summary = "알림 전송 테스트")
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> send(
-        NotificationSendRequest request
+        @RequestBody NotificationSendRequest request
     ) {
         notificationSendService.send(request);
         return ResponseEntity.ok(BaseResponse.from(OK));


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로필 교환 요청, 수락, 거절에 대한 알림이 추가되었습니다.
  * 알림 테스트용 새로운 엔드포인트가 추가되었습니다.

* **Bug Fixes**
  * 프로필 교환 승인 이벤트 명칭이 일관되게 "수락"으로 변경되었습니다.

* **Refactor**
  * 일부 이벤트 필드가 불변성 및 캡슐화를 위해 수정되었습니다.
  * 알림 처리 시 발신자 이름 상수가 도입되어 코드가 일관성 있게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
#223 
해당 이슈에서 이벤트 핸들링 현황 부분에 있는 매치 관련 이벤트가 아래처럼 변경되어야합니다.

- 매치 요청(`MatchRequestedEvent`): 요청자 닉네임 추가로 보내주도록 비즈니스 로직  수정
- 매치 응답: 기존 `MatchRespondedEvent` 제거 후 매치 수락/거절 이벤트로 나누고, 다른 이벤트들처럼 수락/거절한 사람 닉네임도 보내주도록 구현(`MatchAcceptedEvent`, `MatchRejectedEvent`)