### PR TITLE
여러 알림 타입을 한 번에 수신 설정 토글할 수 있도록 변경

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,58 +1,55 @@
 <component name="ProjectCodeStyleConfiguration">
-    <code_scheme name="Project" version="173">
-        <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="false" />
-        <option name="SOFT_MARGINS" value="120" />
-        <JavaCodeStyleSettings>
-            <option name="GENERATE_FINAL_LOCALS" value="true" />
-            <option name="GENERATE_FINAL_PARAMETERS" value="true" />
-            <option name="VISIBILITY" value="private" />
-            <option name="ALIGN_MULTILINE_RECORDS" value="false" />
-            <option name="ALIGN_MULTILINE_DECONSTRUCTION_LIST_COMPONENTS" value="false" />
-            <option name="ALIGN_TYPES_IN_MULTI_CATCH" value="false" />
-        </JavaCodeStyleSettings>
-        <editorconfig>
-            <option name="ENABLED" value="false" />
-        </editorconfig>
-        <codeStyleSettings language="JAVA">
-            <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-            <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-            <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
-            <option name="ALIGN_MULTILINE_FOR" value="false" />
-            <option name="CALL_PARAMETERS_WRAP" value="1" />
-            <option name="METHOD_PARAMETERS_WRAP" value="1" />
-            <option name="RESOURCE_LIST_WRAP" value="1" />
-            <option name="EXTENDS_LIST_WRAP" value="1" />
-            <option name="THROWS_LIST_WRAP" value="1" />
-            <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-            <option name="THROWS_KEYWORD_WRAP" value="1" />
-            <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
-            <option name="BINARY_OPERATION_WRAP" value="1" />
-            <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-            <option name="TERNARY_OPERATION_WRAP" value="1" />
-            <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-            <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
-            <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
-            <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
-            <option name="FOR_STATEMENT_WRAP" value="1" />
-            <option name="IF_BRACE_FORCE" value="3" />
-            <option name="DOWHILE_BRACE_FORCE" value="3" />
-            <option name="WHILE_BRACE_FORCE" value="3" />
-            <option name="FOR_BRACE_FORCE" value="3" />
-            <indentOptions>
-                <option name="CONTINUATION_INDENT_SIZE" value="4" />
-            </indentOptions>
-            <arrangement>
-                <groups>
-                    <group>
-                        <type>GETTERS_AND_SETTERS</type>
-                        <order>KEEP</order>
-                    </group>
-                    <group>
-                        <type>OVERRIDDEN_METHODS</type>
-                        <order>KEEP</order>
-                    </group>
-                </groups>
-            </arrangement>
-        </codeStyleSettings>
-    </code_scheme>
+  <code_scheme name="Project" version="173">
+    <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="false" />
+    <option name="SOFT_MARGINS" value="120" />
+    <JavaCodeStyleSettings>
+      <option name="ALIGN_MULTILINE_RECORDS" value="false" />
+      <option name="ALIGN_MULTILINE_DECONSTRUCTION_LIST_COMPONENTS" value="false" />
+      <option name="ALIGN_TYPES_IN_MULTI_CATCH" value="false" />
+    </JavaCodeStyleSettings>
+    <editorconfig>
+      <option name="ENABLED" value="false" />
+    </editorconfig>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="RESOURCE_LIST_WRAP" value="1" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="THROWS_LIST_WRAP" value="1" />
+      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+      <option name="THROWS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <groups>
+          <group>
+            <type>GETTERS_AND_SETTERS</type>
+            <order>KEEP</order>
+          </group>
+          <group>
+            <type>OVERRIDDEN_METHODS</type>
+            <order>KEEP</order>
+          </group>
+        </groups>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
 </component>

--- a/src/main/java/atwoz/atwoz/notification/command/application/NotificationPreferenceService.java
+++ b/src/main/java/atwoz/atwoz/notification/command/application/NotificationPreferenceService.java
@@ -2,11 +2,16 @@ package atwoz.atwoz.notification.command.application;
 
 import atwoz.atwoz.notification.command.domain.NotificationPreference;
 import atwoz.atwoz.notification.command.domain.NotificationPreferenceCommandRepository;
+import atwoz.atwoz.notification.command.domain.NotificationType;
+import atwoz.atwoz.notification.presentation.NotificationPreferenceSetRequest;
 import atwoz.atwoz.notification.presentation.NotificationPreferenceToggleRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static atwoz.atwoz.notification.command.application.NotificationTypeMapper.toNotificationType;
 
