### PR TITLE
활동 회원 전환 기능

### DIFF
--- a/src/main/java/atwoz/atwoz/auth/presentation/filter/PathMatcherConfig.java
+++ b/src/main/java/atwoz/atwoz/auth/presentation/filter/PathMatcherConfig.java
@@ -10,7 +10,7 @@ public class PathMatcherConfig {
 
     private static final List<String> EXCLUDED_URIS = List.of(
         "/member/login", "/member/logout", "/member/code", "/member/login/test",
-        "/admin/login", "/admin/signup", "/admin/logout",
+        "/admin/login", "/admin/signup", "/admin/logout", "/member/profile/active",
         "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**",
         "/webjars/**"
     );

--- a/src/main/java/atwoz/atwoz/common/enums/StatusType.java
+++ b/src/main/java/atwoz/atwoz/common/enums/StatusType.java
@@ -26,6 +26,7 @@ public enum StatusType {
     EXISTS_NOTIFICATION_DATETIME(400, "400500", "Exists Reservation Time"),
     CANNOT_BE_EDITED(400, "400600", "Cannot be edited"),
     INSUFFICIENT_HEARTS(400, "400700", "Insufficient heart balance"),
+    DORMANT_STATUS(400, "400800", "Member is Dormant status"),
 
     UNAUTHORIZED(401, "401", "Unauthorized"),
     MISSING_ACCESS_TOKEN(401, "401001", "Missing Access Token"),

--- a/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionMapper.java
+++ b/src/main/java/atwoz/atwoz/community/presentation/selfintroduction/SelfIntroductionMapper.java
@@ -6,7 +6,7 @@ import atwoz.atwoz.member.command.domain.member.Gender;
 import atwoz.atwoz.member.query.member.AgeConverter;
 
 public class SelfIntroductionMapper {
-    static SelfIntroductionSearchCondition toSelfIntroductionSearchCondition(
+    public static SelfIntroductionSearchCondition toSelfIntroductionSearchCondition(
         SelfIntroductionSearchRequest selfIntroductionSearchRequest) {
         return new SelfIntroductionSearchCondition(
             selfIntroductionSearchRequest.preferredCities(),

--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberAuthService.java
@@ -60,12 +60,16 @@ public class MemberAuthService {
     public MemberLoginServiceDto test(String phoneNumber) {
         Member member = createOrFindMemberByPhoneNumber(phoneNumber);
 
+        if (member.isDeleted()) {
+            throw new MemberDeletedException();
+        }
+
         if (member.isPermanentlySuspended()) {
             throw new PermanentlySuspendedMemberException();
         }
 
-        if (member.isDeleted()) {
-            throw new MemberDeletedException();
+        if (!member.isActive()) {
+            throw new MemberNotActiveException();
         }
 
         String accessToken = tokenProvider.createAccessToken(member.getId(), Role.MEMBER, Instant.now());

--- a/src/main/java/atwoz/atwoz/member/command/application/member/MemberProfileService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/member/MemberProfileService.java
@@ -2,6 +2,7 @@ package atwoz.atwoz.member.command.application.member;
 
 
 import atwoz.atwoz.member.command.application.member.exception.MemberNotFoundException;
+import atwoz.atwoz.member.command.application.member.exception.PermanentlySuspendedMemberException;
 import atwoz.atwoz.member.command.application.member.exception.PrimaryContactTypeSettingNeededException;
 import atwoz.atwoz.member.command.domain.member.ActivityStatus;
 import atwoz.atwoz.member.command.domain.member.Member;
@@ -30,6 +31,19 @@ public class MemberProfileService {
     @Transactional
     public void changeToDormant(Long memberId) {
         getMemberById(memberId).changeToDormant();
+    }
+
+    @Transactional
+    public void changeToActive(String phoneNumber) {
+        Member member = getMemberByPhoneNumber(phoneNumber);
+        validateMemberStatusForActive(member);
+        member.changeToActive();
+    }
+
+    private void validateMemberStatusForActive(final Member member) {
+        if (member.isPermanentlySuspended()) {
+            throw new PermanentlySuspendedMemberException();
+        }
     }
 
     @Transactional
@@ -72,6 +86,10 @@ public class MemberProfileService {
 
     private Member getMemberById(Long memberId) {
         return memberCommandRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    }
+
+    private Member getMemberByPhoneNumber(String phoneNumber) {
+        return memberCommandRepository.findByPhoneNumber(phoneNumber).orElseThrow(MemberNotFoundException::new);
     }
 
     private ActivityStatus getActivityStatus(String status) {

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/Member.java
@@ -6,6 +6,7 @@ import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartAmount;
 import atwoz.atwoz.heart.command.domain.hearttransaction.vo.HeartBalance;
 import atwoz.atwoz.member.command.domain.member.event.MemberSettingUpdatedEvent;
 import atwoz.atwoz.member.command.domain.member.event.PurchaseHeartGainedEvent;
+import atwoz.atwoz.member.command.domain.member.exception.MemberAlreadyActiveException;
 import atwoz.atwoz.member.command.domain.member.exception.MemberNotActiveException;
 import atwoz.atwoz.member.command.domain.member.vo.KakaoId;
 import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
@@ -100,6 +101,13 @@ public class Member extends SoftDeleteBaseEntity {
             throw new MemberNotActiveException();
         }
         activityStatus = ActivityStatus.DORMANT;
+    }
+
+    public void changeToActive() {
+        if (isActive()) {
+            throw new MemberAlreadyActiveException();
+        }
+        activityStatus = ActivityStatus.ACTIVE;
     }
 
     public void changePrimaryContactTypeToKakao(KakaoId kakaoId) {

--- a/src/main/java/atwoz/atwoz/member/command/domain/member/exception/MemberAlreadyActiveException.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/member/exception/MemberAlreadyActiveException.java
@@ -1,0 +1,8 @@
+package atwoz.atwoz.member.command.domain.member.exception;
+
+public class MemberAlreadyActiveException extends RuntimeException {
+    public MemberAlreadyActiveException() {
+        super("이미 해당 회원은 활동 상태입니다.");
+    }
+
+}

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberController.java
@@ -6,6 +6,7 @@ import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.member.command.application.member.MemberContactService;
 import atwoz.atwoz.member.command.application.member.MemberProfileService;
+import atwoz.atwoz.member.presentation.member.dto.MemberChangeToActiveRequest;
 import atwoz.atwoz.member.presentation.member.dto.MemberMyProfileResponse;
 import atwoz.atwoz.member.presentation.member.dto.MemberProfileResponse;
 import atwoz.atwoz.member.presentation.member.dto.MemberProfileUpdateRequest;
@@ -15,6 +16,7 @@ import atwoz.atwoz.member.query.member.view.MemberContactView;
 import atwoz.atwoz.member.query.member.view.MemberInfoView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -62,6 +64,13 @@ public class MemberController {
     @PostMapping("/profile/dormant")
     public ResponseEntity<BaseResponse<Void>> changeToDormant(@AuthPrincipal AuthContext authContext) {
         memberProfileService.changeToDormant(authContext.getId());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @Operation(summary = "활동 계정 전환 API")
+    @PostMapping("/profile/active")
+    public ResponseEntity<BaseResponse<Void>> changeToActive(@Valid MemberChangeToActiveRequest request) {
+        memberProfileService.changeToActive(request.phoneNumber());
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 

--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberExceptionHandler.java
@@ -3,6 +3,7 @@ package atwoz.atwoz.member.presentation.member;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.member.command.application.member.exception.*;
+import atwoz.atwoz.member.command.domain.member.exception.MemberNotActiveException;
 import atwoz.atwoz.member.query.member.application.exception.ProfileAccessDeniedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -88,5 +89,13 @@ public class MemberExceptionHandler {
 
         return ResponseEntity.badRequest()
             .body(BaseResponse.from(StatusType.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(MemberNotActiveException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMemberNotActiveException(MemberNotActiveException e) {
+        log.warn("회원의 상태가 부적절합니다. {}", e.getMessage());
+
+        return ResponseEntity.badRequest()
+            .body(BaseResponse.from(StatusType.DORMANT_STATUS));
     }
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/member/dto/MemberChangeToActiveRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/dto/MemberChangeToActiveRequest.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.member.presentation.member.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+public record MemberChangeToActiveRequest(
+    @Pattern(regexp = "^010\\d{8}$", message = "010으로 시작하고 8자리의 숫자가 와야합니다.")
+    String phoneNumber
+) {
+}

--- a/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/application/member/MemberAuthServiceTest.java
@@ -13,6 +13,7 @@ import atwoz.atwoz.member.command.application.member.sms.AuthMessageService;
 import atwoz.atwoz.member.command.domain.member.ActivityStatus;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import atwoz.atwoz.member.command.domain.member.exception.MemberNotActiveException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -105,6 +106,24 @@ class MemberAuthServiceTest {
             // When & Then
             Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
                 .isInstanceOf(MemberDeletedException.class);
+        }
+
+        @Test
+        @DisplayName("활동 상태가 아닌 사용자가 로그인할 경우 예외 처리")
+        void shouldThrowExceptionWhenLoginAttemptedByNotActiveMember() {
+            // Given
+            String phoneNumber = "01012345678";
+            String code = "01012345678";
+            Member inactiveMember = Member.fromPhoneNumber("01012345678");
+            inactiveMember.changeToDormant();
+
+            Mockito.when(memberCommandRepository.findByPhoneNumber(phoneNumber))
+                .thenReturn(Optional.of(inactiveMember));
+            Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
+                .isInstanceOf(MemberNotActiveException.class);
         }
 
         @Test

--- a/src/test/java/atwoz/atwoz/member/command/domain/member/MemberTest.java
+++ b/src/test/java/atwoz/atwoz/member/command/domain/member/MemberTest.java
@@ -58,6 +58,20 @@ class MemberTest {
         }
 
         @Test
+        @DisplayName("멤버의 활동 상태를 활동중 상태로 전환합니다.")
+        void changeMemberActivityStatusToActive() {
+            // Given
+            Member member = Member.fromPhoneNumber("01012345678");
+            member.changeToDormant();
+
+            // When
+            member.changeToActive();
+
+            // Then
+            Assertions.assertThat(member.isActive()).isTrue();
+        }
+
+        @Test
         @DisplayName("멤버의 카카오 아이디를 변경합니다.")
         void changeMemberKakaoId() {
             // Given


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 회원의 상태를 '활동'으로 전환하는 API 엔드포인트가 추가되었습니다.
  * 비활동(휴면) 회원 상태에 대한 예외 처리 및 안내 메시지가 제공됩니다.
  * 회원 상태가 이미 '활동'인 경우 예외가 발생하도록 개선되었습니다.

* **버그 수정**
  * 로그인 시 회원 상태(삭제, 영구정지, 비활동)에 대한 검증 순서가 개선되었습니다.

* **사용성 개선**
  * 휴면 상태에 대한 명확한 상태 코드와 메시지가 추가되었습니다.
  * 휴대폰 번호 입력 시 형식 검증이 강화되었습니다.
  * 로그아웃 시 리프레시 토큰 쿠키가 삭제되도록 처리되었습니다.
  * 비활동 회원 로그인 시 적절한 예외가 발생하도록 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
