### PR TITLE
metric export 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ dependencies {
 
     // Monitoring
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.hibernate.orm:hibernate-micrometer'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,6 +11,7 @@ spring:
     show-sql: ${JPA_SHOW_SQL:true}
     properties:
       hibernate:
+        generate_statistics: true
         format_sql: ${JPA_FORMAT_SQL:true}
         jdbc:
           timezone: Asia/Seoul
@@ -94,20 +95,3 @@ bizgo:
 
 scheduler:
   cron: "0 0 0 * * *"
-
-management:
-  server:
-    port: 8081
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
-      base-path: /actuator
-  endpoint:
-    health:
-      show-details: never
-    prometheus:
-      enabled: true
-  metrics:
-    tags:
-      application: ${APP_NAME:depple-spring-server-dev}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,6 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: ${JPA_FORMAT_SQL:true}
+        generate_statistics: true
         jdbc:
           timezone: Asia/Seoul
   
@@ -90,20 +91,3 @@ bizgo:
 
 scheduler:
   cron: "0 0 0 * * *"
-
-management:
-  server:
-    port: 8081
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
-      base-path: /actuator
-  endpoint:
-    health:
-      show-details: never
-    prometheus:
-      enabled: true
-  metrics:
-    tags:
-      application: ${APP_NAME:depple-spring-server-local}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,6 +11,7 @@ spring:
     show-sql: ${JPA_SHOW_SQL:false}
     properties:
       hibernate:
+        generate_statistics: true
         format_sql: ${JPA_FORMAT_SQL:false}
         jdbc:
           timezone: Asia/Seoul
@@ -98,16 +99,3 @@ scheduler:
 management:
   server:
     port: 8081
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
-      base-path: /actuator
-  endpoint:
-    health:
-      show-details: never
-    prometheus:
-      enabled: true
-  metrics:
-    tags:
-      application: ${APP_NAME:depple-spring-server-prod}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,42 @@ spring:
     multipart:
       max-file-size: 50MB
       max-request-size: 50MB
+
+management:
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+    tags:
+      application:
+        ${APP_NAME:deepple-api-service}-${SPRING_PROFILES_ACTIVE:local}
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      group:
+        liveness:
+          show-components: always
+          include:
+            - livenessState
+        readiness:
+          show-components: always
+    prometheus:
+      access: read_only
+  health:
+    livenessState:
+      enabled: true
+    readinessState:
+      enabled: true
+  observations:
+    annotations:
+      enabled: true
+    key-values:
+      application:
+        ${APP_NAME:deepple-api-service}-${SPRING_PROFILES_ACTIVE:local}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Prometheus 통합 및 메트릭 수집 활성화(애플리케이션 및 Hibernate 메트릭 포함)
  * HTTP 요청 히스토그램(퍼센타일) 등 Actuator 관측 설정 추가
  * 애플리케이션 메트릭에 이름 태그(APP_NAME, 프로파일) 자동 추가로 추적성 향상
  * 헬스 체크(liveness/readiness) 및 Prometheus 엔드포인트 활성화
  * 독립 관리 서버 포트로 8081 설정
  * Hibernate 통계 수집(generate_statistics) 활성화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트
- 모니터링을 위한 metric export 설정
- 헬스체크도 8081로 변경