### PR TITLE
Notification 서비스에 성능 테스트용 sendWithoutPush 기능 추가

### DIFF
--- a/src/main/java/deepple/deepple/notification/command/application/NotificationSendService.java
+++ b/src/main/java/deepple/deepple/notification/command/application/NotificationSendService.java
@@ -134,4 +134,30 @@ public class NotificationSendService {
             status
         );
     }
+
+    public void sendWithoutPush(NotificationSendRequest request) {
+        var notification = createNotificationWithTemplate(request);
+        if (notification == null) {
+            return;
+        }
+
+        if (!canSendByPreference(notification)) {
+            return;
+        }
+
+        var device = findReceiversActiveDevice(notification);
+        if (device == null) {
+            return;
+        }
+
+        // FCM 전송 시간 시뮬레이션
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        notification.markAsSent();
+        writer.save(notification);
+    }
 }

--- a/src/main/java/deepple/deepple/notification/presentation/NotificationController.java
+++ b/src/main/java/deepple/deepple/notification/presentation/NotificationController.java
@@ -89,7 +89,7 @@ public class NotificationController {
             Map.of("senderName", "테스트", "rejectionReason", "테스트 사유"),
             ChannelType.PUSH
         );
-        notificationSendService.send(request);
+        notificationSendService.sendWithoutPush(request);
         return ResponseEntity.ok(BaseResponse.from(OK));
     }
 }


### PR DESCRIPTION
- sendWithoutPush 메서드 도입으로 FCM을 사용하지 않는 알림 전송 지원
- NotificationController에서 sendWithoutPush 호출로 로직 수정

#394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 푸시 알림을 제외하고 알림을 전송하는 새로운 기능이 추가되었습니다. 이를 통해 특정 상황에서 더 세밀한 알림 제어가 가능합니다.
  * 테스트 알림 전송 엔드포인트의 동작이 업데이트되어 푸시 없이 알림을 전송하도록 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트