### PR TITLE
차단 생성 API 구현

### DIFF
--- a/src/main/java/atwoz/atwoz/block/adapter/listener/BlockEventHandler.java
+++ b/src/main/java/atwoz/atwoz/block/adapter/listener/BlockEventHandler.java
@@ -23,6 +23,9 @@ public class BlockEventHandler {
         Long blockedId = event.getReporteeId();
         try {
             blockCommander.createBlock(blockerId, blockedId);
+        } catch (IllegalStateException | IllegalArgumentException exception) {
+            log.info("신고 이벤트로 인한 차단 처리 중 오류가 발생했습니다. blockerId: {}, blockedId: {}, message: {}", blockerId,
+                blockedId, exception.getMessage());
         } catch (Exception exception) {
             log.warn("신고 이벤트로 인한 차단 처리 중 오류가 발생했습니다. blockerId: {}, blockedId: {}", blockerId, blockedId, exception);
         }

--- a/src/main/java/atwoz/atwoz/block/adapter/listener/BlockEventHandler.java
+++ b/src/main/java/atwoz/atwoz/block/adapter/listener/BlockEventHandler.java
@@ -1,0 +1,30 @@
+package atwoz.atwoz.block.adapter.listener;
+
+import atwoz.atwoz.block.application.provided.BlockCommander;
+import atwoz.atwoz.report.command.domain.event.ReportCreatedEvent;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
+public class BlockEventHandler {
+    private final BlockCommander blockCommander;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ReportCreatedEvent event) {
+        Long blockerId = event.getReporterId();
+        Long blockedId = event.getReporteeId();
+        try {
+            blockCommander.createBlock(blockerId, blockedId);
+        } catch (Exception exception) {
+            log.warn("신고 이벤트로 인한 차단 처리 중 오류가 발생했습니다. blockerId: {}, blockedId: {}", blockerId, blockedId, exception);
+        }
+    }
+}

--- a/src/main/java/atwoz/atwoz/block/adapter/webapi/BlockApi.java
+++ b/src/main/java/atwoz/atwoz/block/adapter/webapi/BlockApi.java
@@ -1,0 +1,35 @@
+package atwoz.atwoz.block.adapter.webapi;
+
+import atwoz.atwoz.auth.presentation.AuthContext;
+import atwoz.atwoz.auth.presentation.AuthPrincipal;
+import atwoz.atwoz.block.adapter.webapi.dto.BlockCreateRequest;
+import atwoz.atwoz.block.application.provided.BlockCommander;
+import atwoz.atwoz.common.enums.StatusType;
+import atwoz.atwoz.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "차단 API")
+@RestController
+@RequestMapping("/blocks")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlockApi {
+    private final BlockCommander blockCommander;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> createBlock(
+        @RequestBody @Valid BlockCreateRequest request,
+        @AuthPrincipal AuthContext authContext
+    ) {
+        Long blockerId = authContext.getId();
+        blockCommander.createBlock(blockerId, request.blockedId());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+}

--- a/src/main/java/atwoz/atwoz/block/adapter/webapi/dto/BlockCreateRequest.java
+++ b/src/main/java/atwoz/atwoz/block/adapter/webapi/dto/BlockCreateRequest.java
@@ -1,0 +1,9 @@
+package atwoz.atwoz.block.adapter.webapi.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record BlockCreateRequest(
+    @NotNull
+    Long blockedId
+) {
+}

--- a/src/main/java/atwoz/atwoz/block/application/BlockModifyService.java
+++ b/src/main/java/atwoz/atwoz/block/application/BlockModifyService.java
@@ -1,0 +1,25 @@
+package atwoz.atwoz.block.application;
+
+import atwoz.atwoz.block.application.provided.BlockCommander;
+import atwoz.atwoz.block.application.required.BlockRepository;
+import atwoz.atwoz.block.domain.Block;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlockModifyService implements BlockCommander {
+    private final BlockRepository blockRepository;
+
+    @Override
+    @Transactional
+    public void createBlock(Long blockerId, Long blockedId) {
+        if (blockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)) {
+            throw new IllegalStateException("이미 차단된 멤버입니다.");
+        }
+        Block block = Block.of(blockerId, blockedId);
+        blockRepository.save(block);
+    }
+}

--- a/src/main/java/atwoz/atwoz/block/application/provided/BlockCommander.java
+++ b/src/main/java/atwoz/atwoz/block/application/provided/BlockCommander.java
@@ -1,0 +1,5 @@
+package atwoz.atwoz.block.application.provided;
+
+public interface BlockCommander {
+    void createBlock(Long blockerId, Long blockedId);
+}

--- a/src/main/java/atwoz/atwoz/block/application/required/BlockRepository.java
+++ b/src/main/java/atwoz/atwoz/block/application/required/BlockRepository.java
@@ -1,0 +1,10 @@
+package atwoz.atwoz.block.application.required;
+
+import atwoz.atwoz.block.domain.Block;
+import org.springframework.data.repository.Repository;
+
+public interface BlockRepository extends Repository<Block, Long> {
+    Block save(Block block);
+
+    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+}

