### PR TITLE
알림 관련 요청사항 반영

### DIFF
--- a/src/main/java/atwoz/atwoz/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/atwoz/atwoz/common/exception/GlobalExceptionHandler.java
@@ -72,16 +72,6 @@ public class GlobalExceptionHandler {
             .body(BaseResponse.from(StatusType.CONFLICT));
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<BaseResponse<Void>> handleGlobalException(Exception exception, HttpServletRequest request) {
-        String requestInfo = "Request URI: " + request.getRequestURI() + ", Method: " + request.getMethod();
-        log.error("Unexpected error occurred. RequestInfo: {}, ExceptionMessage: {}", requestInfo,
-            exception.getMessage(), exception);
-
-        return ResponseEntity.internalServerError()
-            .body(BaseResponse.from(StatusType.INTERNAL_SERVER_ERROR));
-    }
-
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<BaseResponse<Void>> handleEntityNotFoundException(EntityNotFoundException e) {
         log.warn("Entity not found exception", e);
@@ -118,6 +108,16 @@ public class GlobalExceptionHandler {
 
         log.error("Data access exception", e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(BaseResponse.from(StatusType.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse<Void>> handleGlobalException(Exception exception, HttpServletRequest request) {
+        String requestInfo = "Request URI: " + request.getRequestURI() + ", Method: " + request.getMethod();
+        log.error("Unexpected error occurred. RequestInfo: {}, ExceptionMessage: {}", requestInfo,
+            exception.getMessage(), exception);
+
+        return ResponseEntity.internalServerError()
             .body(BaseResponse.from(StatusType.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/atwoz/atwoz/notification/command/application/DeviceRegistrationService.java
+++ b/src/main/java/atwoz/atwoz/notification/command/application/DeviceRegistrationService.java
@@ -13,14 +13,31 @@ public class DeviceRegistrationService {
 
     private final DeviceRegistrationCommandRepository deviceRegistrationCommandRepository;
 
+    /**
+     * 디바이스를 등록하거나 토큰을 갱신합니다.
+     * 단일 기기만 지원하므로, 새로운 기기 등록 시 기존 모든 기기를 삭제합니다.
+     *
+     * @param memberId 회원 ID
+     * @param request  디바이스 등록 요청 (deviceId: 기기 고유 식별자, registrationToken: FCM 토큰)
+     */
     @Transactional
     public void register(long memberId, DeviceRegisterRequest request) {
         deviceRegistrationCommandRepository.findByMemberIdAndDeviceId(memberId, request.deviceId())
             .ifPresentOrElse(
-                deviceRegistration -> deviceRegistration.refreshRegistrationToken(request.registrationToken()),
-                () -> {
-                    var registration = DeviceRegistration.of(memberId, request.deviceId(), request.registrationToken());
-                    deviceRegistrationCommandRepository.save(registration);
-                });
+                // 기존 디바이스가 있으면 FCM 토큰만 갱신
+                device -> device.refreshRegistrationToken(request.registrationToken()),
+                // 새로운 디바이스면 기존 모든 디바이스 삭제 후 등록
+                () -> registerNewDevice(memberId, request)
+            );
+    }
+
+    /**
+     * 새로운 디바이스를 등록합니다.
+     * 기존 모든 디바이스를 삭제한 후 새 디바이스를 등록하여 단일 기기만 유지합니다.
+     */
+    private void registerNewDevice(long memberId, DeviceRegisterRequest request) {
+        deviceRegistrationCommandRepository.deleteByMemberId(memberId);
+        var registration = DeviceRegistration.of(memberId, request.deviceId(), request.registrationToken());
+        deviceRegistrationCommandRepository.save(registration);
     }
 }

--- a/src/main/java/atwoz/atwoz/notification/command/application/NotificationReadRequest.java
+++ b/src/main/java/atwoz/atwoz/notification/command/application/NotificationReadRequest.java
@@ -1,0 +1,10 @@
+package atwoz.atwoz.notification.command.application;
+
+import lombok.NonNull;
+
+import java.util.List;
+
+public record NotificationReadRequest(
+    @NonNull List<Long> notificationIds
+) {
+}

--- a/src/main/java/atwoz/atwoz/notification/command/application/NotificationReadRequest.java
+++ b/src/main/java/atwoz/atwoz/notification/command/application/NotificationReadRequest.java
@@ -1,10 +1,10 @@
 package atwoz.atwoz.notification.command.application;
 
-import lombok.NonNull;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public record NotificationReadRequest(
-    @NonNull List<Long> notificationIds
+    @NotEmpty List<Long> notificationIds
 ) {
 }

--- a/src/main/java/atwoz/atwoz/notification/command/application/NotificationReadService.java
+++ b/src/main/java/atwoz/atwoz/notification/command/application/NotificationReadService.java
@@ -14,14 +14,7 @@ public class NotificationReadService {
 
     @Transactional
     public void markAsRead(NotificationReadRequest request) {
-        request.notificationIds().forEach(notificationId -> {
-            Notification notification = getNotification(notificationId);
-            notification.markAsRead();
-        });
-    }
-
-    private Notification getNotification(long notificationId) {
-        return notificationCommandRepository.findById(notificationId)
-            .orElseThrow(() -> new NotificationNotFoundException(notificationId));
+        notificationCommandRepository.findAllById(request.notificationIds())
+            .forEach(Notification::markAsRead);
     }
 }

--- a/src/main/java/atwoz/atwoz/notification/command/application/NotificationReadService.java
+++ b/src/main/java/atwoz/atwoz/notification/command/application/NotificationReadService.java
@@ -13,9 +13,11 @@ public class NotificationReadService {
     private final NotificationCommandRepository notificationCommandRepository;
 
     @Transactional
-    public void markAsRead(long notificationId) {
-        Notification notification = getNotification(notificationId);
-        notification.markAsRead();
+    public void markAsRead(NotificationReadRequest request) {
+        request.notificationIds().forEach(notificationId -> {
+            Notification notification = getNotification(notificationId);
+            notification.markAsRead();
+        });
     }
 
     private Notification getNotification(long notificationId) {

--- a/src/main/java/atwoz/atwoz/notification/command/domain/DeviceRegistration.java
+++ b/src/main/java/atwoz/atwoz/notification/command/domain/DeviceRegistration.java
@@ -21,8 +21,10 @@ public class DeviceRegistration {
 
     private Long memberId;
 
+    /** 기기 고유 식별자 (Android Device ID, iOS IDFV 등) */
     private String deviceId;
 
+    /** FCM(Firebase Cloud Messaging) 등록 토큰 */
     private String registrationToken;
 
     private boolean isActive = true;

--- a/src/main/java/atwoz/atwoz/notification/command/domain/DeviceRegistration.java
+++ b/src/main/java/atwoz/atwoz/notification/command/domain/DeviceRegistration.java
@@ -9,7 +9,6 @@ import lombok.NonNull;
 @Entity
 @Table(
     name = "device_registrations",
-    indexes = @Index(name = "idx_member_id_active", columnList = "memberId, isActive"),
     uniqueConstraints = @UniqueConstraint(name = "uk_member_id", columnNames = "memberId")
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,10 +21,14 @@ public class DeviceRegistration {
 
     private Long memberId;
 
-    /** 기기 고유 식별자 (Android Device ID, iOS IDFV 등) */
+    /**
+     * 기기 고유 식별자
+     */
     private String deviceId;
 
-    /** FCM(Firebase Cloud Messaging) 등록 토큰 */
+    /**
+     * FCM(Firebase Cloud Messaging) 등록 토큰
+     */
     private String registrationToken;
 
     private boolean isActive = true;

--- a/src/main/java/atwoz/atwoz/notification/command/domain/DeviceRegistration.java
+++ b/src/main/java/atwoz/atwoz/notification/command/domain/DeviceRegistration.java
@@ -9,7 +9,8 @@ import lombok.NonNull;
 @Entity
 @Table(
     name = "device_registrations",
-    indexes = @Index(name = "idx_member_id_active", columnList = "memberId, isActive")
+    indexes = @Index(name = "idx_member_id_active", columnList = "memberId, isActive"),
+    uniqueConstraints = @UniqueConstraint(name = "uk_member_id", columnNames = "memberId")
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/atwoz/atwoz/notification/command/domain/DeviceRegistrationCommandRepository.java
+++ b/src/main/java/atwoz/atwoz/notification/command/domain/DeviceRegistrationCommandRepository.java
@@ -9,4 +9,6 @@ public interface DeviceRegistrationCommandRepository extends JpaRepository<Devic
     Optional<DeviceRegistration> findByMemberIdAndDeviceId(long memberId, String deviceId);
 
     Optional<DeviceRegistration> findByMemberIdAndIsActiveTrue(long memberId);
+
+    void deleteByMemberId(long memberId);
 }

--- a/src/main/java/atwoz/atwoz/notification/presentation/NotificationController.java
+++ b/src/main/java/atwoz/atwoz/notification/presentation/NotificationController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -33,7 +34,7 @@ public class NotificationController {
 
     @Operation(summary = "알림 읽기")
     @PatchMapping
-    public ResponseEntity<BaseResponse<Void>> markAsRead(@RequestBody NotificationReadRequest request) {
+    public ResponseEntity<BaseResponse<Void>> markAsRead(@Validated @RequestBody NotificationReadRequest request) {
         notificationReadService.markAsRead(request);
         return ResponseEntity.ok(BaseResponse.from(OK));
     }

--- a/src/main/java/atwoz/atwoz/notification/presentation/NotificationController.java
+++ b/src/main/java/atwoz/atwoz/notification/presentation/NotificationController.java
@@ -3,6 +3,7 @@ package atwoz.atwoz.notification.presentation;
 import atwoz.atwoz.auth.presentation.AuthContext;
 import atwoz.atwoz.auth.presentation.AuthPrincipal;
 import atwoz.atwoz.common.response.BaseResponse;
+import atwoz.atwoz.notification.command.application.NotificationReadRequest;
 import atwoz.atwoz.notification.command.application.NotificationReadService;
 import atwoz.atwoz.notification.command.application.NotificationSendRequest;
 import atwoz.atwoz.notification.command.application.NotificationSendService;
@@ -31,9 +32,9 @@ public class NotificationController {
     private final NotificationSendService notificationSendService;
 
     @Operation(summary = "알림 읽기")
-    @PatchMapping("/{notificationId}")
-    public ResponseEntity<BaseResponse<Void>> markAsRead(@PathVariable long notificationId) {
-        notificationReadService.markAsRead(notificationId);
+    @PatchMapping
+    public ResponseEntity<BaseResponse<Void>> markAsRead(@RequestBody NotificationReadRequest request) {
+        notificationReadService.markAsRead(request);
         return ResponseEntity.ok(BaseResponse.from(OK));
     }
 

--- a/src/main/java/atwoz/atwoz/notification/query/NotificationQueryRepository.java
+++ b/src/main/java/atwoz/atwoz/notification/query/NotificationQueryRepository.java
@@ -22,7 +22,8 @@ public class NotificationQueryRepository {
                 notification.receiverId,
                 notification.type.stringValue(),
                 notification.title,
-                notification.body
+                notification.body,
+                notification.createdAt
             ))
             .from(notification)
             .where(

--- a/src/main/java/atwoz/atwoz/notification/query/NotificationView.java
+++ b/src/main/java/atwoz/atwoz/notification/query/NotificationView.java
@@ -4,6 +4,8 @@ import atwoz.atwoz.notification.command.domain.NotificationType;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
+
 public record NotificationView(
     long notificationId,
     long senderId,
@@ -11,7 +13,8 @@ public record NotificationView(
     @Schema(implementation = NotificationType.class)
     String notificationType,
     String title,
-    String body
+    String body,
+    LocalDateTime createdAt
 ) {
     @QueryProjection
     public NotificationView {

--- a/src/test/java/atwoz/atwoz/notification/command/application/DeviceRegistrationServiceTest.java
+++ b/src/test/java/atwoz/atwoz/notification/command/application/DeviceRegistrationServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -26,8 +27,8 @@ class DeviceRegistrationServiceTest {
     DeviceRegistrationService service;
 
     @Test
-    @DisplayName("신규 디바이스 등록 시 저장 호출")
-    void registerSavesNewRegistration() {
+    @DisplayName("신규 디바이스 등록 시 기존 디바이스 삭제 후 저장")
+    void registerDeletesExistingDevicesAndSavesNewRegistration() {
         // given
         long memberId = 1L;
         var request = new DeviceRegisterRequest("device-123", "token-abc");
@@ -38,6 +39,7 @@ class DeviceRegistrationServiceTest {
         service.register(memberId, request);
 
         // then
+        verify(repository).deleteByMemberId(memberId);
         verify(repository).save(argThat(reg ->
             reg.getRegistrationToken().equals(request.registrationToken()) && reg.isActive()
         ));
@@ -58,6 +60,7 @@ class DeviceRegistrationServiceTest {
 
         // then
         verify(existing).refreshRegistrationToken(request.registrationToken());
+        verify(repository, never()).deleteByMemberId(anyLong());
         verify(repository, never()).save(any());
         assertThat(existing.getRegistrationToken()).isEqualTo(request.registrationToken());
         assertThat(existing.isActive()).isTrue();

--- a/src/test/java/atwoz/atwoz/notification/command/application/NotificationReadServiceTest.java
+++ b/src/test/java/atwoz/atwoz/notification/command/application/NotificationReadServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static atwoz.atwoz.notification.command.domain.NotificationType.LIKE;
@@ -33,9 +34,10 @@ class NotificationReadServiceTest {
         long notificationId = 1L;
         var notification = Notification.create(SYSTEM, 10L, 20L, LIKE, "t", "b");
         when(repository.findById(notificationId)).thenReturn(Optional.of(notification));
+        var request = new NotificationReadRequest(List.of(notificationId));
 
         // when
-        service.markAsRead(notificationId);
+        service.markAsRead(request);
 
         // then
         assertThat(notification.isRead()).isTrue();
@@ -47,9 +49,30 @@ class NotificationReadServiceTest {
         // given
         long notificationId = 2L;
         when(repository.findById(notificationId)).thenReturn(Optional.empty());
+        var request = new NotificationReadRequest(List.of(notificationId));
 
         // when && then
-        assertThatThrownBy(() -> service.markAsRead(notificationId))
+        assertThatThrownBy(() -> service.markAsRead(request))
             .isInstanceOf(NotificationNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("markAsRead(): 여러 알림의 읽음 상태가 모두 true로 변경")
+    void markAsReadUpdatesMultipleNotifications() {
+        // given
+        long notificationId1 = 1L;
+        long notificationId2 = 2L;
+        var notification1 = Notification.create(SYSTEM, 10L, 20L, LIKE, "t1", "b1");
+        var notification2 = Notification.create(SYSTEM, 10L, 20L, LIKE, "t2", "b2");
+        when(repository.findById(notificationId1)).thenReturn(Optional.of(notification1));
+        when(repository.findById(notificationId2)).thenReturn(Optional.of(notification2));
+        var request = new NotificationReadRequest(List.of(notificationId1, notificationId2));
+
+        // when
+        service.markAsRead(request);
+
+        // then
+        assertThat(notification1.isRead()).isTrue();
+        assertThat(notification2.isRead()).isTrue();
     }
 }

--- a/src/test/java/atwoz/atwoz/notification/command/application/NotificationReadServiceTest.java
+++ b/src/test/java/atwoz/atwoz/notification/command/application/NotificationReadServiceTest.java
@@ -10,12 +10,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Optional;
 
 import static atwoz.atwoz.notification.command.domain.NotificationType.LIKE;
 import static atwoz.atwoz.notification.command.domain.SenderType.SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,7 +31,7 @@ class NotificationReadServiceTest {
         // given
         long notificationId = 1L;
         var notification = Notification.create(SYSTEM, 10L, 20L, LIKE, "t", "b");
-        when(repository.findById(notificationId)).thenReturn(Optional.of(notification));
+        when(repository.findAllById(List.of(notificationId))).thenReturn(List.of(notification));
         var request = new NotificationReadRequest(List.of(notificationId));
 
         // when
@@ -43,18 +41,6 @@ class NotificationReadServiceTest {
         assertThat(notification.isRead()).isTrue();
     }
 
-    @Test
-    @DisplayName("markAsRead(): 알림이 없으면 NotificationNotFoundException 발생")
-    void markAsReadThrowsWhenNotFound() {
-        // given
-        long notificationId = 2L;
-        when(repository.findById(notificationId)).thenReturn(Optional.empty());
-        var request = new NotificationReadRequest(List.of(notificationId));
-
-        // when && then
-        assertThatThrownBy(() -> service.markAsRead(request))
-            .isInstanceOf(NotificationNotFoundException.class);
-    }
 
     @Test
     @DisplayName("markAsRead(): 여러 알림의 읽음 상태가 모두 true로 변경")
@@ -64,8 +50,8 @@ class NotificationReadServiceTest {
         long notificationId2 = 2L;
         var notification1 = Notification.create(SYSTEM, 10L, 20L, LIKE, "t1", "b1");
         var notification2 = Notification.create(SYSTEM, 10L, 20L, LIKE, "t2", "b2");
-        when(repository.findById(notificationId1)).thenReturn(Optional.of(notification1));
-        when(repository.findById(notificationId2)).thenReturn(Optional.of(notification2));
+        when(repository.findAllById(List.of(notificationId1, notificationId2))).thenReturn(
+            List.of(notification1, notification2));
         var request = new NotificationReadRequest(List.of(notificationId1, notificationId2));
 
         // when


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 알림 읽음 처리 API가 요청 본문으로 알림 ID 목록을 받아 여러 알림을 한 번에 읽음 처리합니다.
  * 알림 조회 응답에 생성일시(createdAt)가 추가되어 정렬·표시에 활용할 수 있습니다.
  * 기기 등록에 단일 기기 정책을 적용하여 새 기기 등록 시 기존 기기 연결이 해제됩니다.

* 테스트
  * 알림 다건 읽음 처리와 단일 기기 정책 시나리오에 대한 테스트를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- 프론트에서 요청해주신 부분에 대한 반영본입니다.