### PR TITLE
feat(member): 추가 프로필 이미지 조회 기능 추가

### DIFF
--- a/src/main/java/deepple/deepple/member/presentation/member/MemberMapper.java
+++ b/src/main/java/deepple/deepple/member/presentation/member/MemberMapper.java
@@ -6,18 +6,17 @@ import deepple.deepple.member.command.domain.member.*;
 import deepple.deepple.member.command.domain.member.vo.MemberProfile;
 import deepple.deepple.member.command.domain.member.vo.Nickname;
 import deepple.deepple.member.command.domain.member.vo.Region;
-import deepple.deepple.member.presentation.member.dto.ContactInfo;
-import deepple.deepple.member.presentation.member.dto.MemberInfo;
-import deepple.deepple.member.presentation.member.dto.MemberMyProfileResponse;
-import deepple.deepple.member.presentation.member.dto.MemberProfileUpdateRequest;
+import deepple.deepple.member.presentation.member.dto.*;
 import deepple.deepple.member.query.member.AgeConverter;
 import deepple.deepple.member.query.member.view.BasicMemberInfo;
 import deepple.deepple.member.query.member.view.ContactView;
 import deepple.deepple.member.query.member.view.MatchInfo;
 import deepple.deepple.member.query.member.view.MemberProfileView;
+import deepple.deepple.member.query.profileimage.view.ProfileImageView;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -43,13 +42,17 @@ public class MemberMapper {
             .build();
     }
 