--- a/src/main/java/atwoz/atwoz/block/domain/Block.java
+++ b/src/main/java/atwoz/atwoz/block/domain/Block.java
@@ -1,0 +1,38 @@
+package atwoz.atwoz.block.domain;
+
+import atwoz.atwoz.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@Table(
+    name = "blocks",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "unique_blocker_id_blocked_id", columnNames = {"blockerId", "blockedId"})
+    }
+)
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class Block extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long blockerId;
+
+    private Long blockedId;
+
+    private Block(@NonNull Long blockerId, @NonNull Long blockedId) {
+        if (blockerId.equals(blockedId)) {
+            throw new IllegalArgumentException("blockerId와 blockedId는 같을 수 없습니다.");
+        }
+        this.blockerId = blockerId;
+        this.blockedId = blockedId;
+    }
+
+    public static Block of(Long blockerId, Long blockedId) {
+        return new Block(blockerId, blockedId);
+    }
+}

--- a/src/main/java/atwoz/atwoz/block/domain/Block.java
+++ b/src/main/java/atwoz/atwoz/block/domain/Block.java
@@ -20,8 +20,10 @@ public class Block extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private Long blockerId;
 
+    @Column(nullable = false)
     private Long blockedId;
 
     private Block(@NonNull Long blockerId, @NonNull Long blockedId) {

--- a/src/test/java/atwoz/atwoz/block/application/BlockModifyServiceTest.java
+++ b/src/test/java/atwoz/atwoz/block/application/BlockModifyServiceTest.java
@@ -1,0 +1,72 @@
+package atwoz.atwoz.block.application;
+
+import atwoz.atwoz.block.application.required.BlockRepository;
+import atwoz.atwoz.block.domain.Block;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BlockModifyServiceTest {
+
+    @InjectMocks
+    private BlockModifyService blockModifyService;
+
+    @Mock
+    private BlockRepository blockRepository;
+
+    @Nested
+    @DisplayName("차단을 생성할 때")
+    class CreateBlockTest {
+        @Test
+        @DisplayName("이미 차단된 멤버면 IllegalStateException 예외를 던진다.")
+        void throwsIllegalStateExceptionWhenBlockAlreadyExists() {
+            // given
+            Long blockerId = 1L;
+            Long blockedId = 2L;
+
+            when(blockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)).thenReturn(true);
+
+            // when
+            IllegalStateException result = assertThrows(IllegalStateException.class, () -> {
+                blockModifyService.createBlock(blockerId, blockedId);
+            });
+
+            // then
+            assertThat(result).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("이미 차단된 멤버가 아니면 차단을 생성하고 저장한다.")
+        void createsBlockWhenNotAlreadyBlocked() {
+            // given
+            Long blockerId = 1L;
+            Long blockedId = 2L;
+
+            when(blockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)).thenReturn(false);
+
+            try (MockedStatic<Block> blockMockedStatic = mockStatic(Block.class)) {
+                Block mockBlock = mock(Block.class);
+                blockMockedStatic.when(() -> Block.of(blockerId, blockedId)).thenReturn(mockBlock);
+
+                when(blockRepository.save(mockBlock)).thenReturn(mockBlock);
+
+                // when
+                blockModifyService.createBlock(blockerId, blockedId);
+
+                // then
+                blockMockedStatic.verify(() -> Block.of(blockerId, blockedId), times(1));
+                verify(blockRepository, times(1)).save(mockBlock);
+            }
+        }
+    }
+}

--- a/src/test/java/atwoz/atwoz/block/domain/BlockTest.java
+++ b/src/test/java/atwoz/atwoz/block/domain/BlockTest.java
@@ -1,0 +1,64 @@
+package atwoz.atwoz.block.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BlockTest {
+
+    @Nested
+    @DisplayName("차단을 생성할 때")
+    class CreateBlockTest {
+
+        @Test
+        @DisplayName("차단하는 id와 차단당하는 id가 같으면 IllegalArgumentException 예외를 던진다.")
+        void throwsIllegalArgumentExceptionWhenBlockerIdEqualsBlockedId() {
+            // given
+            Long blockerId = 1L;
+            Long blockedId = blockerId;
+
+            // when
+            IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () -> {
+                Block.of(blockerId, blockedId);
+            });
+
+            // then
+            assertThat(result).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("차단하는 id가 null이면 NullPointerException 예외를 던진다.")
+        void throwsNullPointerExceptionWhenBlockerIdIsNull() {
+            // given
+            Long blockerId = null;
+            Long blockedId = 1L;
+
+            // when
+            NullPointerException result = assertThrows(NullPointerException.class, () -> {
+                Block.of(blockerId, blockedId);
+            });
+
+            // then
+            assertThat(result).isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("차단당하는 id가 null이면 NullPointerException 예외를 던진다.")
+        void throwsNullPointerExceptionWhenBlockedIdIsNull() {
+            // given
+            Long blockerId = 1L;
+            Long blockedId = null;
+
+            // when
+            NullPointerException result = assertThrows(NullPointerException.class, () -> {
+                Block.of(blockerId, blockedId);
+            });
+
+            // then
+            assertThat(result).isInstanceOf(NullPointerException.class);
+        }
+    }
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 사용자 차단 기능을 추가했습니다. 인증된 사용자가 대상 회원을 차단할 수 있습니다.
  * POST /blocks 엔드포인트를 통해 차단을 생성할 수 있습니다(대상 회원 ID 필요, 입력 검증 포함).
  * 중복 차단을 방지하는 검증과 트랜잭션 처리로 안전한 차단 생성이 보장됩니다.
  * 신고 완료 후 대상 자동 차단 처리가 비동기 방식으로 동작합니다.

* 테스트
  * 차단 도메인의 생성 규칙(유효성, 동일 대상 차단 금지)과 서비스 로직에 대한 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
- 차단 생성 API 구현 및 신고 생성 이벤트 발행 시 차단 생성 핸들링 구현