### PR TITLE
Fix/random

### DIFF
--- a/src/main/java/deepple/deepple/member/command/application/member/MemberProfileService.java
+++ b/src/main/java/deepple/deepple/member/command/application/member/MemberProfileService.java
@@ -4,15 +4,16 @@ package deepple.deepple.member.command.application.member;
 import deepple.deepple.member.command.application.member.exception.MemberNotFoundException;
 import deepple.deepple.member.command.application.member.exception.PermanentlySuspendedMemberException;
 import deepple.deepple.member.command.application.member.exception.ContactTypeSettingNeededException;
-import deepple.deepple.member.command.domain.member.ActivityStatus;
-import deepple.deepple.member.command.domain.member.Member;
-import deepple.deepple.member.command.domain.member.MemberCommandRepository;
-import deepple.deepple.member.command.domain.member.PrimaryContactType;
+import deepple.deepple.member.command.domain.member.*;
+import deepple.deepple.member.command.domain.member.vo.Region;
 import deepple.deepple.member.presentation.member.MemberMapper;
 import deepple.deepple.member.presentation.member.dto.MemberProfileUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 @RequiredArgsConstructor
@@ -102,6 +103,20 @@ public class MemberProfileService {
     public void markDatingExamSubmitted(Long memberId) {
         Member member = getMemberById(memberId);
         member.markDatingExamSubmitted();
+    }
+
+    @Transactional
+    public void t() {
+        List<Member> members = memberCommandRepository.findAll();
+
+        District[] districts = District.values();
+        int size = districts.length;
+
+        for (Member member : members) {
+            District district =
+                districts[ThreadLocalRandom.current().nextInt(size)];
+            member.getProfile().setRegion(Region.of(district));
+        }
     }
 
     private void publish(Member member) {

--- a/src/main/java/deepple/deepple/member/command/application/member/sms/AuthMessageService.java
+++ b/src/main/java/deepple/deepple/member/command/application/member/sms/AuthMessageService.java
@@ -30,7 +30,7 @@ public class AuthMessageService {
     }
 
     private String getMessage(String code) {
-        return "[에이투지] 인증번호 [" + code + "]를 입력해주세요.";
+        return "[Deepple] 인증번호 [" + code + "]를 입력해주세요.";
     }
 
     private String generateNumber() {

--- a/src/main/java/deepple/deepple/member/command/domain/member/District.java
+++ b/src/main/java/deepple/deepple/member/command/domain/member/District.java
@@ -113,7 +113,7 @@ public enum District {
     PYEONGCHANG_GUN(City.GANGWON, "평창군"),
     HONGCHEON_GUN(City.GANGWON, "홍천군"),
     HWACHEON_GUN(City.GANGWON, "화천군"),
-    HWANGSEONG_GUN(City.GANGWON, "횡성군"),
+    HOENGSEONG_GUN(City.GANGWON, "횡성군"),
 
     // 경기도
     GAPYEONG_GUN(City.GYEONGGI, "가평군"),
@@ -197,7 +197,7 @@ public enum District {
     GYERYONG_SI(City.CHUNGCHEONGNAM, "계룡시"),
     GONGJU_SI(City.CHUNGCHEONGNAM, "공주시"),
     GEUMSAN_GUN(City.CHUNGCHEONGNAM, "금산군"),
-    NONGSAN_SI(City.CHUNGCHEONGNAM, "논산시"),
+    NONSAN_SI(City.CHUNGCHEONGNAM, "논산시"),
     DANGJIN_SI(City.CHUNGCHEONGNAM, "당진시"),
     BORYEONG_SI(City.CHUNGCHEONGNAM, "보령시"),
     BUYEO_GUN(City.CHUNGCHEONGNAM, "부여군"),
@@ -227,7 +227,7 @@ public enum District {
     GOHEUNG_GUN(City.JEOLLANAM, "고흥군"),
     GOKSEONG_GUN(City.JEOLLANAM, "곡성군"),
     GWANGYANG_SI(City.JEOLLANAM, "광양시"),
-    GURAE_GUN(City.JEOLLANAM, "구례군"),
+    GURYE_GUN(City.JEOLLANAM, "구례군"),
     NAJU_SI(City.JEOLLANAM, "나주시"),
     DAMYANG_GUN(City.JEOLLANAM, "담양군"),
     MOKPO_SI(City.JEOLLANAM, "목포시"),

--- a/src/main/java/deepple/deepple/member/command/domain/member/MemberCommandRepository.java
+++ b/src/main/java/deepple/deepple/member/command/domain/member/MemberCommandRepository.java
@@ -24,4 +24,6 @@ public interface MemberCommandRepository {
     List<Member> saveAll(List<Member> members);
 
     void deleteBefore(LocalDateTime dateTime);
+
+    List<Member> findAll();
 }

--- a/src/main/java/deepple/deepple/member/command/domain/member/vo/MemberProfile.java
+++ b/src/main/java/deepple/deepple/member/command/domain/member/vo/MemberProfile.java
@@ -2,10 +2,7 @@ package deepple.deepple.member.command.domain.member.vo;
 
 import deepple.deepple.member.command.domain.member.*;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -42,6 +39,7 @@ public class MemberProfile {
     private Mbti mbti;
 
     @Embedded
+    @Setter
     private Region region;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryImpl.java
+++ b/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryImpl.java
@@ -65,6 +65,6 @@ public class MemberCommandRepositoryImpl implements MemberCommandRepository {
 
     @Override
     public List<Member> findAll() {
-        memberCommandJpaRepository.findAll();
+        return memberCommandJpaRepository.findAll();
     }
 }

--- a/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryImpl.java
+++ b/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryImpl.java
@@ -62,4 +62,9 @@ public class MemberCommandRepositoryImpl implements MemberCommandRepository {
     public void deleteBefore(final LocalDateTime dateTime) {
         memberCommandJpaRepository.deleteAllBefore(dateTime);
     }
+
+    @Override
+    public List<Member> findAll() {
+        memberCommandJpaRepository.findAll();
+    }
 }

--- a/src/main/java/deepple/deepple/member/presentation/member/MemberController.java
+++ b/src/main/java/deepple/deepple/member/presentation/member/MemberController.java
@@ -8,6 +8,7 @@ import deepple.deepple.common.response.BaseResponse;
 import deepple.deepple.member.command.application.member.MemberAuthService;
 import deepple.deepple.member.command.application.member.MemberContactService;
 import deepple.deepple.member.command.application.member.MemberProfileService;
+import deepple.deepple.member.command.domain.member.Member;
 import deepple.deepple.member.presentation.member.dto.MemberChangeToActiveRequest;
 import deepple.deepple.member.presentation.member.dto.MemberMyProfileResponse;
 import deepple.deepple.member.presentation.member.dto.MemberProfileResponse;
@@ -24,6 +25,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "회원 정보 조회 및 변경 API")
 @RestController
@@ -125,5 +128,10 @@ public class MemberController {
             .path(refreshTokenCookieProperties.path())
             .maxAge(0)
             .build();
+    }
+
+    @GetMapping("/random")
+    public void suffle() {
+        memberProfileService.t();
     }
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **신기능**
  * SMS 인증 발신자명이 "Deepple"로 변경되었습니다.
  * 관리자용 회원 지역 일괄 할당을 트리거하는 새 API 엔드포인트가 추가되었습니다.
  * 전체 회원 조회 기능이 추가되어 일괄 처리 흐름이 가능해졌습니다.

* **버그 수정**
  * 지역명 표기 오류(횡성군, 논산시, 구례군)가 올바르게 수정되었습니다.

* **기타**
  * 회원 프로필의 지역 필드에 대해 업데이트(설정) 가능성이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트