### PR TITLE
마지막 접속 시각 저장 및 조회 기능 추가

### DIFF
--- a/src/main/java/deepple/deepple/member/command/application/member/MemberAuthService.java
+++ b/src/main/java/deepple/deepple/member/command/application/member/MemberAuthService.java
@@ -61,6 +61,9 @@ public class MemberAuthService {
 
         Events.raise(MemberLoggedInEvent.from(member.getId()));
 
+        memberCommandRepository.updateLastAccessedAt(member.getId(),
+            LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()));
+
         return new MemberLoginServiceDto(accessToken, refreshToken, member.isProfileSettingNeeded(),
             member.getActivityStatus() != null ? member.getActivityStatus().name() : null);
     }
@@ -107,6 +110,9 @@ public class MemberAuthService {
         String newAccessToken = tokenProvider.createAccessToken(memberId, role, issuedAt);
         String newRefreshToken = tokenProvider.createRefreshToken(memberId, role, issuedAt);
         tokenRepository.save(newRefreshToken);
+
+        memberCommandRepository.updateLastAccessedAt(memberId,
+            LocalDateTime.ofInstant(issuedAt, ZoneId.systemDefault()));
 
         return new TokenPairResponse(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/deepple/deepple/member/command/domain/member/Member.java
+++ b/src/main/java/deepple/deepple/member/command/domain/member/Member.java
@@ -11,6 +11,8 @@ import deepple.deepple.member.command.domain.member.vo.PhoneNumber;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "members", indexes = {
     @Index(name = "idx_deleted_at", columnList = "deletedAt")
@@ -64,6 +66,9 @@ public class Member extends SoftDeleteBaseEntity {
     @Getter
     @Builder.Default
     private boolean isDatingExamSubmitted = false;
+
+    @Getter
+    private LocalDateTime lastAccessedAt;
 
     public static Member fromPhoneNumber(@NonNull String phoneNumber) {
         return Member.builder()

--- a/src/main/java/deepple/deepple/member/command/domain/member/MemberCommandRepository.java
+++ b/src/main/java/deepple/deepple/member/command/domain/member/MemberCommandRepository.java
@@ -24,4 +24,6 @@ public interface MemberCommandRepository {
     List<Member> saveAll(List<Member> members);
 
     void deleteBefore(LocalDateTime dateTime);
+
+    void updateLastAccessedAt(Long memberId, LocalDateTime accessedAt);
 }

--- a/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandJpaRepository.java
+++ b/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandJpaRepository.java
@@ -22,4 +22,8 @@ public interface MemberCommandJpaRepository extends JpaRepository<Member, Long> 
     @Query("DELETE FROM Member m WHERE m.deletedAt <= :deletedAt")
     @Modifying(clearAutomatically = true)
     void deleteAllBefore(LocalDateTime deletedAt);
+
+    @Query("UPDATE Member m SET m.lastAccessedAt = :accessedAt WHERE m.id = :memberId")
+    @Modifying
+    void updateLastAccessedAt(Long memberId, LocalDateTime accessedAt);
 }

--- a/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryImpl.java
+++ b/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryImpl.java
@@ -6,6 +6,7 @@ import deepple.deepple.member.command.domain.member.vo.KakaoId;
 import deepple.deepple.member.command.domain.member.vo.PhoneNumber;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -64,6 +65,7 @@ public class MemberCommandRepositoryImpl implements MemberCommandRepository {
     }
 
     @Override
+    @Transactional
     public void updateLastAccessedAt(Long memberId, LocalDateTime accessedAt) {
         memberCommandJpaRepository.updateLastAccessedAt(memberId, accessedAt);
     }

--- a/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryImpl.java
+++ b/src/main/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryImpl.java
@@ -62,4 +62,9 @@ public class MemberCommandRepositoryImpl implements MemberCommandRepository {
     public void deleteBefore(final LocalDateTime dateTime) {
         memberCommandJpaRepository.deleteAllBefore(dateTime);
     }
+
+    @Override
+    public void updateLastAccessedAt(Long memberId, LocalDateTime accessedAt) {
+        memberCommandJpaRepository.updateLastAccessedAt(memberId, accessedAt);
+    }
 }

--- a/src/main/java/deepple/deepple/member/presentation/member/MemberMapper.java
+++ b/src/main/java/deepple/deepple/member/presentation/member/MemberMapper.java
@@ -52,7 +52,8 @@ public class MemberMapper {
             basicMemberInfo.job(), basicMemberInfo.hobbies(), basicMemberInfo.mbti(), basicMemberInfo.city(),
             basicMemberInfo.district(),
             basicMemberInfo.smokingStatus(), basicMemberInfo.drinkingStatus(), basicMemberInfo.highestEducation(),
-            basicMemberInfo.religion(), basicMemberInfo.like(), additionalProfileImages);
+            basicMemberInfo.religion(), basicMemberInfo.like(), basicMemberInfo.lastAccessedAt(),
+            additionalProfileImages);
     }
 
     public static MemberMyProfileResponse toMemberMyProfileResponse(MemberProfileView view) {

--- a/src/main/java/deepple/deepple/member/presentation/member/dto/MemberInfo.java
+++ b/src/main/java/deepple/deepple/member/presentation/member/dto/MemberInfo.java
@@ -4,6 +4,7 @@ import deepple.deepple.like.command.domain.LikeLevel;
 import deepple.deepple.member.command.domain.member.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -35,6 +36,7 @@ public record MemberInfo(
     String religion,
     @Schema(implementation = LikeLevel.class)
     String likeLevel,
+    LocalDateTime lastAccessedAt,
     @Schema(description = "메인 이미지를 제외한 추가 프로필 이미지 목록 (order 오름차순)")
     List<ProfileImageInfo> additionalProfileImages
 ) {

--- a/src/main/java/deepple/deepple/member/query/member/infra/MemberQueryRepository.java
+++ b/src/main/java/deepple/deepple/member/query/member/infra/MemberQueryRepository.java
@@ -106,6 +106,7 @@ public class MemberQueryRepository {
                     member.profile.smokingStatus.stringValue(), member.profile.drinkingStatus.stringValue(),
                     member.profile.highestEducation.stringValue(), member.profile.religion.stringValue(),
                     like.level.stringValue(),
+                    member.lastAccessedAt,
                     match.id, match.requesterId, match.responderId, match.requestMessage.value,
                     match.responseMessage.value, match.status.stringValue(), match.requesterContactType.stringValue(),
                     match.responderContactType.stringValue(),

--- a/src/main/java/deepple/deepple/member/query/member/view/BasicMemberInfo.java
+++ b/src/main/java/deepple/deepple/member/query/member/view/BasicMemberInfo.java
@@ -1,5 +1,6 @@
 package deepple.deepple.member.query.member.view;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 
 public record BasicMemberInfo(
@@ -18,6 +19,7 @@ public record BasicMemberInfo(
     String drinkingStatus,
     String highestEducation,
     String religion,
-    String like
+    String like,
+    LocalDateTime lastAccessedAt
 ) {
 }

--- a/src/main/java/deepple/deepple/member/query/member/view/OtherMemberProfileView.java
+++ b/src/main/java/deepple/deepple/member/query/member/view/OtherMemberProfileView.java
@@ -2,6 +2,7 @@ package deepple.deepple.member.query.member.view;
 
 import com.querydsl.core.annotations.QueryProjection;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 
 public record OtherMemberProfileView(
@@ -27,6 +28,7 @@ public record OtherMemberProfileView(
         String highestEducation,
         String religion,
         String like,
+        LocalDateTime lastAccessedAt,
         Long matchId,
         Long requesterId,
         Long responderId,
@@ -45,7 +47,7 @@ public record OtherMemberProfileView(
     ) {
         this(
             new BasicMemberInfo(id, nickname, profileImageUrl, yearOfBirth, gender, height, job, hobbies, mbti, city,
-                district, smokingStatus, drinkingStatus, highestEducation, religion, like),
+                district, smokingStatus, drinkingStatus, highestEducation, religion, like, lastAccessedAt),
             matchId == null ? null
                 : new MatchInfo(matchId, requesterId, responderId, requestMessage, responseMessage, matchStatus,
                     requesterContactType, responderContactType),

--- a/src/main/resources/db/migration/V16__add_last_accessed_at_to_members.sql
+++ b/src/main/resources/db/migration/V16__add_last_accessed_at_to_members.sql
@@ -1,0 +1,2 @@
+ALTER TABLE members
+    ADD COLUMN last_accessed_at DATETIME(6) NULL;

--- a/src/test/java/deepple/deepple/member/command/application/member/MemberAuthServiceTest.java
+++ b/src/test/java/deepple/deepple/member/command/application/member/MemberAuthServiceTest.java
@@ -240,6 +240,64 @@ class MemberAuthServiceTest {
             Assertions.assertThatThrownBy(() -> memberAuthService.login(phoneNumber, code))
                 .isInstanceOf(MemberLoginConflictException.class);
         }
+
+        @Test
+        @DisplayName("로그인 성공 시 마지막 접속 시각을 갱신한다")
+        void updatesLastAccessedAtOnLogin() {
+            String phoneNumber = "01012345678";
+            String code = "01012345678";
+            Instant fixedInstant = Instant.parse("2024-01-01T00:00:00Z");
+
+            try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class)) {
+                mockedInstant.when(Instant::now).thenReturn(fixedInstant);
+
+                when(memberCommandRepository.findByPhoneNumber(phoneNumber)).thenReturn(Optional.of(member));
+                when(
+                    jwtProvider.createAccessToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER), Mockito.eq(fixedInstant)))
+                    .thenReturn("accessToken");
+                when(jwtProvider.createRefreshToken(Mockito.anyLong(), Mockito.eq(Role.MEMBER),
+                    Mockito.eq(fixedInstant)))
+                    .thenReturn("refreshToken");
+                Mockito.doNothing().when(authMessageService).authenticate(phoneNumber, code);
+
+                // When
+                memberAuthService.login(phoneNumber, code);
+
+                // Then
+                Mockito.verify(memberCommandRepository)
+                    .updateLastAccessedAt(Mockito.eq(memberId), Mockito.any(LocalDateTime.class));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신 테스트")
+    class Refresh {
+
+        @Test
+        @DisplayName("토큰 갱신 성공 시 마지막 접속 시각을 갱신한다")
+        void updatesLastAccessedAtOnRefresh() {
+            // Given
+            String refreshToken = "refreshToken";
+            long memberId = 1L;
+
+            when(tokenParser.isExpired(refreshToken)).thenReturn(false);
+            when(tokenParser.isValid(refreshToken)).thenReturn(true);
+            when(tokenRepository.exists(refreshToken)).thenReturn(true);
+            when(tokenParser.getId(refreshToken)).thenReturn(memberId);
+            when(tokenParser.getRole(refreshToken)).thenReturn(Role.MEMBER);
+            when(jwtProvider.createAccessToken(Mockito.eq(memberId), Mockito.eq(Role.MEMBER), Mockito.any()))
+                .thenReturn("newAccessToken");
+            when(jwtProvider.createRefreshToken(Mockito.eq(memberId), Mockito.eq(Role.MEMBER), Mockito.any()))
+                .thenReturn("newRefreshToken");
+
+            // When
+            memberAuthService.refresh(refreshToken);
+
+            // Then
+            Mockito.verify(memberCommandRepository)
+                .updateLastAccessedAt(Mockito.eq(memberId), Mockito.any(LocalDateTime.class));
+        }
     }
 
     @Nested

--- a/src/test/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryLastAccessedAtTest.java
+++ b/src/test/java/deepple/deepple/member/command/infra/member/MemberCommandRepositoryLastAccessedAtTest.java
@@ -1,0 +1,48 @@
+package deepple.deepple.member.command.infra.member;
+
+import deepple.deepple.common.MockEventsExtension;
+import deepple.deepple.member.command.domain.member.Member;
+import deepple.deepple.member.command.domain.member.MemberCommandRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(MemberCommandRepositoryImpl.class)
+@ExtendWith(MockEventsExtension.class)
+class MemberCommandRepositoryLastAccessedAtTest {
+
+    @Autowired
+    private MemberCommandRepository memberCommandRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("updateLastAccessedAt 호출 시 last_accessed_at만 갱신되고 updatedAt은 변하지 않는다")
+    void updatesLastAccessedAtWithoutTouchingUpdatedAt() {
+        // Given
+        Member member = Member.fromPhoneNumber("01012345678");
+        entityManager.persist(member);
+        entityManager.flush();
+        LocalDateTime originalUpdatedAt = member.getUpdatedAt();
+        LocalDateTime accessedAt = LocalDateTime.of(2026, 1, 1, 12, 0);
+
+        // When
+        memberCommandRepository.updateLastAccessedAt(member.getId(), accessedAt);
+        entityManager.clear();
+
+        // Then
+        Member reloaded = entityManager.find(Member.class, member.getId());
+        assertThat(reloaded.getLastAccessedAt()).isEqualTo(accessedAt);
+        assertThat(reloaded.getUpdatedAt()).isEqualTo(originalUpdatedAt);
+    }
+}

--- a/src/test/java/deepple/deepple/member/query/member/infra/MemberQueryRepositoryTest.java
+++ b/src/test/java/deepple/deepple/member/query/member/infra/MemberQueryRepositoryTest.java
@@ -33,7 +33,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
@@ -567,6 +569,38 @@ class MemberQueryRepositoryTest {
             assertThat(view.profileExchangeInfo().responderId()).isEqualTo(otherMember.getId());
             assertThat(view.profileExchangeInfo().profileExchangeStatus()).isEqualTo(
                 profileExchange.getStatus().name());
+        }
+
+        @Test
+        @DisplayName("상대방의 마지막 접속 시각을 함께 조회한다")
+        void getLastAccessedAt() {
+            // Given
+            LocalDateTime accessedAt = LocalDateTime.of(2026, 1, 1, 12, 0);
+            ReflectionTestUtils.setField(otherMember, "lastAccessedAt", accessedAt);
+            entityManager.persist(otherMember);
+            entityManager.flush();
+
+            // When
+            OtherMemberProfileView view = memberQueryRepository.findOtherProfileByMemberId(member.getId(),
+                    otherMember.getId())
+                .orElse(null);
+
+            // Then
+            assertThat(view).isNotNull();
+            assertThat(view.basicMemberInfo().lastAccessedAt()).isEqualTo(accessedAt);
+        }
+
+        @Test
+        @DisplayName("접속 기록이 없는 회원은 lastAccessedAt이 null로 조회된다")
+        void getNullLastAccessedAtWhenNeverAccessed() {
+            // When
+            OtherMemberProfileView view = memberQueryRepository.findOtherProfileByMemberId(member.getId(),
+                    otherMember.getId())
+                .orElse(null);
+
+            // Then
+            assertThat(view).isNotNull();
+            assertThat(view.basicMemberInfo().lastAccessedAt()).isNull();
         }
 
         private void assertionsBasicInfo(BasicMemberInfo basicMemberInfo, MemberProfile otherMemberProfile) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 회원의 마지막 접속 시간이 저장되고, 로그인/토큰 갱신 시 자동으로 업데이트됩니다.
  * 회원 프로필 조회 응답에 마지막 접속 시간이 포함됩니다.

* **Bug Fixes**
  * 마지막 접속 기록이 없는 경우에도 프로필 조회가 정상 동작하도록 개선했습니다.

* **Tests**
  * 로그인/갱신 시 마지막 접속 시간 업데이트와 조회 결과 반영을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 자료
- 

## 노트