### PR TITLE
Flyway Config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,13 +56,13 @@ dependencies {
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    
+
     // Redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.45.1'
 
     // flyway
-    runtimeOnly 'org.flywaydb:flyway-core'
-    runtimeOnly 'org.flywaydb:flyway-mysql'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/atwoz/atwoz/common/config/FlywayConfig.java
+++ b/src/main/java/atwoz/atwoz/common/config/FlywayConfig.java
@@ -1,0 +1,34 @@
+package atwoz.atwoz.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import javax.sql.DataSource;
+
+@Slf4j
+@Configuration
+@Profile("!test")
+public class FlywayConfig {
+    @Bean
+    public Flyway flyway(DataSource dataSource) {
+        return Flyway.configure()
+            .baselineOnMigrate(true)
+            .dataSource(dataSource)
+            .load();
+    }
+
+    @Bean
+    public ApplicationRunner migrateFlyway(Flyway flyway) {
+        return args -> {
+            try {
+                flyway.migrate();
+            } catch (Exception e) {
+                log.error("Flyway migration failed", e);
+            }
+        };
+    }
+}

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -22,7 +22,7 @@ spring:
         enabled: true
 
   flyway:
-    enabled: true
+    enabled: false
     locations: classpath:db/migration
     baseline-on-migrate: true
     baseline-version: 0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
       max-request-size: 50MB
 
   flyway:
-    enabled: true
+    enabled: false
     locations: classpath:db/migration
     baseline-on-migrate: true
     baseline-version: 0


### PR DESCRIPTION
@coderabbitai summary

## 노트

flyway가 ddl auto 실행이 완료된 이후에 실행되는 것을 보장하기 위해 ApplicationRunner로 실행되도록 했어요
ApplicationRunner는 ApplicationContext가 생성된 직후 실행되는데요, 그래서 flyway migration 가 실행되기 전에 api health check 가 올 수 있고, 현재 CD 로직에서 이 타이밍에 health check를 하게되면 정상 동작하게 되는 것으로 판단하고 CD를 마치게 됩니다
이후에 flyway migration이 실패하면 application은 멈추게 됩니다.

근데 flyway migration은 배포 이후 기본 데이터 삽입을 도와주는 편의를 위한 도구로 사용 중이기 때문에, 이것의 성공 실패 여부에 따라 application이 영향을 받지 않도록 실패시에 에러 로깅만 남기도록 해서 application에 영향이 없도록 했어요.

추가로 flyway는 테스트 코드에서 필요 없기 때문에 `@Profile("!test")`로 테스트 코드에서 실행되지 않도록 처리했어요