### PR TITLE
미션 데이터 삽입 스크립트 수정

### DIFF
--- a/src/main/resources/db/migration/V2__instert_default_missions.sql
+++ b/src/main/resources/db/migration/V2__instert_default_missions.sql
@@ -1,5 +1,6 @@
-INSERT INTO missions (created_at, updated_at, action_type, frequency_type, target_gender ,required_attempt, repeatable_count, rewarded_heart, is_public)
-VALUES (NOW(6), NOW(6), 'LIKE', 'DAILY', 'MALE', 1, 2, 2 ,1),
-       (NOW(6), NOW(6), 'LIKE', 'DAILY', 'MALE', 1, 3, 2 ,1),
-       (NOW(6), NOW(6), 'INTERVIEW', 'CHALLENGE', 'ALL', 3, 1, 10 ,1),
-       (NOW(6), NOW(6), 'FIRST_DATE_EXAM', 'CHALLENGE', 'ALL', 1, 1, 10 ,1)
+INSERT INTO missions (created_at, updated_at, action_type, frequency_type, target_gender, required_attempt,
+                      repeatable_count, rewarded_heart, is_public)
+VALUES (NOW(6), NOW(6), 'LIKE', 'DAILY', 'MALE', 1, 2, 2, 1),
+       (NOW(6), NOW(6), 'LIKE', 'DAILY', 'FEMALE', 1, 3, 2, 1),
+       (NOW(6), NOW(6), 'INTERVIEW', 'CHALLENGE', 'ALL', 1, 1, 30, 1),
+       (NOW(6), NOW(6), 'FIRST_DATE_EXAM', 'CHALLENGE', 'ALL', 1, 1, 15, 1)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 기본 미션이 성별별로 구성되어 여성 사용자에게도 동일한 미션이 노출됩니다.
- Chores
  - 기본 미션 데이터 갱신: 일부 미션의 보상 상향 조정(예: 인터뷰 30, 첫 데이트 점검 15).
  - 미션별 시도 횟수·보상 수치 정렬 및 초기 데이터 형식 개선으로 일관성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
- flyway로 미션 데이터 삽입하는 스크립트에 잘못된 내용이 있어 수정했어요
- 좋아요 미션은 male만 두개 있고 female이 없고
- 인터뷰 미션은 최대 1회 30 보상 하트인데, 최대 3회 회당 10 보상 하트
- 모의고사 미션은 보상 하트가 15인데 10으로 되어있었네요
