### PR TITLE
member introduction 테이블에 member_id, introduced_member_id 복합 인덱스 추가

### DIFF
--- a/src/main/java/deepple/deepple/member/command/domain/introduction/MemberIntroduction.java
+++ b/src/main/java/deepple/deepple/member/command/domain/introduction/MemberIntroduction.java
@@ -11,7 +11,11 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 @Entity
-@Table(name = "member_introductions")
+@Table(name = "member_introductions",
+    indexes = {
+        @Index(name = "idx_member_introductions_member_introduced", columnList = "memberId, introducedMemberId"),
+    }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class MemberIntroduction extends BaseEntity {

--- a/src/main/resources/db/migration/V5__add_indexes_to_member_introductions.sql
+++ b/src/main/resources/db/migration/V5__add_indexes_to_member_introductions.sql
@@ -1,0 +1,4 @@
+-- memberId, introducedMemberId 복합 조회 성능 향상을 위한 복합 인덱스
+-- memberId 단독 조회에도 사용 가능
+CREATE INDEX idx_member_introductions_member_introduced
+    ON member_introductions (member_id, introduced_member_id);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 회원 소개 기능의 데이터베이스 조회 성능을 개선하기 위해 복합 인덱스를 추가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 노트
- [성능 테스트](https://github.com/deepple-dev/deepple-api/issues/394#issuecomment-3713361560) 기반으로 member introduction 테이블에 member_id, introduced_member_id 복합 인덱스 추가