### PR TITLE
소울 메이트 목록 조회 기능 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package atwoz.atwoz.common.exception;
 
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -55,5 +56,29 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.internalServerError()
             .body(BaseResponse.from(StatusType.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleEntityNotFoundException(EntityNotFoundException e) {
+        log.warn("Entity not found exception", e);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(BaseResponse.of(StatusType.NOT_FOUND, e.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<BaseResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("Illegal argument exception", e);
+
+        return ResponseEntity.badRequest()
+            .body(BaseResponse.of(StatusType.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<BaseResponse<Void>> handleIllegalStateException(IllegalStateException e) {
+        log.warn("Illegal state exception", e);
+
+        return ResponseEntity.badRequest()
+            .body(BaseResponse.of(StatusType.BAD_REQUEST, e.getMessage()));
     }
 }

--- a/src/main/java/atwoz/atwoz/datingexam/adapter/database/SoulmateQueryRepositoryImpl.java
+++ b/src/main/java/atwoz/atwoz/datingexam/adapter/database/SoulmateQueryRepositoryImpl.java
@@ -1,0 +1,43 @@
+package atwoz.atwoz.datingexam.adapter.database;
+
+import atwoz.atwoz.datingexam.application.required.SoulmateQueryRepository;
+import atwoz.atwoz.member.command.domain.member.ActivityStatus;
+import atwoz.atwoz.member.command.domain.member.Gender;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static atwoz.atwoz.datingexam.domain.QDatingExamSubmit.datingExamSubmit;
+import static atwoz.atwoz.member.command.domain.member.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class SoulmateQueryRepositoryImpl implements SoulmateQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Set<Long> findSoulmateIds(Long memberId, String requiredSubjectAnswers) {
+        Gender gender = queryFactory
+            .select(member.profile.gender)
+            .from(member)
+            .where(member.id.eq(memberId))
+            .fetchOne();
+
+        return queryFactory
+            .select(datingExamSubmit.memberId)
+            .from(datingExamSubmit)
+            .innerJoin(member).on(member.id.eq(datingExamSubmit.memberId))
+            .where(datingExamSubmit.requiredSubjectAnswers.eq(requiredSubjectAnswers)
+                .and(member.profile.gender.eq(gender.getOpposite()))
+                .and(member.isProfilePublic.isTrue())
+                .and(member.activityStatus.eq(ActivityStatus.ACTIVE))
+            )
+            .where(datingExamSubmit.memberId.ne(memberId))
+            .fetch()
+            .stream()
+            .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/atwoz/atwoz/datingexam/application/SoulmateQueryService.java
+++ b/src/main/java/atwoz/atwoz/datingexam/application/SoulmateQueryService.java
@@ -1,0 +1,43 @@
+package atwoz.atwoz.datingexam.application;
+
+import atwoz.atwoz.datingexam.application.provided.SoulmateFinder;
+import atwoz.atwoz.datingexam.application.required.DatingExamSubmitRepository;
+import atwoz.atwoz.datingexam.application.required.SoulmateQueryRepository;
+import atwoz.atwoz.datingexam.domain.DatingExamSubmit;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Set;
+
+
+@Service
+@Transactional
+@Validated
+@RequiredArgsConstructor
+public class SoulmateQueryService implements SoulmateFinder {
+    private final DatingExamSubmitRepository datingExamSubmitRepository;
+    private final SoulmateQueryRepository soulmateQueryRepository;
+
+    @Override
+    public Set<Long> findSoulmateIds(Long memberId) {
+        DatingExamSubmit datingExamSubmit = getDatingExamSubmit(memberId);
+        validateDatingExamSubmit(datingExamSubmit);
+        Set<Long> soulmateIds = soulmateQueryRepository.findSoulmateIds(memberId,
+            datingExamSubmit.getRequiredSubjectAnswers());
+        return soulmateIds;
+    }
+
+    private DatingExamSubmit getDatingExamSubmit(Long memberId) {
+        return datingExamSubmitRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("연애 모의고사 제출 기록이 없습니다. 회원 ID: " + memberId));
+    }
+
+    private void validateDatingExamSubmit(DatingExamSubmit datingExamSubmit) {
+        if (!datingExamSubmit.isRequiredSubjectSubmitted()) {
+            throw new IllegalStateException("필수 과목을 먼저 제출해야 합니다. datingExamSubmitId: " + datingExamSubmit.getId());
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/datingexam/application/provided/SoulmateFinder.java
+++ b/src/main/java/atwoz/atwoz/datingexam/application/provided/SoulmateFinder.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.datingexam.application.provided;
+
+import java.util.Set;
+
+public interface SoulmateFinder {
+    Set<Long> findSoulmateIds(Long memberId);
+}

--- a/src/main/java/atwoz/atwoz/datingexam/application/required/SoulmateQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/datingexam/application/required/SoulmateQueryRepository.java
@@ -1,0 +1,7 @@
+package atwoz.atwoz.datingexam.application.required;
+
+import java.util.Set;
+
+public interface SoulmateQueryRepository {
+    Set<Long> findSoulmateIds(Long memberId, String requiredSubjectAnswers);
+}

--- a/src/main/java/atwoz/atwoz/datingexam/domain/DatingExamSubmit.java
+++ b/src/main/java/atwoz/atwoz/datingexam/domain/DatingExamSubmit.java
@@ -68,4 +68,8 @@ public class DatingExamSubmit extends BaseEntity {
         }
         this.preferredSubjectAnswers = preferredSubjectAnswers;
     }
+
+    public boolean isRequiredSubjectSubmitted() {
+        return requiredSubjectAnswers != null && !requiredSubjectAnswers.isBlank();
+    }
 }

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionService.java
@@ -43,6 +43,11 @@ public class MemberIntroductionService {
         createIntroduction(memberId, introducedMemberId, IntroductionType.RECENTLY_JOINED);
     }
 
+    @Transactional
+    public void createSoulmateIntroduction(long memberId, long introducedMemberId) {
+        createIntroduction(memberId, introducedMemberId, IntroductionType.SOULMATE);
+    }
+
     private void createIntroduction(long memberId, long introducedMemberId, IntroductionType introductionType) {
         validateIntroduction(memberId, introducedMemberId);
         MemberIntroduction memberIntroduction = MemberIntroduction.of(memberId, introducedMemberId, introductionType);

--- a/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/introduction/MemberIntroductionService.java
@@ -1,5 +1,7 @@
 package atwoz.atwoz.member.command.application.introduction;
 
+import atwoz.atwoz.datingexam.application.required.DatingExamSubmitRepository;
+import atwoz.atwoz.datingexam.domain.DatingExamSubmit;
 import atwoz.atwoz.member.command.application.introduction.exception.IntroducedMemberNotActiveException;
 import atwoz.atwoz.member.command.application.introduction.exception.IntroducedMemberNotFoundException;
 import atwoz.atwoz.member.command.application.introduction.exception.MemberIntroductionAlreadyExistsException;
@@ -8,6 +10,7 @@ import atwoz.atwoz.member.command.domain.introduction.MemberIntroduction;
 import atwoz.atwoz.member.command.domain.introduction.MemberIntroductionCommandRepository;
 import atwoz.atwoz.member.command.domain.member.Member;
 import atwoz.atwoz.member.command.domain.member.MemberCommandRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberIntroductionService {
     private final MemberCommandRepository memberCommandRepository;
     private final MemberIntroductionCommandRepository memberIntroductionCommandRepository;
+    private final DatingExamSubmitRepository datingExamSubmitRepository;
 
     @Transactional
     public void createGradeIntroduction(long memberId, long introducedMemberId) {
@@ -45,7 +49,23 @@ public class MemberIntroductionService {
 
     @Transactional
     public void createSoulmateIntroduction(long memberId, long introducedMemberId) {
+        validateSoulmateIntroduction(memberId, introducedMemberId);
         createIntroduction(memberId, introducedMemberId, IntroductionType.SOULMATE);
+    }
+
+    private void validateSoulmateIntroduction(long memberId, long introducedMemberId) {
+        String memberAnswers = getDatingExamSubmitAnswers(memberId);
+        String introducedMemberAnswers = getDatingExamSubmitAnswers(introducedMemberId);
+        if (!memberAnswers.equals(introducedMemberAnswers)) {
+            throw new IllegalStateException("연애 모의고사 답안이 일치하지 않습니다. " +
+                "회원 ID: " + memberId + ", 소개된 회원 ID: " + introducedMemberId);
+        }
+    }
+
+    private String getDatingExamSubmitAnswers(long memberId) {
+        DatingExamSubmit datingExamSubmit = datingExamSubmitRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("연애 모의고사 제출 기록이 없습니다. 회원 ID: " + memberId));
+        return datingExamSubmit.getRequiredSubjectAnswers();
     }
 
     private void createIntroduction(long memberId, long introducedMemberId, IntroductionType introductionType) {

--- a/src/main/java/atwoz/atwoz/member/command/domain/introduction/IntroductionType.java
+++ b/src/main/java/atwoz/atwoz/member/command/domain/introduction/IntroductionType.java
@@ -8,7 +8,8 @@ public enum IntroductionType {
     SAME_RELIGION("종교가 같아요"),
     SAME_CITY("지역이 같아요"),
     RECENTLY_JOINED("최근 가입한 회원"),
-    TODAY_CARD("오늘의 카드");
+    TODAY_CARD("오늘의 카드"),
+    SOULMATE("소울 메이트");
 
     @Getter
     private final String description;
@@ -18,6 +19,6 @@ public enum IntroductionType {
     }
 
     public boolean isFreeIntroduction() {
-        return this == TODAY_CARD;
+        return this == TODAY_CARD || this == SOULMATE;
     }
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionController.java
@@ -4,6 +4,7 @@ import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.enums.StatusType;
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.datingexam.application.provided.SoulmateFinder;
 import atwoz.atwoz.member.command.application.introduction.MemberIntroductionService;
 import atwoz.atwoz.member.command.application.introduction.TodayCardService;
 import atwoz.atwoz.member.presentation.introduction.dto.MemberIntroductionCreateRequest;
@@ -29,6 +30,7 @@ public class MemberIntroductionController {
     private final TodayCardQueryService todayCardQueryService;
     private final IntroductionQueryService introductionQueryService;
     private final MemberIntroductionService memberintroductionService;
+    private final SoulmateFinder soulmateFinder;
 
     @Operation(summary = "다이아 등급 이성 조회")
     @GetMapping("/grade")
@@ -139,6 +141,27 @@ public class MemberIntroductionController {
         @AuthPrincipal AuthContext authContext) {
         long memberId = authContext.getId();
         memberintroductionService.createRecentIntroduction(memberId, request.introducedMemberId());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @Operation(summary = "소울 메이트 이성 조회")
+    @GetMapping("/soulmate")
+    public ResponseEntity<BaseResponse<List<MemberIntroductionProfileView>>> findSoulmateIntroductions(
+        @AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        Set<Long> soulmateMemberIds = soulmateFinder.findSoulmateIds(memberId);
+        List<MemberIntroductionProfileView> introductionProfileViews = introductionQueryService
+            .findMemberIntroductionProfileViews(memberId, soulmateMemberIds);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, introductionProfileViews));
+    }
+
+    @Operation(summary = "소울 메이트 이성 프로필 블러 해제")
+    @PostMapping("/soulmate")
+    public ResponseEntity<BaseResponse<Void>> createSoulmateIntroduction(
+        @Valid @RequestBody MemberIntroductionCreateRequest request,
+        @AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        memberintroductionService.createSoulmateIntroduction(memberId, request.introducedMemberId());
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/introduction/MemberIntroductionExceptionHandler.java
@@ -5,6 +5,7 @@ import atwoz.atwoz.common.response.BaseResponse;
 import atwoz.atwoz.member.command.application.introduction.exception.IntroducedMemberNotActiveException;
 import atwoz.atwoz.member.command.application.introduction.exception.IntroducedMemberNotFoundException;
 import atwoz.atwoz.member.command.application.introduction.exception.MemberIdealNotFoundException;
+import atwoz.atwoz.member.command.application.introduction.exception.MemberIntroductionAlreadyExistsException;
 import atwoz.atwoz.member.command.domain.introduction.exception.InvalidAgeRangeException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -47,5 +48,14 @@ public class MemberIntroductionExceptionHandler {
 
         return ResponseEntity.badRequest()
             .body(BaseResponse.from(StatusType.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(MemberIntroductionAlreadyExistsException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMemberIntroductionAlreadyExistsException(
+        MemberIntroductionAlreadyExistsException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(400)
+            .body(BaseResponse.of(StatusType.CONFLICT, e.getMessage()));
     }
 }

--- a/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionQueryService.java
+++ b/src/main/java/atwoz/atwoz/member/query/introduction/application/IntroductionQueryService.java
@@ -73,6 +73,16 @@ public class IntroductionQueryService {
             memberIntroductionProfileQueryResults, interviewAnswerQueryResults);
     }
 
+    public List<MemberIntroductionProfileView> findMemberIntroductionProfileViews(long memberId, Set<Long> memberIds) {
+        List<MemberIntroductionProfileQueryResult> memberIntroductionProfileQueryResults =
+            introductionQueryRepository.findAllMemberIntroductionProfileQueryResultByMemberIds(memberId,
+                memberIds);
+        List<InterviewAnswerQueryResult> interviewAnswerQueryResults =
+            introductionQueryRepository.findAllInterviewAnswerInfoByMemberIds(memberIds);
+        return MemberIntroductionProfileViewMapper.mapWithDefaultTag(
+            memberIntroductionProfileQueryResults, interviewAnswerQueryResults);
+    }
+
     private Set<Long> getDiamondGradeIntroductionMemberIds(long memberId) {
         return introductionMemberIdFetcher.fetch(
             memberId,

--- a/src/test/java/atwoz/atwoz/datingexam/adapter/database/SoulmateQueryRepositoryImplTest.java
+++ b/src/test/java/atwoz/atwoz/datingexam/adapter/database/SoulmateQueryRepositoryImplTest.java
@@ -1,0 +1,99 @@
+package atwoz.atwoz.datingexam.adapter.database;
+
+import atwoz.atwoz.QuerydslConfig;
+import atwoz.atwoz.datingexam.domain.DatingExamSubmit;
+import atwoz.atwoz.member.command.domain.member.ActivityStatus;
+import atwoz.atwoz.member.command.domain.member.Gender;
+import atwoz.atwoz.member.command.domain.member.Member;
+import atwoz.atwoz.member.command.domain.member.vo.MemberProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@Import({QuerydslConfig.class, SoulmateQueryRepositoryImpl.class})
+@DataJpaTest
+class SoulmateQueryRepositoryImplTest {
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private SoulmateQueryRepositoryImpl soulmateQueryRepository;
+
+    @Nested
+    @DisplayName("소울 메이트 아이디 목록을 조회할 때,")
+    class FindSoulmateIds {
+
+        private Member createMemberAndSubmit(String phoneNumber, Gender gender, boolean isProfilePublic,
+            ActivityStatus activityStatus, String answer) {
+            Member member = Member.fromPhoneNumber(phoneNumber);
+            MemberProfile profile = MemberProfile.builder()
+                .gender(gender)
+                .build();
+            member.updateProfile(profile);
+            if (isProfilePublic) {
+                member.publishProfile();
+            }
+            member.changeActivityStatus(activityStatus);
+
+            em.persist(member);
+            em.flush();
+
+            DatingExamSubmit datingExamSubmit = DatingExamSubmit.from(member.getId());
+            setField(datingExamSubmit, "requiredSubjectAnswers", answer);
+
+            em.persist(datingExamSubmit);
+            em.flush();
+
+            return member;
+        }
+
+        @Test
+        @DisplayName("연애 모의고사 필수 과목 제출 답안이 일치하고, 성별이 다르며, 프로필이 공개 상태이고, 활동 상태가 ACTIVE인 멤버들의 아이디를 조회한다.")
+        void whenNoDatingExamSubmitThenReturnEmptyList() {
+            // given
+            Gender gender = Gender.MALE;
+            boolean isProfilePublic = true;
+            ActivityStatus activityStatus = ActivityStatus.ACTIVE;
+            String sameAnswer = "sameAnswer";
+
+            // 소울 메이트 아이디 조회 요청한 멤버
+            Member requester = createMemberAndSubmit("01000000000", gender, isProfilePublic, activityStatus,
+                sameAnswer);
+
+            // 소울 메이트로 조회될 멤버
+            Member soulmateMember = createMemberAndSubmit("01000000001", gender.getOpposite(), isProfilePublic,
+                activityStatus, sameAnswer);
+
+            // 필수과목 답안이 달라 소울 메이트가 아닌 멤버
+            Member differentAnswerMember = createMemberAndSubmit("01000000002", gender.getOpposite(), isProfilePublic,
+                activityStatus, "differentAnswer");
+
+            // 같은 성별이라 소울 메이트에서 제외될 멤버
+            Member sameGenderMember = createMemberAndSubmit("01000000003", gender, isProfilePublic, activityStatus,
+                sameAnswer);
+
+            // 프로필 비공개 상태라 소울 메이트에서 제외될 멤버
+            Member profilePublicFalseMember = createMemberAndSubmit("01000000004", gender.getOpposite(), false,
+                activityStatus, sameAnswer);
+
+            // 활동 상태가 ACTIVE가 아니라서 소울 메이트에서 제외될 멤버
+            Member inactiveMember = createMemberAndSubmit("01000000005", gender.getOpposite(), isProfilePublic,
+                ActivityStatus.DORMANT, sameAnswer);
+
+            // when
+            Set<Long> soulmateIds = soulmateQueryRepository.findSoulmateIds(requester.getId(), sameAnswer);
+
+            // then
+            assertThat(soulmateIds).containsOnly(soulmateMember.getId());
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/datingexam/application/SoulmateQueryServiceTest.java
+++ b/src/test/java/atwoz/atwoz/datingexam/application/SoulmateQueryServiceTest.java
@@ -1,0 +1,65 @@
+package atwoz.atwoz.datingexam.application;
+
+import atwoz.atwoz.datingexam.application.required.DatingExamSubmitRepository;
+import atwoz.atwoz.datingexam.application.required.SoulmateQueryRepository;
+import atwoz.atwoz.datingexam.domain.DatingExamSubmit;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SoulmateQueryServiceTest {
+
+    @InjectMocks
+    private SoulmateQueryService soulmateQueryService;
+
+    @Mock
+    private DatingExamSubmitRepository datingExamSubmitRepository;
+
+    @Mock
+    private SoulmateQueryRepository soulmateQueryRepository;
+
+    @Nested
+    @DisplayName("소울 메이트 아이디 목록을 조회할 때,")
+    class FindSoulmateIds {
+
+        @Test
+        @DisplayName("유저의 연애 모의고사 제출 기록이 없다면, EntityNotFoundException을 던진다.")
+        void whenNoDatingExamSubmitThenThrowEntityNotFoundException() {
+            // given
+            Long memberId = 1L;
+            when(datingExamSubmitRepository.findByMemberId(memberId))
+                .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> soulmateQueryService.findSoulmateIds(memberId)
+            ).isInstanceOf(EntityNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("유저의 연애 모의고사 제출 기록이 있지만 필수 과목이 제출되지 않았다면, IllegalStateException을 던진다.")
+        void whenDatingExamSubmitExistsButNotRequiredThenThrowIllegalStateException() {
+            // given
+            Long memberId = 1L;
+            DatingExamSubmit datingExamSubmit = mock(DatingExamSubmit.class);
+            when(datingExamSubmitRepository.findByMemberId(memberId))
+                .thenReturn(Optional.of(datingExamSubmit));
+            when(datingExamSubmit.isRequiredSubjectSubmitted()).thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> soulmateQueryService.findSoulmateIds(memberId)
+            ).isInstanceOf(IllegalStateException.class);
+        }
+    }
+}


### PR DESCRIPTION
@coderabbitai summary

## 노트
- 소울 메이트 프로필 조회 포멧이 소개 받기와 동일하고, 소개 받기와 중복되지 않도록 처리 위해서 소개 타입을 추가하여 처리했습니다.
- 커스텀 예외를 사용했을때, 핸들링이 누락되어 500으로 응답이 가는 경우가 종종 발생하더라고요. 그래서 이번에 예외는 최대한 표준 예외를 사용했어요. 표준 예외를 잘 사용하면 핸들링 누락 방지도 되고 예외 클래스 정의하는 추가 비용이 줄어 좋을 것 같아요. 의견 공유 부탁드릴게요!