@@ -43,6 +48,19 @@ public class NotificationPreferenceService {
     @Transactional
     public void disableForType(long memberId, NotificationPreferenceToggleRequest request) {
         getNotificationPreference(memberId).disableForNotificationType(toNotificationType(request.type()));
+    }
+
+    @Transactional
+    public void setNotificationPreferences(Long memberId, NotificationPreferenceSetRequest request) {
+        var preference = getNotificationPreference(memberId);
+
+        Map<NotificationType, Boolean> preferences = request.preferences().entrySet().stream()
+            .collect(Collectors.toMap(
+                entry -> toNotificationType(entry.getKey()),
+                Map.Entry::getValue
+            ));
+
+        preference.updateNotificationPreferences(preferences);
     }
 
     private NotificationPreference getNotificationPreference(long memberId) {

--- a/src/main/java/atwoz/atwoz/notification/command/domain/NotificationPreference.java
+++ b/src/main/java/atwoz/atwoz/notification/command/domain/NotificationPreference.java
@@ -32,11 +32,11 @@ public class NotificationPreference extends SoftDeleteBaseEntity {
     @MapKeyEnumerated(STRING)
     @MapKeyColumn(name = "notification_type")
     @Column(name = "enabled")
-    private Map<NotificationType, Boolean> isEnabledByNotificationType = new EnumMap<>(NotificationType.class);
+    private Map<NotificationType, Boolean> preferences = new EnumMap<>(NotificationType.class);
 
-    private NotificationPreference(Long memberId, Map<NotificationType, Boolean> isEnabledByNotificationType) {
+    private NotificationPreference(Long memberId, Map<NotificationType, Boolean> preferences) {
         this.memberId = memberId;
-        this.isEnabledByNotificationType = new EnumMap<>(isEnabledByNotificationType);
+        this.preferences = new EnumMap<>(preferences);
     }
 
     public static NotificationPreference of(long memberId) {
@@ -47,8 +47,12 @@ public class NotificationPreference extends SoftDeleteBaseEntity {
         return new NotificationPreference(memberId, defaults);
     }
 
+    public Map<NotificationType, Boolean> getNotificationPreferences() {
+        return new EnumMap<>(preferences);
+    }
+
     public boolean canReceive(NotificationType type) {
-        return isEnabledGlobally && isEnabledByNotificationType.getOrDefault(type, false);
+        return isEnabledGlobally && preferences.getOrDefault(type, false);
     }
 
     public void enableGlobally() {
@@ -60,14 +64,18 @@ public class NotificationPreference extends SoftDeleteBaseEntity {
     }
 
     public boolean isDisabledForType(NotificationType type) {
-        return !isEnabledByNotificationType.getOrDefault(type, false);
+        return !preferences.getOrDefault(type, false);
     }
 
     public void enableForNotificationType(NotificationType type) {
-        isEnabledByNotificationType.put(type, true);
+        preferences.put(type, true);
     }
 
     public void disableForNotificationType(NotificationType type) {
-        isEnabledByNotificationType.put(type, false);
+        preferences.put(type, false);
+    }
+
+    public void updateNotificationPreferences(Map<NotificationType, Boolean> preferences) {
+        this.preferences.putAll(preferences);
     }
 }

--- a/src/main/java/atwoz/atwoz/notification/presentation/NotificationExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/notification/presentation/NotificationExceptionHandler.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class NotificationExceptionHandler {
 
     @ExceptionHandler(ReceiverNotificationPreferenceNotFoundException.class)
-    public ResponseEntity<BaseResponse<Void>> handleReceiverNotificationSettingNotFoundException(
+    public ResponseEntity<BaseResponse<Void>> handleReceiverNotificationPreferenceNotFoundException(
         ReceiverNotificationPreferenceNotFoundException e) {
         log.warn(e.getMessage());
 

--- a/src/main/java/atwoz/atwoz/notification/presentation/NotificationPreferenceController.java
+++ b/src/main/java/atwoz/atwoz/notification/presentation/NotificationPreferenceController.java
@@ -9,10 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static atwoz.atwoz.common.enums.StatusType.OK;
 
@@ -55,6 +52,16 @@ public class NotificationPreferenceController {
         @Valid @ModelAttribute NotificationPreferenceToggleRequest notificationPreferenceToggleRequest
     ) {
         notificationPreferenceService.disableForType(authContext.getId(), notificationPreferenceToggleRequest);
+        return ResponseEntity.ok(BaseResponse.from(OK));
+    }
+
+    @Operation(summary = "원하는 알림 토글")
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> setNotificationPreference(
+        @AuthPrincipal AuthContext authContext,
+        @Valid @RequestBody NotificationPreferenceSetRequest notificationPreferenceSetRequest
+    ) {
+        notificationPreferenceService.setNotificationPreferences(authContext.getId(), notificationPreferenceSetRequest);
         return ResponseEntity.ok(BaseResponse.from(OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/notification/presentation/NotificationPreferenceExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/notification/presentation/NotificationPreferenceExceptionHandler.java
@@ -2,6 +2,7 @@ package atwoz.atwoz.notification.presentation;
 
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.notification.command.application.InvalidNotificationTypeException;
 import atwoz.atwoz.notification.command.application.NotificationPreferenceNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
@@ -23,5 +24,15 @@ public class NotificationPreferenceExceptionHandler {
 
         return ResponseEntity.status(404)
             .body(BaseResponse.from(StatusType.NOT_FOUND));
+    }
+
+    @ExceptionHandler(InvalidNotificationTypeException.class)
+    public ResponseEntity<BaseResponse<Void>> handleInvalidNotificationTypeException(
+        InvalidNotificationTypeException e
+    ) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(400)
+            .body(BaseResponse.from(StatusType.BAD_REQUEST));
     }
 }

--- a/src/main/java/atwoz/atwoz/notification/presentation/NotificationPreferenceSetRequest.java
+++ b/src/main/java/atwoz/atwoz/notification/presentation/NotificationPreferenceSetRequest.java
@@ -1,0 +1,23 @@
+package atwoz.atwoz.notification.presentation;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
+
+public record NotificationPreferenceSetRequest(
+    @Schema(
+        description = "알림 타입별 설정 (true: 허용, false: 거부)",
+        example = """
+            {
+                "MATCH_REQUEST": true,
+                "MATCH_ACCEPT": true,
+                "LIKE": false,
+                "PROFILE_EXCHANGE_REQUEST": true
+            }
+            """
+    )
+    @NotNull(message = "알림 설정을 입력해주세요.")
+    Map<String, Boolean> preferences
+) {
+}

--- a/src/test/java/atwoz/atwoz/notification/command/domain/NotificationPreferenceTest.java
+++ b/src/test/java/atwoz/atwoz/notification/command/domain/NotificationPreferenceTest.java
@@ -3,8 +3,10 @@ package atwoz.atwoz.notification.command.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static atwoz.atwoz.notification.command.domain.NotificationType.LIKE;
-import static atwoz.atwoz.notification.command.domain.NotificationType.MATCH_REQUEST;
+import java.util.EnumMap;
+import java.util.Map;
+
+import static atwoz.atwoz.notification.command.domain.NotificationType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NotificationPreferenceTest {
@@ -16,87 +18,120 @@ class NotificationPreferenceTest {
         long memberId = 42L;
 
         // when
-        var pref = NotificationPreference.of(memberId);
+        var preference = NotificationPreference.of(memberId);
 
         // then
-        assertThat(pref.getMemberId()).isEqualTo(memberId);
-        assertThat(pref.isEnabledGlobally()).isTrue();
-        assertThat(pref.canReceive(MATCH_REQUEST)).isTrue();
-        assertThat(pref.canReceive(LIKE)).isTrue();
+        assertThat(preference.getMemberId()).isEqualTo(memberId);
+        assertThat(preference.isEnabledGlobally()).isTrue();
+        assertThat(preference.canReceive(MATCH_REQUEST)).isTrue();
+        assertThat(preference.canReceive(LIKE)).isTrue();
     }
 
     @Test
     @DisplayName("disableGlobally(): 글로벌 비활성화 시 모든 타입 수신 불가")
     void disableGloballyDisablesAllTypes() {
         // given
-        var pref = NotificationPreference.of(1L);
+        var preference = NotificationPreference.of(1L);
 
         // when
-        pref.disableGlobally();
+        preference.disableGlobally();
 
         // then
-        assertThat(pref.isEnabledGlobally()).isFalse();
-        assertThat(pref.canReceive(MATCH_REQUEST)).isFalse();
-        assertThat(pref.canReceive(LIKE)).isFalse();
+        assertThat(preference.isEnabledGlobally()).isFalse();
+        assertThat(preference.canReceive(MATCH_REQUEST)).isFalse();
+        assertThat(preference.canReceive(LIKE)).isFalse();
     }
 
     @Test
     @DisplayName("enableGlobally(): 글로벌 활성화 시 원복 확인")
     void enableGloballyRestoresAllTypes() {
         // given
-        var pref = NotificationPreference.of(1L);
-        pref.disableGlobally();
+        var preference = NotificationPreference.of(1L);
+        preference.disableGlobally();
 
         // when
-        pref.enableGlobally();
+        preference.enableGlobally();
 
         // then
-        assertThat(pref.isEnabledGlobally()).isTrue();
-        assertThat(pref.canReceive(MATCH_REQUEST)).isTrue();
-        assertThat(pref.canReceive(LIKE)).isTrue();
+        assertThat(preference.isEnabledGlobally()).isTrue();
+        assertThat(preference.canReceive(MATCH_REQUEST)).isTrue();
+        assertThat(preference.canReceive(LIKE)).isTrue();
     }
 
     @Test
     @DisplayName("disableForNotificationType(): 특정 타입만 비활성화")
     void disableForNotificationTypeAffectsOnlyThatType() {
         // given
-        var pref = NotificationPreference.of(1L);
+        var preference = NotificationPreference.of(1L);
 
         // when
-        pref.disableForNotificationType(MATCH_REQUEST);
+        preference.disableForNotificationType(MATCH_REQUEST);
 
         // then
-        assertThat(pref.canReceive(MATCH_REQUEST)).isFalse();
-        assertThat(pref.canReceive(LIKE)).isTrue();
+        assertThat(preference.canReceive(MATCH_REQUEST)).isFalse();
+        assertThat(preference.canReceive(LIKE)).isTrue();
     }
 
     @Test
     @DisplayName("enableForNotificationType(): 특정 타입만 활성화")
     void enableForNotificationTypeRestoresOnlyThatType() {
         // given
-        var pref = NotificationPreference.of(1L);
-        pref.disableForNotificationType(MATCH_REQUEST);
+        var preference = NotificationPreference.of(1L);
+        preference.disableForNotificationType(MATCH_REQUEST);
 
         // when
-        pref.enableForNotificationType(MATCH_REQUEST);
+        preference.enableForNotificationType(MATCH_REQUEST);
 
         // then
-        assertThat(pref.canReceive(MATCH_REQUEST)).isTrue();
+        assertThat(preference.canReceive(MATCH_REQUEST)).isTrue();
     }
 
     @Test
     @DisplayName("isDisabledForType(): 내부 맵 값 그대로 반환")
     void isDisabledForTypeReflectsInternalMap() {
         // given
-        var pref = NotificationPreference.of(1L);
-        boolean before = pref.isDisabledForType(MATCH_REQUEST);
+        var preference = NotificationPreference.of(1L);
+        boolean before = preference.isDisabledForType(MATCH_REQUEST);
 
         // when
-        pref.disableForNotificationType(MATCH_REQUEST);
-        boolean after = pref.isDisabledForType(MATCH_REQUEST);
+        preference.disableForNotificationType(MATCH_REQUEST);
+        boolean after = preference.isDisabledForType(MATCH_REQUEST);
 
         // then
         assertThat(before).isFalse();
         assertThat(after).isTrue();
+    }
+
+    @Test
+    @DisplayName("getNotificationPreferences(): 반환된 맵은 내부 상태의 복사본이어야 함")
+    void getNotificationPreferencesReturnsCopy() {
+        // given
+        var preference = NotificationPreference.of(1L);
+
+        // when
+        Map<NotificationType, Boolean> returnedPreferences = preference.getNotificationPreferences();
+        returnedPreferences.put(MATCH_REQUEST, false);
+
+        // then
+        assertThat(returnedPreferences.get(MATCH_REQUEST)).isFalse();
+        assertThat(preference.canReceive(MATCH_REQUEST)).isTrue();
+    }
+
+    @Test
+    @DisplayName("updateNotificationPreferences(): 지정된 타입만 업데이트")
+    void updateNotificationPreferencesUpdatesSpecifiedTypes() {
+        // given
+        var preference = NotificationPreference.of(1L);
+        Map<NotificationType, Boolean> updates = new EnumMap<>(NotificationType.class);
+        updates.put(MATCH_REQUEST, false);
+        updates.put(LIKE, false);
+
+        // when
+        preference.updateNotificationPreferences(updates);
+
+        // then
+        assertThat(preference.canReceive(MATCH_REQUEST)).isFalse();
+        assertThat(preference.canReceive(LIKE)).isFalse();
+        assertThat(preference.canReceive(MATCH_ACCEPT)).isTrue();
     }
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 여러 알림 유형에 대한 알림 환경설정을 한 번에 설정할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 알림 환경설정 요청을 위한 새로운 요청 형식이 도입되었습니다.

* **버그 수정**
  * 알림 환경설정이 존재하지 않을 때 예외가 올바르게 발생하도록 테스트가 추가되었습니다.

* **테스트**
  * 알림 환경설정 서비스 및 도메인 로직에 대한 테스트가 추가 및 개선되었습니다.  
  * 환경설정 복사 및 일괄 업데이트 동작에 대한 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- 머지되면 알림 타입 별로 on/off 됐는지 여부 한번에 내려주는 API 구현 예정입니다.
- 멤버 프로필 쪽에 초기에 한번에 정보같은거 내려주는 api가 있는걸로 아는데, 태현님이 보셨을때 거기에 추가하는게 나은지 아니면 따로 만드는게 나을지 의견 부탁드려요!