### PR TITLE
도커 이미지 eclipse-temurin:21-jdk-jammy 사용하도록 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 빌드를 위한 베이스 이미지
-FROM openjdk:21-slim as build
+FROM eclipse-temurin:21-jdk-jammy as build
 
 # 작업 디렉토리 설정
 WORKDIR /workspace/app
@@ -22,7 +22,7 @@ COPY src src
 RUN ./gradlew build -x test --no-daemon
 
 # 런타임을 위한 새로운 베이스 이미지
-FROM openjdk:21-slim
+FROM eclipse-temurin:21-jre-jammy
 
 VOLUME /tmp
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 기본 이미지 업데이트: 더 최신의 스테이블 버전으로 변경되었습니다. 애플리케이션의 기능에는 변화가 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
- 도커 이미지 eclipse-temurin:21-jdk-jammy 사용하도록 변경