### PR TITLE
feat(datingexam): 가치관 테스트 유형 2개 추가 (#453)

### DIFF
--- a/src/main/java/deepple/deepple/datingexam/application/dto/DominantPersonalityTypeResponse.java
+++ b/src/main/java/deepple/deepple/datingexam/application/dto/DominantPersonalityTypeResponse.java
@@ -10,7 +10,9 @@ public record DominantPersonalityTypeResponse(
     int decisiveIndependentCount,
     int growingRunningMateCount,
     int devotedRomanticCount,
-    int realisticShelterCount
+    int realisticShelterCount,
+    int stimulatingAdventurerCount,
+    int rationalRealistCount
 ) {
     public static DominantPersonalityTypeResponse from(DatingExamSubmitResult result) {
         return new DominantPersonalityTypeResponse(
@@ -18,7 +20,9 @@ public record DominantPersonalityTypeResponse(
             result.getDecisiveIndependentCount(),
             result.getGrowingRunningMateCount(),
             result.getDevotedRomanticCount(),
-            result.getRealisticShelterCount()
+            result.getRealisticShelterCount(),
+            result.getStimulatingAdventurerCount(),
+            result.getRationalRealistCount()
         );
     }
 }

--- a/src/main/java/deepple/deepple/datingexam/domain/AnswerPersonalityType.java
+++ b/src/main/java/deepple/deepple/datingexam/domain/AnswerPersonalityType.java
@@ -4,5 +4,7 @@ public enum AnswerPersonalityType {
     DECISIVE_INDEPENDENT,    // (A) 단호한 독립주의자
     GROWING_RUNNING_MATE,    // (B) 성장하는 러닝메이트
     DEVOTED_ROMANTIC,        // (C) 헌신적인 로맨티스트
-    REALISTIC_SHELTER        // (D) 현실적인 안식처
+    REALISTIC_SHELTER,       // (D) 현실적인 안식처
+    STIMULATING_ADVENTURER,  // (E) 자극모험형
+    RATIONAL_REALIST         // (F) 이성중심형
 }

--- a/src/main/java/deepple/deepple/datingexam/domain/DatingExamSubmitResult.java
+++ b/src/main/java/deepple/deepple/datingexam/domain/DatingExamSubmitResult.java
@@ -40,6 +40,12 @@ public class DatingExamSubmitResult extends BaseEntity {
     @Column(nullable = false)
     private int realisticShelterCount;
 
+    @Column(nullable = false)
+    private int stimulatingAdventurerCount;
+
+    @Column(nullable = false)
+    private int rationalRealistCount;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)", nullable = false)
     private AnswerPersonalityType dominantPersonalityType;
@@ -50,6 +56,8 @@ public class DatingExamSubmitResult extends BaseEntity {
         this.growingRunningMateCount = 0;
         this.devotedRomanticCount = 0;
         this.realisticShelterCount = 0;
+        this.stimulatingAdventurerCount = 0;
+        this.rationalRealistCount = 0;
         this.dominantPersonalityType = AnswerPersonalityType.DECISIVE_INDEPENDENT;
     }
 
@@ -62,6 +70,8 @@ public class DatingExamSubmitResult extends BaseEntity {
         this.growingRunningMateCount += counts.getOrDefault(AnswerPersonalityType.GROWING_RUNNING_MATE, 0);
         this.devotedRomanticCount += counts.getOrDefault(AnswerPersonalityType.DEVOTED_ROMANTIC, 0);
         this.realisticShelterCount += counts.getOrDefault(AnswerPersonalityType.REALISTIC_SHELTER, 0);
+        this.stimulatingAdventurerCount += counts.getOrDefault(AnswerPersonalityType.STIMULATING_ADVENTURER, 0);
+        this.rationalRealistCount += counts.getOrDefault(AnswerPersonalityType.RATIONAL_REALIST, 0);
         recalculateDominant();
     }
 
@@ -79,6 +89,14 @@ public class DatingExamSubmitResult extends BaseEntity {
         }
         if (this.realisticShelterCount > maxCount) {
             dominant = AnswerPersonalityType.REALISTIC_SHELTER;
+            maxCount = this.realisticShelterCount;
+        }
+        if (this.stimulatingAdventurerCount > maxCount) {
+            dominant = AnswerPersonalityType.STIMULATING_ADVENTURER;
+            maxCount = this.stimulatingAdventurerCount;
+        }
+        if (this.rationalRealistCount > maxCount) {
+            dominant = AnswerPersonalityType.RATIONAL_REALIST;
         }
 
         this.dominantPersonalityType = dominant;

--- a/src/main/resources/db/migration/V17__add_new_personality_type_counts.sql
+++ b/src/main/resources/db/migration/V17__add_new_personality_type_counts.sql
@@ -1,0 +1,3 @@
+ALTER TABLE dating_exam_submit_result
+    ADD COLUMN stimulating_adventurer_count INT NOT NULL DEFAULT 0,
+    ADD COLUMN rational_realist_count       INT NOT NULL DEFAULT 0;

--- a/src/test/java/deepple/deepple/datingexam/domain/DatingExamSubmitResultTest.java
+++ b/src/test/java/deepple/deepple/datingexam/domain/DatingExamSubmitResultTest.java
@@ -102,6 +102,39 @@ class DatingExamSubmitResultTest {
         }
 
         @Test
+        @DisplayName("신규 유형(STIMULATING_ADVENTURER)도 최다 카운트면 dominant가 된다.")
+        void newTypeCanBecomeDominant() {
+            // Given
+            DatingExamSubmitResult result = DatingExamSubmitResult.create(1L);
+
+            // When
+            result.addCounts(Map.of(
+                AnswerPersonalityType.STIMULATING_ADVENTURER, 4,
+                AnswerPersonalityType.DECISIVE_INDEPENDENT, 2
+            ));
+
+            // Then
+            assertThat(result.getStimulatingAdventurerCount()).isEqualTo(4);
+            assertThat(result.getDominantPersonalityType()).isEqualTo(AnswerPersonalityType.STIMULATING_ADVENTURER);
+        }
+
+        @Test
+        @DisplayName("신규 유형이 기존 유형과 동점이면 ordinal이 작은 기존 유형이 우선한다.")
+        void tieBreaksToExistingTypeOverNewType() {
+            // Given
+            DatingExamSubmitResult result = DatingExamSubmitResult.create(1L);
+
+            // When
+            result.addCounts(Map.of(
+                AnswerPersonalityType.REALISTIC_SHELTER, 3,
+                AnswerPersonalityType.RATIONAL_REALIST, 3
+            ));
+
+            // Then
+            assertThat(result.getDominantPersonalityType()).isEqualTo(AnswerPersonalityType.REALISTIC_SHELTER);
+        }
+
+        @Test
         @DisplayName("빈 맵으로 addCounts를 호출해도 정상 동작한다.")
         void addCountsWithEmptyMap() {
             // Given


### PR DESCRIPTION
## 개요
가치관 테스트 성격 유형을 4종 → 6종으로 확장합니다.

## 변경 사항
- `AnswerPersonalityType`에 `STIMULATING_ADVENTURER`(자극모험형), `RATIONAL_REALIST`(이성중심형) 추가
- `DatingExamSubmitResult`: 유형별 카운트 컬럼 2개 추가, `addCounts`/`recalculateDominant` 확장 — 동점 시 기존 유형(작은 ordinal) 우선 규칙 유지
- `DominantPersonalityTypeResponse`: 카운트 필드 2개 추가
- `V17__add_new_personality_type_counts.sql`: `dating_exam_submit_result`에 컬럼 2개 추가

## 검증
- `DatingExamSubmitResultTest` 통과 (신규 유형 우세/동점 케이스 테스트 추가)

Closes #453