### PR TITLE
프로필 이미지 저장하지 않는 버그 수정

### DIFF
--- a/src/main/java/atwoz/atwoz/member/command/application/profileImage/ProfileImageService.java
+++ b/src/main/java/atwoz/atwoz/member/command/application/profileImage/ProfileImageService.java
@@ -52,7 +52,7 @@ public class ProfileImageService {
             ProfileImage profileImage = ProfileImage
                 .builder()
                 .memberId(memberId)
-                .imageUrl(ImageUrl.from(request.getImageUrl()))
+                .imageUrl(ImageUrl.from(request.imageUrl()))
                 .order(order)
                 .isPrimary(order == 1)
                 .build();

--- a/src/main/java/atwoz/atwoz/member/presentation/profileimage/ProfileImageController.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/profileimage/ProfileImageController.java
@@ -32,9 +32,11 @@ public class ProfileImageController {
     @Operation(summary = "프로필 이미지 업로드")
     @PostMapping
     public ResponseEntity<BaseResponse<List<ProfileImageUploadResponse>>> updateProfileImage(
-        @ModelAttribute @Valid ProfileImageUploadRequestWrapper request, @AuthPrincipal AuthContext authContext) {
-        return ResponseEntity.ok(
-            BaseResponse.of(StatusType.OK, profileImageService.save(authContext.getId(), request.getRequests())));
+        @RequestBody @Valid ProfileImageUploadRequestWrapper request,
+        @AuthPrincipal AuthContext authContext
+    ) {
+        List<ProfileImageUploadResponse> result = profileImageService.save(authContext.getId(), request.requests());
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, result));
     }
 
     @Operation(summary = "프로필 이미지 업로드용 preSignedUrl 생성")

--- a/src/main/java/atwoz/atwoz/member/presentation/profileimage/dto/ProfileImageUploadRequest.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/profileimage/dto/ProfileImageUploadRequest.java
@@ -1,16 +1,9 @@
 package atwoz.atwoz.member.presentation.profileimage.dto;
 
 import jakarta.validation.constraints.NotEmpty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class ProfileImageUploadRequest {
+public record ProfileImageUploadRequest(
     @NotEmpty(message = "이미지 URL을 입력해주세요")
-    String imageUrl;
+    String imageUrl
+) {
 }

--- a/src/main/java/atwoz/atwoz/member/presentation/profileimage/dto/ProfileImageUploadRequestWrapper.java
+++ b/src/main/java/atwoz/atwoz/member/presentation/profileimage/dto/ProfileImageUploadRequestWrapper.java
@@ -1,13 +1,11 @@
 package atwoz.atwoz.member.presentation.profileimage.dto;
 
 import jakarta.validation.Valid;
-import lombok.Getter;
 
-import java.util.ArrayList;
 import java.util.List;
 
-@Getter
-public class ProfileImageUploadRequestWrapper {
+public record ProfileImageUploadRequestWrapper(
     @Valid
-    private final List<ProfileImageUploadRequest> requests = new ArrayList<>();
+    List<ProfileImageUploadRequest> requests
+) {
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 프로필 이미지 업로드 기능의 내부 구조를 개선했습니다.
  * API 요청 처리 방식을 현대화하여 안정성을 높였습니다.
  * 코드 유지보수성 향상을 위한 기술적 개선사항을 적용했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
- request dto를 기존과 다른 방식으로 구현 및 사용해서 request body에 이미지를 넣어도 request dto에 들어가지 않는 문제
- request dto를 기존과 동일한 방식인 record, `@RequestBody` 를 사용하도록 수정