### PR TITLE
알림 타입 변경에 따른 DB 데이터 꼬임 문제 해결

### DIFF
--- a/src/main/java/atwoz/atwoz/admin/command/domain/warning/Warning.java
+++ b/src/main/java/atwoz/atwoz/admin/command/domain/warning/Warning.java
@@ -1,5 +1,6 @@
 package atwoz.atwoz.admin.command.domain.warning;
 
+import atwoz.atwoz.common.entity.BaseEntity;
 import atwoz.atwoz.common.event.Events;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -18,7 +19,7 @@ import static jakarta.persistence.EnumType.STRING;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Warning {
+public class Warning extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/atwoz/atwoz/notification/command/domain/NotificationPreference.java
+++ b/src/main/java/atwoz/atwoz/notification/command/domain/NotificationPreference.java
@@ -28,7 +28,7 @@ public class NotificationPreference extends SoftDeleteBaseEntity {
     private boolean isEnabledGlobally = true;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "notification_types", joinColumns = @JoinColumn(name = "member_id"))
+    @CollectionTable(name = "member_notification_preferences", joinColumns = @JoinColumn(name = "member_id"))
     @MapKeyEnumerated(STRING)
     @MapKeyColumn(name = "notification_type")
     @Column(name = "is_enabled")


### PR DESCRIPTION
## 노트
- 알림 타입 변경에 따른 DB 데이터 꼬임 문제가 발생했습니다. (다른건 바꿨는데 알림 설정 쪽이 안바뀌어 이전 설정이 로드돼 매핑이 안됨)
- DB 데이터 자체를 바꿔야해서 코드는 따로 없는데, 테이블 이름을 좀 더 명확하게 수정했습니다.