-    public static MemberInfo toBasicInfo(BasicMemberInfo basicMemberInfo) {
+    public static MemberInfo toBasicInfo(BasicMemberInfo basicMemberInfo, List<ProfileImageView> profileImages) {
+        List<ProfileImageInfo> additionalProfileImages = profileImages.stream()
+            .filter(profileImage -> !profileImage.isPrimary())
+            .map(profileImage -> new ProfileImageInfo(profileImage.url(), profileImage.order()))
+            .toList();
         return new MemberInfo(basicMemberInfo.id(), basicMemberInfo.nickname(), basicMemberInfo.profileImageUrl(),
             AgeConverter.toAge(basicMemberInfo.yearOfBirth()), basicMemberInfo.gender(), basicMemberInfo.height(),
             basicMemberInfo.job(), basicMemberInfo.hobbies(), basicMemberInfo.mbti(), basicMemberInfo.city(),
             basicMemberInfo.district(),
             basicMemberInfo.smokingStatus(), basicMemberInfo.drinkingStatus(), basicMemberInfo.highestEducation(),
-            basicMemberInfo.religion(), basicMemberInfo.like());
+            basicMemberInfo.religion(), basicMemberInfo.like(), additionalProfileImages);
     }
 
     public static MemberMyProfileResponse toMemberMyProfileResponse(MemberProfileView view) {

--- a/src/main/java/deepple/deepple/member/presentation/member/dto/MemberInfo.java
+++ b/src/main/java/deepple/deepple/member/presentation/member/dto/MemberInfo.java
@@ -4,6 +4,7 @@ import deepple.deepple.like.command.domain.LikeLevel;
 import deepple.deepple.member.command.domain.member.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
 import java.util.Set;
 
 public record MemberInfo(
@@ -33,6 +34,8 @@ public record MemberInfo(
     @Schema(implementation = Religion.class)
     String religion,
     @Schema(implementation = LikeLevel.class)
-    String likeLevel
+    String likeLevel,
+    @Schema(description = "메인 이미지를 제외한 추가 프로필 이미지 목록 (order 오름차순)")
+    List<ProfileImageInfo> additionalProfileImages
 ) {
 }

--- a/src/main/java/deepple/deepple/member/presentation/member/dto/ProfileImageInfo.java
+++ b/src/main/java/deepple/deepple/member/presentation/member/dto/ProfileImageInfo.java
@@ -1,0 +1,13 @@
+package deepple.deepple.member.presentation.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "추가 프로필 이미지 (메인 이미지 제외)")
+public record ProfileImageInfo(
+    @Schema(description = "이미지 URL", example = "https://cdn.deepple.co.kr/profile/2.jpg")
+    String url,
+
+    @Schema(description = "이미지 정렬 순서", example = "1")
+    int order
+) {
+}

--- a/src/main/java/deepple/deepple/member/query/member/application/MemberQueryService.java
+++ b/src/main/java/deepple/deepple/member/query/member/application/MemberQueryService.java
@@ -10,6 +10,8 @@ import deepple.deepple.member.query.member.application.event.MemberProfileRetrie
 import deepple.deepple.member.query.member.application.exception.ProfileAccessDeniedException;
 import deepple.deepple.member.query.member.infra.MemberQueryRepository;
 import deepple.deepple.member.query.member.view.*;
+import deepple.deepple.member.query.profileimage.ProfileImageQueryRepository;
+import deepple.deepple.member.query.profileimage.view.ProfileImageView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class MemberQueryService {
     private final MemberQueryRepository memberQueryRepository;
+    private final ProfileImageQueryRepository profileImageQueryRepository;
 
 
     public MemberInfoView getInfoCache(Long memberId) {
@@ -49,10 +52,12 @@ public class MemberQueryService {
 
         List<InterviewResultView> interviewResultViews = memberQueryRepository.findInterviewsByMemberId(otherMemberId);
 
+        List<ProfileImageView> profileImages = profileImageQueryRepository.findByMemberId(otherMemberId);
+
         Events.raise(MemberProfileRetrievedEvent.of(memberId, otherMemberId,
             profileAccessView.matchRequesterId(), profileAccessView.matchResponderId()));
 
-        return new MemberProfileResponse(MemberMapper.toBasicInfo(profileView.basicMemberInfo()),
+        return new MemberProfileResponse(MemberMapper.toBasicInfo(profileView.basicMemberInfo(), profileImages),
             profileView.matchInfo(),
             MemberMapper.toContactInfo(profileView.contactView(), profileView.matchInfo(), otherMemberId),
             profileView.profileExchangeInfo(),

--- a/src/test/java/deepple/deepple/member/query/member/application/MemberQueryServiceTest.java
+++ b/src/test/java/deepple/deepple/member/query/member/application/MemberQueryServiceTest.java
@@ -4,10 +4,14 @@ import deepple.deepple.common.event.Events;
 import deepple.deepple.community.command.domain.profileexchange.ProfileExchangeStatus;
 import deepple.deepple.member.command.application.member.exception.MemberNotFoundException;
 import deepple.deepple.member.command.domain.member.ActivityStatus;
+import deepple.deepple.member.presentation.member.dto.MemberProfileResponse;
+import deepple.deepple.member.presentation.member.dto.ProfileImageInfo;
 import deepple.deepple.member.query.member.application.event.MemberProfileRetrievedEvent;
 import deepple.deepple.member.query.member.application.exception.ProfileAccessDeniedException;
 import deepple.deepple.member.query.member.infra.MemberQueryRepository;
 import deepple.deepple.member.query.member.view.*;
+import deepple.deepple.member.query.profileimage.ProfileImageQueryRepository;
+import deepple.deepple.member.query.profileimage.view.ProfileImageView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,9 +24,12 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -30,6 +37,9 @@ import static org.mockito.Mockito.*;
 class MemberQueryServiceTest {
     @Mock
     private MemberQueryRepository memberQueryRepository;
+
+    @Mock
+    private ProfileImageQueryRepository profileImageQueryRepository;
 
     @InjectMocks
     private MemberQueryService memberQueryService;
@@ -199,6 +209,70 @@ class MemberQueryServiceTest {
                 // Then
                 mockEvents.verify(() -> Events.raise(memberProfileRetrievedEvent));
             }
+        }
+
+        @DisplayName("상대방 프로필 조회 시 메인 이미지를 제외한 추가 이미지를 순서대로 반환한다.")
+        @Test
+        void returnsAdditionalProfileImagesExcludingPrimary() {
+            // Given
+            ProfileAccessView profileAccessView = new ProfileAccessView(true, null, null, null, null, null, false,
+                false,
+                ActivityStatus.ACTIVE.name());
+            OtherMemberProfileView view = new OtherMemberProfileView(mock(BasicMemberInfo.class), mock(MatchInfo.class),
+                mock(ContactView.class), mock(ProfileExchangeInfo.class), mock(IntroductionInfo.class));
+            when(memberQueryRepository.findProfileAccessViewByMemberId(memberId, otherMemberId)).thenReturn(
+                Optional.of(profileAccessView));
+            when(memberQueryRepository.findOtherProfileByMemberId(memberId, otherMemberId)).thenReturn(
+                Optional.of(view));
+            when(profileImageQueryRepository.findByMemberId(otherMemberId)).thenReturn(List.of(
+                new ProfileImageView(1L, "https://image/main.jpg", true, 0),
+                new ProfileImageView(2L, "https://image/sub1.jpg", false, 1),
+                new ProfileImageView(3L, "https://image/sub2.jpg", false, 2)
+            ));
+
+            // When
+            MemberProfileResponse response;
+            try (MockedStatic<Events> mockEvents = mockStatic(Events.class);
+                MockedStatic<MemberProfileRetrievedEvent> mockMemberProfileRetrievedEvent = mockStatic(
+                    MemberProfileRetrievedEvent.class)) {
+                response = memberQueryService.getMemberProfile(memberId, otherMemberId);
+            }
+
+            // Then
+            assertThat(response.memberInfo().additionalProfileImages())
+                .extracting(ProfileImageInfo::url, ProfileImageInfo::order)
+                .containsExactly(
+                    tuple("https://image/sub1.jpg", 1),
+                    tuple("https://image/sub2.jpg", 2));
+        }
+
+        @DisplayName("메인 이미지만 존재하는 경우, 추가 이미지 목록은 비어 있다.")
+        @Test
+        void returnsEmptyAdditionalProfileImagesWhenOnlyPrimaryExists() {
+            // Given
+            ProfileAccessView profileAccessView = new ProfileAccessView(true, null, null, null, null, null, false,
+                false,
+                ActivityStatus.ACTIVE.name());
+            OtherMemberProfileView view = new OtherMemberProfileView(mock(BasicMemberInfo.class), mock(MatchInfo.class),
+                mock(ContactView.class), mock(ProfileExchangeInfo.class), mock(IntroductionInfo.class));
+            when(memberQueryRepository.findProfileAccessViewByMemberId(memberId, otherMemberId)).thenReturn(
+                Optional.of(profileAccessView));
+            when(memberQueryRepository.findOtherProfileByMemberId(memberId, otherMemberId)).thenReturn(
+                Optional.of(view));
+            when(profileImageQueryRepository.findByMemberId(otherMemberId)).thenReturn(List.of(
+                new ProfileImageView(1L, "https://image/main.jpg", true, 0)
+            ));
+
+            // When
+            MemberProfileResponse response;
+            try (MockedStatic<Events> mockEvents = mockStatic(Events.class);
+                MockedStatic<MemberProfileRetrievedEvent> mockMemberProfileRetrievedEvent = mockStatic(
+                    MemberProfileRetrievedEvent.class)) {
+                response = memberQueryService.getMemberProfile(memberId, otherMemberId);
+            }
+
+            // Then
+            assertThat(response.memberInfo().additionalProfileImages()).isEmpty();
         }
     }
 }


### PR DESCRIPTION
- 추가 프로필 이미지 목록 필드 도입
- 메인 이미지 제외한 추가 이미지 필터링 및 매핑 로직 구현
- 관련 유닛 테스트 추가 및 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 멤버 프로필에 메인 이미지 외에 추가 프로필 이미지를 표시할 수 있도록 개선했습니다.
  * 추가 이미지는 설정된 순서에 따라 정렬되어 표시됩니다.

* **Tests**
  * 추가 프로필 이미지 조회 및 표시 로직의 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->