### PR TITLE
DeviceRegistration에 unique 제약조건 제거

### DIFF
--- a/src/main/resources/db/migration/V3__drop_unique_constraint_from_device_registration.sql
+++ b/src/main/resources/db/migration/V3__drop_unique_constraint_from_device_registration.sql
@@ -1,1 +1,0 @@
-ALTER TABLE device_registrations DROP INDEX UK744olwqc6hg3k0m94mnaudjv8;


### PR DESCRIPTION
#288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 디바이스 등록 테이블에서 deviceId에 대한 고유 제약 조건이 제거되었습니다.  
* **Chores**
  * 관련 데이터베이스 마이그레이션 스크립트가 추가되어 기존 고유 인덱스가 삭제됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->