### PR TITLE
셀프 소개글 수정 권한 오류 수정

### DIFF
--- a/src/main/java/atwoz/atwoz/community/command/application/selfintroduction/SelfIntroductionService.java
+++ b/src/main/java/atwoz/atwoz/community/command/application/selfintroduction/SelfIntroductionService.java
@@ -51,7 +51,7 @@ public class SelfIntroductionService {
     }
 
     private void validateSelfIntroductionAuthor(Long memberIdFromSelfIntroduction, Long memberId) {
-        if (memberIdFromSelfIntroduction != memberId) {
+        if (!memberIdFromSelfIntroduction.equals(memberId)) {
             throw new NotSelfIntroductionAuthorException();
         }
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 자기소개 작성자 검증이 정확하게 작동하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
- Long 타입의 값 비교를 == 연산자를 사용하여 수행하고 있더라고요
- Long 타입의 값 비교 equals로 하도록 수정했습니다.
- Long 타입에서 값 비교에 ==을 사용하면 동일한 인스턴스 인지 확인하는 거라 equals 사용해야합니다
- 다만 -128 ~ 127 사이의 Long은 캐싱된 객체를 사용하기 때문에 기존에 문제 없이 동작하는 것 처럼 보였나봐요
- 다른 로직에서도 Long 값 비교를 == 사용중인 것이 있는지 확인해봤는데 다른 로직에서 이슈가 없어서 해당 로직만 수정했습니다.