### PR TITLE
Http Get에서 "@RequestBody" 사용한 것 "@ModelAttribute" 사용하도록 수정

### DIFF
--- a/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/member/MemberAuthController.java
@@ -93,8 +93,8 @@ public class MemberAuthController {
     }
 
     @Operation(summary = "휴대폰 번호 인증 코드 발송")
-    @GetMapping("/code")
-    public ResponseEntity<BaseResponse<Void>> getCode(@ModelAttribute @Valid MemberCodeRequest request) {
+    @PostMapping("/code")
+    public ResponseEntity<BaseResponse<Void>> getCode(@RequestBody @Valid MemberCodeRequest request) {
         memberAuthService.sendAuthCode(request.phoneNumber());
         return ResponseEntity.ok()
             .body(BaseResponse.from(StatusType.OK));


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 인증 코드 발급 API의 HTTP 메서드를 GET에서 POST로 변경하여 요청 처리 방식을 안정화했습니다. 요청 바디(예: JSON 형식의 phoneNumber)를 사용해 인증 코드를 발급합니다.
  - 영향: 클라이언트는 이제 쿼리스트링/폼이 아닌 JSON 본문으로 phoneNumber를 전송하도록 변경해야 합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- Http Get에서 "@RequestBody" 사용한 것 "@ModelAttribute" 사용하도록 수정