### PR TITLE
fix : 프로필 교환 응답 시, 자신에게 알림이 오는 문제

### DIFF
--- a/src/main/java/atwoz/atwoz/notification/infra/NotificationEventHandler.java
+++ b/src/main/java/atwoz/atwoz/notification/infra/NotificationEventHandler.java
@@ -92,8 +92,8 @@ public class NotificationEventHandler {
     public void handleProfileExchangeAcceptedEvent(ProfileExchangeAcceptedEvent event) {
         NotificationSendRequest request = new NotificationSendRequest(
             SenderType.MEMBER,
-            event.getRequesterId(),
             event.getResponderId(),
+            event.getRequesterId(),
             NotificationType.PROFILE_EXCHANGE_ACCEPT,
             Map.of(SENDER_NAME, event.getSenderName()),
             ChannelType.PUSH
@@ -106,8 +106,8 @@ public class NotificationEventHandler {
     public void handleProfileExchangeRejectedEvent(ProfileExchangeRejectedEvent event) {
         NotificationSendRequest request = new NotificationSendRequest(
             SenderType.MEMBER,
-            event.getRequesterId(),
             event.getResponderId(),
+            event.getRequesterId(),
             NotificationType.PROFILE_EXCHANGE_REJECT,
             Map.of(SENDER_NAME, event.getSenderName()),
             ChannelType.PUSH


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 프로필 교환 수락/거절 이벤트에서 알림 대상 식별자가 뒤바뀌던 문제를 수정하여, 요청자와 응답자에게 정확한 알림이 발송됩니다.
  * 잘못된 사용자에게 도착하거나 발신자/수신자 표시가 어긋나던 현상을 해소했습니다.
  * 알림 내용의 정확성이 향상되어 사용자 혼란이 줄어듭니다.
  * 다른 유형의 알림 동작에는 변화가 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
