### PR TITLE
feat(datingexam): 선택 과목 정보 조회 API 삭제 (#451)

### DIFF
--- a/src/main/java/deepple/deepple/datingexam/adapter/webapi/DatingExamApi.java
+++ b/src/main/java/deepple/deepple/datingexam/adapter/webapi/DatingExamApi.java
@@ -44,16 +44,6 @@ public class DatingExamApi {
         return ResponseEntity.ok(BaseResponse.of(StatusType.OK, requiredExamInfo));
     }
 
-    @Operation(summary = "선택 과목 정보 조회 API")
-    @GetMapping("/optional")
-    public ResponseEntity<BaseResponse<DatingExamInfoWithSubjectSubmissionResponse>> getOptionalExamInfo(
-        @AuthPrincipal AuthContext authContext
-    ) {
-        final DatingExamInfoWithSubjectSubmissionResponse optionalExamInfo = datingExamFinder.findOptionalExamInfo(
-            authContext.getId());
-        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, optionalExamInfo));
-    }
-
     @Operation(summary = "대표 성격 유형 조회 API")
     @GetMapping("/personality-type")
     public ResponseEntity<BaseResponse<DominantPersonalityTypeResponse>> getDominantPersonalityType(

--- a/src/main/java/deepple/deepple/datingexam/application/DatingExamQueryService.java
+++ b/src/main/java/deepple/deepple/datingexam/application/DatingExamQueryService.java
@@ -34,13 +34,6 @@ public class DatingExamQueryService implements DatingExamFinder {
     }
 
     @Override
-    public DatingExamInfoWithSubjectSubmissionResponse findOptionalExamInfo(Long memberId) {
-        DatingExamInfoResponse datingExamInfo = datingExamQueryRepository.findDatingExamInfo(SubjectType.OPTIONAL);
-        Set<DatingExamSubmit> submittedExams = datingExamSubmitRepository.findAllByMemberId(memberId);
-        return new DatingExamInfoWithSubjectSubmissionResponse(datingExamInfo, submittedExams);
-    }
-
-    @Override
     public DominantPersonalityTypeResponse findDominantPersonalityType(Long memberId) {
         DatingExamSubmitResult result = datingExamSubmitResultRepository.findByMemberId(memberId)
             .orElseThrow(() -> new IllegalStateException("연애고사 제출 결과가 없습니다. memberId: " + memberId));

--- a/src/main/java/deepple/deepple/datingexam/application/provided/DatingExamFinder.java
+++ b/src/main/java/deepple/deepple/datingexam/application/provided/DatingExamFinder.java
@@ -6,7 +6,5 @@ import deepple.deepple.datingexam.application.dto.DominantPersonalityTypeRespons
 public interface DatingExamFinder {
     DatingExamInfoWithSubjectSubmissionResponse findRequiredExamInfo(Long memberId);
 
-    DatingExamInfoWithSubjectSubmissionResponse findOptionalExamInfo(Long memberId);
-
     DominantPersonalityTypeResponse findDominantPersonalityType(Long memberId);
 }


### PR DESCRIPTION
## 개요
`GET /dating-exam/optional` 선택 과목 정보 조회 API를 삭제합니다.

## 변경 사항
- 컨트롤러 `DatingExamApi.getOptionalExamInfo` 제거
- 삭제로 사용되지 않게 된 `DatingExamFinder.findOptionalExamInfo` (인터페이스 + `DatingExamQueryService` 구현) 제거
- `SubjectType.OPTIONAL` enum은 제출/소울메이트 흐름에서 계속 사용되므로 유지

## 검증
- `./gradlew compileJava` 통과
- `getOptionalExamInfo`/`findOptionalExamInfo` 잔존 참조 없음 (남은 1건은 레포지토리 테스트 메서드명으로 무관)

Closes #451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 선택 과목 정보 조회 기능이 제거되었습니다.
  * 이제 시험 정보 조회는 필수 과목 정보와 대표 성격 유형 정보 조회를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->