### PR TITLE
feat(member): 유형별 이상형 조회 및 순번별 언락 API 추가 (#454)

### DIFF
--- a/docs/superpowers/specs/2026-07-20-member-personality-type-introduction-design.md
+++ b/docs/superpowers/specs/2026-07-20-member-personality-type-introduction-design.md
@@ -1,0 +1,124 @@
+# 유형별 이상형 조회 API 설계 (#454)
+
+- **이슈**: #454 `GET /member/introduction/{유형}` 유형별 이상형 조회 API 추가
+- **작성일**: 2026-07-20
+- **선행 의존**: #453(가치관 테스트 유형 6종 확장) 완료 — `AnswerPersonalityType` 6종 존재
+
+## 1. 목표
+
+홈화면에서 사용자가 6개 성격 유형(`AnswerPersonalityType`) 중 하나를 선택하면, 그 유형에 해당하는 이성을 최대 3명까지 조회하고 상세로 진입할 수 있는 기능을 추가한다. 하루 1회만 무료 오픈이 가능하며, 상세 진입 시 첫 상대는 무료, 이후 상대는 하트를 소모한다.
+
+## 2. 확정된 요구사항 (화면 플로우 반영)
+
+- 6개 유형을 제공하되 **무료 오픈은 하루 1회**만 가능
+- 한 번 오픈된 유형은 **24시간 유지 후 초기화**(오픈 시점 기준 롤링)
+- 오픈된 유형의 목록은 24시간 동안 **같은 후보 3명이 고정** 노출
+- **다른 유형 차단**: 오늘 한 유형을 오픈했다면 24h 내 다른 유형은 오픈 불가
+- **최대 3명** 제공, 후보가 더 많으면 **최신 가입순** 상위 3명
+- **조회 실패(0명)**: 목록으로 이동하지 않고 팝업만 닫힘 → 서버는 빈 목록 반환하며 **오픈을 소진하지 않음**
+- **상세 진입 = 언락**: 해당 유형의 **첫 언락은 무료**, 2·3번째 언락은 **하트 소모**(순번은 언락 순서 기준)
+
+## 3. 스코프
+
+포함:
+- `GET /member/introduction/{personalityType}` — 유형 오픈 / 목록 조회
+- `POST /member/introduction/{personalityType}/{targetMemberId}` — 상세 언락(순번별 과금)
+
+제외(별도/기존 재사용):
+- 프로필 상세 렌더링 자체(기존 `GET /member/{memberId}` 재사용)
+- #452 문항 데이터 확정(별도 진행)
+
+## 4. 접근 방식
+
+**기존 소개 파이프라인 확장 (A안)** 을 채택한다. 근거: `MemberIntroductionController` / `IntroductionQueryService` / 하트 이벤트 파이프라인(`MemberIntroducedEvent` → `HeartUsageEventHandler`) / View 매핑이 이미 정비되어 재사용 이득이 크다. "유형→회원 조회" 포트만 datingexam에 신규로 추가한다.
+
+## 5. 아키텍처 / 컴포넌트
+
+### 5.1 datingexam 도메인 (신규 포트)
+- `application/provided/PersonalityTypeMemberFinder` (신규 인터페이스)
+  - `List<Long> findMemberIdsByDominantPersonalityType(long requesterId, AnswerPersonalityType type)`
+  - 반환: 반대 성별 · `isProfilePublic=true` · `activityStatus=ACTIVE` · 차단/피차단 제외 필터를 적용한 회원 id를 **최신 가입순(member.id desc)** 으로 반환
+- 구현: `SoulmateQueryRepositoryImpl.findSameAnswerMemberIds()` 를 템플릿으로 한 QueryDSL 조회. `dating_exam_submit_result.dominant_personality_type = :type` 조인/조건 추가.
+- 노출: `SoulmateFinder` 패턴과 동일하게 `provided` 포트로 member 도메인에 제공.
+
+> 결정: "이미 소개/매칭된 상대 제외"는 member_introductions·match 테이블에 의존하므로 datingexam이 아닌 **member 도메인**에서 적용한다(도메인 결합 최소화). datingexam 포트는 유형·성별·공개·활성·차단까지만 책임진다.
+
+### 5.2 member/query 도메인
+- `IntroductionQueryService` (또는 신규 `PersonalityIntroductionQueryService`)에 유형별 조회 유스케이스 추가:
+  1. Redis 오픈 상태 확인
+  2. 미오픈 시 `PersonalityTypeMemberFinder`로 후보 id 획득 → **이미 소개/매칭된 상대 제외** → 상위 3명
+  3. 뷰 매핑은 기존 `findMemberIntroductionProfileViews(memberId, memberIds)` 재사용 → `List<MemberIntroductionProfileView>`
+- Redis 오픈 상태 저장소(신규): 오픈 유형 + 후보 id + 언락 집합 관리.
+
+### 5.3 member/command 도메인
+- 언락(상세 진입) 유스케이스: 첫 언락 무료 / 이후 과금 분기.
+  - 대상이 현재 오픈 목록(Redis)에 포함되는지 검증
+  - 이미 언락됨 → 무과금(멱등) 반환
+  - 언락 집합이 비어있음(첫 언락) → **무료**: `MemberIntroduction` 레코드 생성하되 하트 이벤트 미발행
+  - 그 외 → **과금**: 기존 경로(`MemberIntroduction.of()` → `MemberIntroducedEvent` → `INTRODUCTION` 정책 차감)
+  - 언락 성공 시 Redis 언락 집합에 targetId 추가
+- `IntroductionType`에 신규 값 추가(예: `PERSONALITY`) 및 `TransactionSubtype` 대응값 추가(과금 대상이므로 free-eligible 아님).
+
+> 구현 유의: 기존 `MemberIntroduction.of()`는 생성 시 항상 `MemberIntroducedEvent`를 발행한다. "첫 언락 무료"를 위해 이벤트를 발행하지 않는 생성 경로(무료 전용 팩토리/플래그)가 필요하다. 세부 방식은 구현 계획에서 확정.
+
+### 5.4 presentation
+- `MemberIntroductionController`(`@RequestMapping("/member/introduction")`)에 2개 엔드포인트 추가:
+  - `GET /{personalityType}` → `BaseResponse<List<MemberIntroductionProfileView>>`
+  - `POST /{personalityType}/{targetMemberId}` → `BaseResponse<Void>`(또는 언락된 뷰)
+- 인증: `@AuthPrincipal AuthContext authContext` → `authContext.getId()`
+- 라우팅: 기존 고정 경로(`/grade`,`/hobby`,`/religion`,`/city`,`/recent`,`/ideal`,`/soulmate`)가 우선 매칭되며 `AnswerPersonalityType` enum 값과 겹치지 않아 충돌 없음. 잘못된 유형 문자열은 enum 바인딩 실패 → 400.
+
+## 6. 데이터 흐름
+
+### 6.1 GET (오픈/조회)
+```
+GET /member/introduction/{type}
+  └ Redis 오픈상태 조회 intro:personality:open:{memberId}
+      ├ 존재 & 같은 type  → 저장된 id 3개로 View 매핑 후 반환
+      ├ 존재 & 다른 type  → 409 (이미 오늘 다른 유형 오픈)
+      └ 없음 → PersonalityTypeMemberFinder.findMemberIdsByDominantPersonalityType(memberId, type)
+               → 이미 소개/매칭 제외 → 상위 3명
+               ├ 0명 → 빈 목록 반환(Redis 저장 X, 오픈 미소진)
+               └ ≥1명 → Redis 저장(type + ids, TTL 24h) → View 매핑 후 반환
+```
+
+### 6.2 POST (언락/과금)
+```
+POST /member/introduction/{type}/{targetMemberId}
+  └ Redis 오픈상태 확인: type 일치 & targetMemberId ∈ 저장된 ids 인지 검증(아니면 400/409)
+      ├ 이미 언락(unlocked set 포함) → 무과금 반환
+      ├ unlocked set 비어있음(첫 언락) → 무료 레코드 생성, 이벤트 미발행
+      └ 그 외 → MemberIntroduction.of() → MemberIntroducedEvent → INTRODUCTION 하트 차감
+  └ unlocked set에 targetMemberId 추가
+```
+
+### 6.3 Redis 키
+| 키 | 값 | TTL | 용도 |
+|---|---|---|---|
+| `intro:personality:open:{memberId}` | `{type, [id1,id2,id3]}` | 24h(롤링) | 오픈 상태 + 고정 목록 |
+| `intro:personality:unlocked:{memberId}` | Set&lt;targetId&gt; | 24h(롤링) | 첫 언락 판정 |
+
+> 두 키의 TTL은 오픈 시점에 함께 설정하여 동일 창(window)에서 만료되게 한다.
+
+## 7. 엣지 케이스
+
+- **0명**: 빈 목록 반환, 오픈 미소진(Redis 미저장) — 다음 시도에서 다른/같은 유형 오픈 가능
+- **다른 유형 재오픈**: 24h 내 거부(409)
+- **24h 경과**: 키 만료 → 재오픈 가능(유형 무관)
+- **하트 부족**: 언락 과금 시 기존 하트 부족 예외 그대로 전파(레코드/언락 미반영)
+- **언락 멱등**: 같은 대상 재언락 → 무과금
+- **오픈 목록에 없는 대상 언락 시도**: 거부(위변조 방지)
+- **datingexam 결과 없음(제출 이력 없는 회원만 존재)**: 0명과 동일 처리
+
+## 8. 테스트 전략
+
+- **datingexam 쿼리** (`@DataJpaTest`): `dominantPersonalityType` + 반대성별·공개·ACTIVE·차단제외 필터, 최신순, 다양한 유형 혼재 시 정확 조회
+- **오픈 게이트(서비스 단위)**: 같은 유형 재요청 시 동일 목록 / 다른 유형 거부 / 0명 미소진 / 24h 만료 후 재오픈
+- **언락 과금(서비스 단위)**: 첫 언락 무료(이벤트 미발행) / 2·3번째 과금(이벤트 발행) / 멱등 / 오픈목록 외 대상 거부
+- **하트 차감 통합**: `MemberIntroducedEvent` → `HeartUsageEventHandler` → `INTRODUCTION` 정책(남10/여4) 반영 확인
+
+## 9. 미결/향후
+
+- 상세 응답 형태(POST가 언락된 View를 돌려줄지 Void일지)는 프론트 요구에 맞춰 구현 계획에서 확정
+- `IntroductionType.PERSONALITY` 네이밍 최종 확정
+- 후보 다양성(랜덤) 요구가 추후 생기면 선별 전략만 교체(인터페이스 유지)

--- a/src/main/java/deepple/deepple/datingexam/adapter/database/PersonalityTypeMemberQueryRepositoryImpl.java
+++ b/src/main/java/deepple/deepple/datingexam/adapter/database/PersonalityTypeMemberQueryRepositoryImpl.java
@@ -1,0 +1,84 @@
+package deepple.deepple.datingexam.adapter.database;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import deepple.deepple.datingexam.application.required.PersonalityTypeMemberQueryRepository;
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+import deepple.deepple.member.command.domain.member.ActivityStatus;
+import deepple.deepple.member.command.domain.member.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static deepple.deepple.block.domain.QBlock.block;
+import static deepple.deepple.datingexam.domain.QDatingExamSubmitResult.datingExamSubmitResult;
+import static deepple.deepple.member.command.domain.member.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class PersonalityTypeMemberQueryRepositoryImpl implements PersonalityTypeMemberQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Long> findMemberIdsByDominantType(Long memberId, AnswerPersonalityType type) {
+        Set<Long> typeMemberIds = getMemberIdsByDominantType(type);
+        typeMemberIds.removeAll(getExcludedMemberIds(memberId));
+
+        if (typeMemberIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Gender gender = queryFactory
+            .select(member.profile.gender)
+            .from(member)
+            .where(member.id.eq(memberId))
+            .fetchOne();
+
+        if (gender == null) {
+            throw new IllegalStateException("멤버의 성별이 null입니다. 멤버 ID: " + memberId);
+        }
+
+        return queryFactory
+            .select(member.id)
+            .from(member)
+            .where(member.id.in(typeMemberIds)
+                .and(member.profile.gender.eq(gender.getOpposite()))
+                .and(member.isProfilePublic.isTrue())
+                .and(member.activityStatus.eq(ActivityStatus.ACTIVE))
+                .and(member.id.ne(memberId))
+            )
+            .orderBy(member.id.desc())
+            .fetch();
+    }
+
+    private Set<Long> getMemberIdsByDominantType(AnswerPersonalityType type) {
+        return new HashSet<>(queryFactory
+            .select(datingExamSubmitResult.memberId)
+            .from(datingExamSubmitResult)
+            .where(datingExamSubmitResult.dominantPersonalityType.eq(type))
+            .fetch());
+    }
+
+    private Set<Long> getExcludedMemberIds(Long memberId) {
+        List<Long> blockedIds = queryFactory
+            .select(block.blockedId)
+            .from(block)
+            .where(block.blockerId.eq(memberId))
+            .fetch();
+
+        List<Long> blockerIds = queryFactory
+            .select(block.blockerId)
+            .from(block)
+            .where(block.blockedId.eq(memberId))
+            .fetch();
+
+        return Stream.concat(
+            Stream.concat(blockedIds.stream(), blockerIds.stream()),
+            Stream.of(memberId)
+        ).collect(java.util.stream.Collectors.toSet());
+    }
+}

--- a/src/main/java/deepple/deepple/datingexam/application/PersonalityTypeMemberQueryService.java
+++ b/src/main/java/deepple/deepple/datingexam/application/PersonalityTypeMemberQueryService.java
@@ -1,0 +1,25 @@
+package deepple.deepple.datingexam.application;
+
+import deepple.deepple.datingexam.application.provided.PersonalityTypeMemberFinder;
+import deepple.deepple.datingexam.application.required.PersonalityTypeMemberQueryRepository;
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+@Service
+@Transactional
+@Validated
+@RequiredArgsConstructor
+public class PersonalityTypeMemberQueryService implements PersonalityTypeMemberFinder {
+    private final PersonalityTypeMemberQueryRepository personalityTypeMemberQueryRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Long> findMemberIdsByDominantType(Long memberId, AnswerPersonalityType type) {
+        return personalityTypeMemberQueryRepository.findMemberIdsByDominantType(memberId, type);
+    }
+}

--- a/src/main/java/deepple/deepple/datingexam/application/provided/PersonalityTypeMemberFinder.java
+++ b/src/main/java/deepple/deepple/datingexam/application/provided/PersonalityTypeMemberFinder.java
@@ -1,0 +1,13 @@
+package deepple.deepple.datingexam.application.provided;
+
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+
+import java.util.List;
+
+public interface PersonalityTypeMemberFinder {
+    /**
+     * 주어진 대표 성격 유형(dominantPersonalityType)을 가진 이성 회원 id를 최신 가입순으로 조회한다.
+     * 반대 성별 · 프로필 공개 · ACTIVE · 차단/피차단·본인 제외 필터가 적용된다.
+     */
+    List<Long> findMemberIdsByDominantType(Long memberId, AnswerPersonalityType type);
+}

--- a/src/main/java/deepple/deepple/datingexam/application/required/PersonalityTypeMemberQueryRepository.java
+++ b/src/main/java/deepple/deepple/datingexam/application/required/PersonalityTypeMemberQueryRepository.java
@@ -1,0 +1,9 @@
+package deepple.deepple.datingexam.application.required;
+
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+
+import java.util.List;
+
+public interface PersonalityTypeMemberQueryRepository {
+    List<Long> findMemberIdsByDominantType(Long memberId, AnswerPersonalityType type);
+}

--- a/src/main/java/deepple/deepple/heart/command/domain/hearttransaction/vo/TransactionSubtype.java
+++ b/src/main/java/deepple/deepple/heart/command/domain/hearttransaction/vo/TransactionSubtype.java
@@ -13,6 +13,7 @@ public enum TransactionSubtype {
     SOULMATE("소울 메이트"),
     SAME_ANSWER("연애 고사 답변 일치"),
     IDEAL("이상형"),
+    PERSONALITY("유형별 이상형"),
     MATCH("매칭"),
     MATCH_ACCEPTED("매칭 수락"),
     PROFILE_EXCHANGE("프로필 교환");

--- a/src/main/java/deepple/deepple/member/command/application/introduction/PersonalityIntroductionUnlockService.java
+++ b/src/main/java/deepple/deepple/member/command/application/introduction/PersonalityIntroductionUnlockService.java
@@ -1,0 +1,72 @@
+package deepple.deepple.member.command.application.introduction;
+
+import deepple.deepple.block.application.required.BlockRepository;
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+import deepple.deepple.member.command.application.introduction.exception.IntroducedMemberBlockedException;
+import deepple.deepple.member.command.application.introduction.exception.IntroducedMemberNotActiveException;
+import deepple.deepple.member.command.application.introduction.exception.IntroducedMemberNotFoundException;
+import deepple.deepple.member.command.application.introduction.exception.InvalidPersonalityIntroductionUnlockException;
+import deepple.deepple.member.command.domain.introduction.IntroductionType;
+import deepple.deepple.member.command.domain.introduction.MemberIntroduction;
+import deepple.deepple.member.command.domain.introduction.MemberIntroductionCommandRepository;
+import deepple.deepple.member.command.domain.member.Member;
+import deepple.deepple.member.command.domain.member.MemberCommandRepository;
+import deepple.deepple.member.query.introduction.intra.PersonalityIntroductionOpenState;
+import deepple.deepple.member.query.introduction.intra.PersonalityIntroductionRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalityIntroductionUnlockService {
+    private final MemberCommandRepository memberCommandRepository;
+    private final MemberIntroductionCommandRepository memberIntroductionCommandRepository;
+    private final BlockRepository blockRepository;
+    private final PersonalityIntroductionRedisRepository personalityIntroductionRedisRepository;
+
+    /**
+     * 유형별 이상형 프로필 상세를 언락한다.
+     * 오픈된 유형의 첫 언락은 무료(하트 이벤트 미발행), 이후 언락은 하트를 차감한다.
+     * 이미 언락된 대상은 멱등하게 처리한다.
+     */
+    @Transactional
+    public void unlock(long memberId, AnswerPersonalityType type, long targetMemberId) {
+        PersonalityIntroductionOpenState openState = personalityIntroductionRedisRepository.findOpenState(memberId)
+            .orElseThrow(() -> new InvalidPersonalityIntroductionUnlockException("오픈된 유형별 이상형 목록이 없습니다."));
+        if (openState.type() != type || !openState.memberIds().contains(targetMemberId)) {
+            throw new InvalidPersonalityIntroductionUnlockException(
+                "오픈된 목록에 없는 대상입니다. targetMemberId: " + targetMemberId);
+        }
+
+        Set<Long> unlockedMemberIds = personalityIntroductionRedisRepository.findUnlockedMemberIds(memberId);
+        if (unlockedMemberIds.contains(targetMemberId)
+            || memberIntroductionCommandRepository.existsByMemberIdAndIntroducedMemberId(memberId, targetMemberId)) {
+            return;
+        }
+
+        validateTarget(memberId, targetMemberId);
+
+        boolean isFirstUnlock = unlockedMemberIds.isEmpty();
+        MemberIntroduction memberIntroduction = isFirstUnlock
+            ? MemberIntroduction.ofWithoutCharge(memberId, targetMemberId, IntroductionType.PERSONALITY)
+            : MemberIntroduction.of(memberId, targetMemberId, IntroductionType.PERSONALITY);
+        memberIntroductionCommandRepository.save(memberIntroduction);
+
+        personalityIntroductionRedisRepository.addUnlockedMemberId(memberId, targetMemberId);
+    }
+
+    private void validateTarget(long memberId, long targetMemberId) {
+        Member target = memberCommandRepository.findById(targetMemberId)
+            .orElseThrow(IntroducedMemberNotFoundException::new);
+        if (!target.isActive()) {
+            throw new IntroducedMemberNotActiveException();
+        }
+        if (blockRepository.existsByBlockerIdAndBlockedId(memberId, targetMemberId)
+            || blockRepository.existsByBlockerIdAndBlockedId(targetMemberId, memberId)) {
+            throw new IntroducedMemberBlockedException();
+        }
+    }
+}

--- a/src/main/java/deepple/deepple/member/command/application/introduction/exception/InvalidPersonalityIntroductionUnlockException.java
+++ b/src/main/java/deepple/deepple/member/command/application/introduction/exception/InvalidPersonalityIntroductionUnlockException.java
@@ -1,0 +1,7 @@
+package deepple.deepple.member.command.application.introduction.exception;
+
+public class InvalidPersonalityIntroductionUnlockException extends RuntimeException {
+    public InvalidPersonalityIntroductionUnlockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/deepple/deepple/member/command/application/introduction/exception/PersonalityIntroductionAlreadyOpenedException.java
+++ b/src/main/java/deepple/deepple/member/command/application/introduction/exception/PersonalityIntroductionAlreadyOpenedException.java
@@ -1,0 +1,10 @@
+package deepple.deepple.member.command.application.introduction.exception;
+
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+
+public class PersonalityIntroductionAlreadyOpenedException extends RuntimeException {
+    public PersonalityIntroductionAlreadyOpenedException(AnswerPersonalityType openedType,
+        AnswerPersonalityType requestedType) {
+        super("오늘은 이미 '" + openedType + "' 유형을 소개받아 다른 유형('" + requestedType + "')은 소개받을 수 없습니다.");
+    }
+}

--- a/src/main/java/deepple/deepple/member/command/domain/introduction/IntroductionType.java
+++ b/src/main/java/deepple/deepple/member/command/domain/introduction/IntroductionType.java
@@ -11,7 +11,8 @@ public enum IntroductionType {
     TODAY_CARD("오늘의 카드"),
     SOULMATE("소울 메이트"),
     SAME_ANSWER("연애 고사 답변 일치"),
-    IDEAL("이상형");
+    IDEAL("이상형"),
+    PERSONALITY("유형별 이상형");
 
     @Getter
     private final String description;

--- a/src/main/java/deepple/deepple/member/command/domain/introduction/MemberIntroduction.java
+++ b/src/main/java/deepple/deepple/member/command/domain/introduction/MemberIntroduction.java
@@ -45,6 +45,15 @@ public class MemberIntroduction extends BaseEntity {
         return memberIntroduction;
     }
 
+    /**
+     * 하트 차감 이벤트를 발행하지 않고 소개 레코드만 생성한다.
+     * 유형별 이상형의 첫 언락처럼 무료로 소개해야 하는 경우에 사용한다.
+     */
+    public static MemberIntroduction ofWithoutCharge(Long memberId, Long introducedMemberId,
+        @NonNull IntroductionType type) {
+        return new MemberIntroduction(memberId, introducedMemberId, type);
+    }
+
     private void validateMemberId(@NonNull Long memberId, @NonNull Long introducedMemberId) {
         if (memberId.equals(introducedMemberId)) {
             throw new InvalidIntroductionMemberIdException(memberId, introducedMemberId);

--- a/src/main/java/deepple/deepple/member/presentation/introduction/MemberIntroductionController.java
+++ b/src/main/java/deepple/deepple/member/presentation/introduction/MemberIntroductionController.java
@@ -5,11 +5,14 @@ import deepple.deepple.auth.presentation.AuthPrincipal;
 import deepple.deepple.common.enums.StatusType;
 import deepple.deepple.common.response.BaseResponse;
 import deepple.deepple.datingexam.application.provided.SoulmateFinder;
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
 import deepple.deepple.member.command.application.introduction.MemberIntroductionService;
+import deepple.deepple.member.command.application.introduction.PersonalityIntroductionUnlockService;
 import deepple.deepple.member.command.application.introduction.TodayCardService;
 import deepple.deepple.member.presentation.introduction.dto.MemberIntroductionCreateRequest;
 import deepple.deepple.member.query.introduction.application.IntroductionQueryService;
 import deepple.deepple.member.query.introduction.application.MemberIntroductionProfileView;
+import deepple.deepple.member.query.introduction.application.PersonalityIntroductionQueryService;
 import deepple.deepple.member.query.introduction.application.TodayCardQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,6 +34,8 @@ public class MemberIntroductionController {
     private final IntroductionQueryService introductionQueryService;
     private final MemberIntroductionService memberIntroductionService;
     private final SoulmateFinder soulmateFinder;
+    private final PersonalityIntroductionQueryService personalityIntroductionQueryService;
+    private final PersonalityIntroductionUnlockService personalityIntroductionUnlockService;
 
     @Operation(summary = "다이아 등급 이성 조회")
     @GetMapping("/grade")
@@ -192,6 +197,28 @@ public class MemberIntroductionController {
         @AuthPrincipal AuthContext authContext) {
         long memberId = authContext.getId();
         memberIntroductionService.createIdealIntroduction(memberId, request.introducedMemberId());
+        return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
+    }
+
+    @Operation(summary = "유형별 이상형 조회 (하루 1회 오픈, 최대 3명)")
+    @GetMapping("/{personalityType}")
+    public ResponseEntity<BaseResponse<List<MemberIntroductionProfileView>>> findPersonalityTypeIntroductions(
+        @PathVariable AnswerPersonalityType personalityType,
+        @AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        List<MemberIntroductionProfileView> introductionProfileViews =
+            personalityIntroductionQueryService.open(memberId, personalityType);
+        return ResponseEntity.ok(BaseResponse.of(StatusType.OK, introductionProfileViews));
+    }
+
+    @Operation(summary = "유형별 이상형 프로필 상세 언락 (첫 상대 무료, 이후 하트 차감)")
+    @PostMapping("/{personalityType}/{targetMemberId}")
+    public ResponseEntity<BaseResponse<Void>> unlockPersonalityTypeIntroduction(
+        @PathVariable AnswerPersonalityType personalityType,
+        @PathVariable long targetMemberId,
+        @AuthPrincipal AuthContext authContext) {
+        long memberId = authContext.getId();
+        personalityIntroductionUnlockService.unlock(memberId, personalityType, targetMemberId);
         return ResponseEntity.ok(BaseResponse.from(StatusType.OK));
     }
 }

--- a/src/main/java/deepple/deepple/member/presentation/introduction/MemberIntroductionExceptionHandler.java
+++ b/src/main/java/deepple/deepple/member/presentation/introduction/MemberIntroductionExceptionHandler.java
@@ -67,4 +67,22 @@ public class MemberIntroductionExceptionHandler {
         return ResponseEntity.status(400)
             .body(BaseResponse.of(StatusType.BAD_REQUEST, e.getMessage()));
     }
+
+    @ExceptionHandler(PersonalityIntroductionAlreadyOpenedException.class)
+    public ResponseEntity<BaseResponse<Void>> handlePersonalityIntroductionAlreadyOpenedException(
+        PersonalityIntroductionAlreadyOpenedException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(409)
+            .body(BaseResponse.of(StatusType.CONFLICT, e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidPersonalityIntroductionUnlockException.class)
+    public ResponseEntity<BaseResponse<Void>> handleInvalidPersonalityIntroductionUnlockException(
+        InvalidPersonalityIntroductionUnlockException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(400)
+            .body(BaseResponse.of(StatusType.BAD_REQUEST, e.getMessage()));
+    }
 }

--- a/src/main/java/deepple/deepple/member/query/introduction/application/PersonalityIntroductionQueryService.java
+++ b/src/main/java/deepple/deepple/member/query/introduction/application/PersonalityIntroductionQueryService.java
@@ -1,0 +1,73 @@
+package deepple.deepple.member.query.introduction.application;
+
+import deepple.deepple.datingexam.application.provided.PersonalityTypeMemberFinder;
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+import deepple.deepple.member.command.application.introduction.exception.PersonalityIntroductionAlreadyOpenedException;
+import deepple.deepple.member.query.introduction.intra.IntroductionQueryRepository;
+import deepple.deepple.member.query.introduction.intra.PersonalityIntroductionOpenState;
+import deepple.deepple.member.query.introduction.intra.PersonalityIntroductionRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalityIntroductionQueryService {
+    private static final int MAX_CANDIDATES = 3;
+
+    private final PersonalityTypeMemberFinder personalityTypeMemberFinder;
+    private final IntroductionQueryService introductionQueryService;
+    private final IntroductionQueryRepository introductionQueryRepository;
+    private final PersonalityIntroductionRedisRepository personalityIntroductionRedisRepository;
+
+    /**
+     * 유형별 이상형을 오픈하고 목록(최대 3명)을 조회한다.
+     * 같은 유형이 이미 열려 있으면 24시간 고정된 목록을 그대로 반환하고,
+     * 다른 유형이 열려 있으면 예외를 던진다. 후보가 0명이면 오픈을 소진하지 않는다.
+     */
+    public List<MemberIntroductionProfileView> open(long memberId, AnswerPersonalityType type) {
+        Optional<PersonalityIntroductionOpenState> openState =
+            personalityIntroductionRedisRepository.findOpenState(memberId);
+        if (openState.isPresent()) {
+            PersonalityIntroductionOpenState state = openState.get();
+            if (state.type() != type) {
+                throw new PersonalityIntroductionAlreadyOpenedException(state.type(), type);
+            }
+            return toProfileViews(memberId, state.memberIds());
+        }
+
+        List<Long> candidateMemberIds = computeCandidateMemberIds(memberId, type);
+        if (candidateMemberIds.isEmpty()) {
+            return List.of();
+        }
+        personalityIntroductionRedisRepository.saveOpenState(memberId,
+            new PersonalityIntroductionOpenState(type, candidateMemberIds));
+        return toProfileViews(memberId, candidateMemberIds);
+    }
+
+    private List<Long> computeCandidateMemberIds(long memberId, AnswerPersonalityType type) {
+        List<Long> typeMemberIds = personalityTypeMemberFinder.findMemberIdsByDominantType(memberId, type);
+        Set<Long> excludedMemberIds = findExcludedMemberIds(memberId);
+        return typeMemberIds.stream()
+            .filter(id -> !excludedMemberIds.contains(id))
+            .limit(MAX_CANDIDATES)
+            .toList();
+    }
+
+    private Set<Long> findExcludedMemberIds(long memberId) {
+        Set<Long> excludedMemberIds = new HashSet<>();
+        excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestedMemberId(memberId));
+        excludedMemberIds.addAll(introductionQueryRepository.findAllMatchRequestingMemberId(memberId));
+        excludedMemberIds.addAll(introductionQueryRepository.findAllIntroducedMemberId(memberId));
+        return excludedMemberIds;
+    }
+
+    private List<MemberIntroductionProfileView> toProfileViews(long memberId, List<Long> memberIds) {
+        return introductionQueryService.findMemberIntroductionProfileViews(memberId, new LinkedHashSet<>(memberIds));
+    }
+}

--- a/src/main/java/deepple/deepple/member/query/introduction/intra/PersonalityIntroductionOpenState.java
+++ b/src/main/java/deepple/deepple/member/query/introduction/intra/PersonalityIntroductionOpenState.java
@@ -1,0 +1,15 @@
+package deepple.deepple.member.query.introduction.intra;
+
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+
+import java.util.List;
+
+/**
+ * 유형별 이상형 오픈 상태. 오픈 시점에 확정된 유형과 고정 후보 id 목록을 담는다.
+ * Redis에 JSON으로 직렬화되어 24시간 동안 유지된다.
+ */
+public record PersonalityIntroductionOpenState(
+    AnswerPersonalityType type,
+    List<Long> memberIds
+) {
+}

--- a/src/main/java/deepple/deepple/member/query/introduction/intra/PersonalityIntroductionRedisRepository.java
+++ b/src/main/java/deepple/deepple/member/query/introduction/intra/PersonalityIntroductionRedisRepository.java
@@ -1,0 +1,90 @@
+package deepple.deepple.member.query.introduction.intra;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import deepple.deepple.member.query.introduction.intra.exception.IntroductionMemberIdSerializationFailedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class PersonalityIntroductionRedisRepository {
+    private static final String OPEN_PREFIX = "introduction:personality:open:";
+    private static final String UNLOCKED_PREFIX = "introduction:personality:unlocked:";
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveOpenState(long memberId, PersonalityIntroductionOpenState state) {
+        try {
+            redisTemplate.opsForValue().set(openKey(memberId), objectMapper.writeValueAsString(state), TTL);
+        } catch (JsonProcessingException e) {
+            throw new IntroductionMemberIdSerializationFailedException(e);
+        }
+    }
+
+    public Optional<PersonalityIntroductionOpenState> findOpenState(long memberId) {
+        String json = redisTemplate.opsForValue().get(openKey(memberId));
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, PersonalityIntroductionOpenState.class));
+        } catch (JsonProcessingException e) {
+            throw new IntroductionMemberIdSerializationFailedException(e);
+        }
+    }
+
+    public Set<Long> findUnlockedMemberIds(long memberId) {
+        String json = redisTemplate.opsForValue().get(unlockedKey(memberId));
+        if (json == null) {
+            return new HashSet<>();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<Set<Long>>() {});
+        } catch (JsonProcessingException e) {
+            throw new IntroductionMemberIdSerializationFailedException(e);
+        }
+    }
+
+    public void addUnlockedMemberId(long memberId, long targetMemberId) {
+        Set<Long> unlockedMemberIds = findUnlockedMemberIds(memberId);
+        unlockedMemberIds.add(targetMemberId);
+        try {
+            redisTemplate.opsForValue().set(unlockedKey(memberId), objectMapper.writeValueAsString(unlockedMemberIds));
+        } catch (JsonProcessingException e) {
+            throw new IntroductionMemberIdSerializationFailedException(e);
+        }
+        alignUnlockedExpiry(memberId);
+    }
+
+    /**
+     * 언락 집합 키의 만료 시각을 오픈 상태 키와 동일한 창(window)으로 맞춘다.
+     * 언락이 반복돼도 24시간 창이 연장되지 않도록 오픈 키의 남은 TTL을 따른다.
+     */
+    private void alignUnlockedExpiry(long memberId) {
+        Long remainingSeconds = redisTemplate.getExpire(openKey(memberId), TimeUnit.SECONDS);
+        if (remainingSeconds != null && remainingSeconds > 0) {
+            redisTemplate.expire(unlockedKey(memberId), Duration.ofSeconds(remainingSeconds));
+        } else {
+            redisTemplate.expire(unlockedKey(memberId), TTL);
+        }
+    }
+
+    private String openKey(long memberId) {
+        return OPEN_PREFIX + memberId;
+    }
+
+    private String unlockedKey(long memberId) {
+        return UNLOCKED_PREFIX + memberId;
+    }
+}

--- a/src/test/java/deepple/deepple/datingexam/adapter/database/PersonalityTypeMemberQueryRepositoryImplTest.java
+++ b/src/test/java/deepple/deepple/datingexam/adapter/database/PersonalityTypeMemberQueryRepositoryImplTest.java
@@ -1,0 +1,114 @@
+package deepple.deepple.datingexam.adapter.database;
+
+import deepple.deepple.block.domain.Block;
+import deepple.deepple.common.MockEventsExtension;
+import deepple.deepple.common.config.QueryDslConfig;
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+import deepple.deepple.datingexam.domain.DatingExamSubmitResult;
+import deepple.deepple.member.command.domain.member.ActivityStatus;
+import deepple.deepple.member.command.domain.member.Gender;
+import deepple.deepple.member.command.domain.member.Member;
+import deepple.deepple.member.command.domain.member.vo.MemberProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import({QueryDslConfig.class, PersonalityTypeMemberQueryRepositoryImpl.class})
+@ExtendWith(MockEventsExtension.class)
+@DataJpaTest
+class PersonalityTypeMemberQueryRepositoryImplTest {
+
+    private static final AnswerPersonalityType TARGET_TYPE = AnswerPersonalityType.STIMULATING_ADVENTURER;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private PersonalityTypeMemberQueryRepositoryImpl repository;
+
+    private int phoneSeq = 0;
+
+    @Test
+    @DisplayName("대표 유형이 일치하는 반대 성별·공개·활성 회원만 최신 가입순으로 조회하고, 다른 유형·동성·비공개·비활성·차단·본인은 제외한다.")
+    void findMemberIdsByDominantType() {
+        // given: 요청자(남성)
+        Member requester = createMember(Gender.MALE, true, ActivityStatus.ACTIVE);
+        createSubmitResult(requester.getId(), TARGET_TYPE);
+
+        // 포함 대상: 반대 성별(여성) · 공개 · 활성 · 대표 유형 일치
+        Member includedA = createMember(Gender.FEMALE, true, ActivityStatus.ACTIVE);
+        createSubmitResult(includedA.getId(), TARGET_TYPE);
+        Member includedB = createMember(Gender.FEMALE, true, ActivityStatus.ACTIVE);
+        createSubmitResult(includedB.getId(), TARGET_TYPE);
+
+        // 제외 대상들
+        Member differentType = createMember(Gender.FEMALE, true, ActivityStatus.ACTIVE);
+        createSubmitResult(differentType.getId(), AnswerPersonalityType.RATIONAL_REALIST);
+
+        Member sameGender = createMember(Gender.MALE, true, ActivityStatus.ACTIVE);
+        createSubmitResult(sameGender.getId(), TARGET_TYPE);
+
+        Member notPublic = createMember(Gender.FEMALE, false, ActivityStatus.ACTIVE);
+        createSubmitResult(notPublic.getId(), TARGET_TYPE);
+
+        Member dormant = createMember(Gender.FEMALE, true, ActivityStatus.DORMANT);
+        createSubmitResult(dormant.getId(), TARGET_TYPE);
+
+        Member blocked = createMember(Gender.FEMALE, true, ActivityStatus.ACTIVE);
+        createSubmitResult(blocked.getId(), TARGET_TYPE);
+        createBlock(requester.getId(), blocked.getId());
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<Long> result = repository.findMemberIdsByDominantType(requester.getId(), TARGET_TYPE);
+
+        // then: 최신 가입순(id desc) → 나중에 가입한 includedB가 먼저
+        assertThat(result).containsExactly(includedB.getId(), includedA.getId());
+    }
+
+    private Member createMember(Gender gender, boolean isProfilePublic, ActivityStatus activityStatus) {
+        Member member = Member.fromPhoneNumber(nextPhoneNumber());
+        em.persist(member);
+        member.updateProfile(MemberProfile.builder().gender(gender).build());
+        if (isProfilePublic) {
+            member.publishProfile();
+        }
+        em.flush();
+
+        if (activityStatus == ActivityStatus.ACTIVE) {
+            member.changeToActive();
+        }
+        if (activityStatus == ActivityStatus.DORMANT && member.isActive()) {
+            member.changeToDormant();
+        }
+        em.flush();
+        return member;
+    }
+
+    private void createSubmitResult(Long memberId, AnswerPersonalityType type) {
+        DatingExamSubmitResult result = DatingExamSubmitResult.create(memberId);
+        result.addCounts(Map.of(type, 1));
+        em.persist(result);
+        em.flush();
+    }
+
+    private void createBlock(Long blockerId, Long blockedId) {
+        em.persist(Block.of(blockerId, blockedId));
+        em.flush();
+    }
+
+    private String nextPhoneNumber() {
+        return String.format("010%08d", phoneSeq++);
+    }
+}

--- a/src/test/java/deepple/deepple/member/command/application/introduction/PersonalityIntroductionUnlockServiceTest.java
+++ b/src/test/java/deepple/deepple/member/command/application/introduction/PersonalityIntroductionUnlockServiceTest.java
@@ -1,0 +1,168 @@
+package deepple.deepple.member.command.application.introduction;
+
+import deepple.deepple.block.application.required.BlockRepository;
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+import deepple.deepple.member.command.application.introduction.exception.InvalidPersonalityIntroductionUnlockException;
+import deepple.deepple.member.command.domain.introduction.IntroductionType;
+import deepple.deepple.member.command.domain.introduction.MemberIntroduction;
+import deepple.deepple.member.command.domain.introduction.MemberIntroductionCommandRepository;
+import deepple.deepple.member.command.domain.member.Member;
+import deepple.deepple.member.command.domain.member.MemberCommandRepository;
+import deepple.deepple.member.query.introduction.intra.PersonalityIntroductionOpenState;
+import deepple.deepple.member.query.introduction.intra.PersonalityIntroductionRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalityIntroductionUnlockServiceTest {
+
+    private static final AnswerPersonalityType TYPE = AnswerPersonalityType.STIMULATING_ADVENTURER;
+
+    @InjectMocks
+    private PersonalityIntroductionUnlockService personalityIntroductionUnlockService;
+
+    @Mock
+    private MemberCommandRepository memberCommandRepository;
+    @Mock
+    private MemberIntroductionCommandRepository memberIntroductionCommandRepository;
+    @Mock
+    private BlockRepository blockRepository;
+    @Mock
+    private PersonalityIntroductionRedisRepository personalityIntroductionRedisRepository;
+
+    @Test
+    @DisplayName("오픈된 상태가 없으면 예외를 던진다.")
+    void throwsWhenNotOpened() {
+        long memberId = 1L;
+        long targetMemberId = 2L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> personalityIntroductionUnlockService.unlock(memberId, TYPE, targetMemberId))
+            .isInstanceOf(InvalidPersonalityIntroductionUnlockException.class);
+    }
+
+    @Test
+    @DisplayName("오픈된 목록에 없는 대상이면 예외를 던진다.")
+    void throwsWhenTargetNotInOpenedList() {
+        long memberId = 1L;
+        long targetMemberId = 99L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId))
+            .thenReturn(Optional.of(new PersonalityIntroductionOpenState(TYPE, List.of(2L, 3L, 4L))));
+
+        assertThatThrownBy(() -> personalityIntroductionUnlockService.unlock(memberId, TYPE, targetMemberId))
+            .isInstanceOf(InvalidPersonalityIntroductionUnlockException.class);
+    }
+
+    @Test
+    @DisplayName("오픈된 유형과 요청 유형이 다르면 예외를 던진다.")
+    void throwsWhenTypeMismatch() {
+        long memberId = 1L;
+        long targetMemberId = 2L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId))
+            .thenReturn(Optional.of(new PersonalityIntroductionOpenState(AnswerPersonalityType.RATIONAL_REALIST,
+                List.of(2L, 3L, 4L))));
+
+        assertThatThrownBy(() -> personalityIntroductionUnlockService.unlock(memberId, TYPE, targetMemberId))
+            .isInstanceOf(InvalidPersonalityIntroductionUnlockException.class);
+    }
+
+    @Test
+    @DisplayName("이미 언락된 대상이면 과금 없이 멱등하게 처리한다.")
+    void idempotentWhenAlreadyUnlocked() {
+        long memberId = 1L;
+        long targetMemberId = 2L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId))
+            .thenReturn(Optional.of(new PersonalityIntroductionOpenState(TYPE, List.of(2L, 3L, 4L))));
+        when(personalityIntroductionRedisRepository.findUnlockedMemberIds(memberId)).thenReturn(Set.of(2L));
+
+        personalityIntroductionUnlockService.unlock(memberId, TYPE, targetMemberId);
+
+        verify(memberIntroductionCommandRepository, never()).save(any());
+        verify(personalityIntroductionRedisRepository, never()).addUnlockedMemberId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("이미 소개 레코드가 있으면(Redis 유실 등) 과금 없이 멱등하게 처리한다.")
+    void idempotentWhenAlreadyIntroducedInDb() {
+        long memberId = 1L;
+        long targetMemberId = 2L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId))
+            .thenReturn(Optional.of(new PersonalityIntroductionOpenState(TYPE, List.of(2L, 3L, 4L))));
+        when(personalityIntroductionRedisRepository.findUnlockedMemberIds(memberId)).thenReturn(Set.of());
+        when(memberIntroductionCommandRepository.existsByMemberIdAndIntroducedMemberId(memberId, targetMemberId))
+            .thenReturn(true);
+
+        personalityIntroductionUnlockService.unlock(memberId, TYPE, targetMemberId);
+
+        verify(memberIntroductionCommandRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("해당 유형의 첫 언락은 하트 차감 없이(ofWithoutCharge) 소개를 생성한다.")
+    void firstUnlockIsFree() {
+        long memberId = 1L;
+        long targetMemberId = 2L;
+        givenValidTarget(memberId, targetMemberId);
+        when(personalityIntroductionRedisRepository.findOpenState(memberId))
+            .thenReturn(Optional.of(new PersonalityIntroductionOpenState(TYPE, List.of(2L, 3L, 4L))));
+        when(personalityIntroductionRedisRepository.findUnlockedMemberIds(memberId)).thenReturn(Set.of());
+
+        try (MockedStatic<MemberIntroduction> mocked = mockStatic(MemberIntroduction.class)) {
+            MemberIntroduction introduction = mock(MemberIntroduction.class);
+            mocked.when(() -> MemberIntroduction.ofWithoutCharge(memberId, targetMemberId, IntroductionType.PERSONALITY))
+                .thenReturn(introduction);
+
+            personalityIntroductionUnlockService.unlock(memberId, TYPE, targetMemberId);
+
+            mocked.verify(() -> MemberIntroduction.ofWithoutCharge(memberId, targetMemberId,
+                IntroductionType.PERSONALITY));
+            mocked.verify(() -> MemberIntroduction.of(anyLong(), anyLong(), any()), never());
+            verify(memberIntroductionCommandRepository).save(introduction);
+            verify(personalityIntroductionRedisRepository).addUnlockedMemberId(memberId, targetMemberId);
+        }
+    }
+
+    @Test
+    @DisplayName("첫 언락 이후에는 하트를 차감하며(of) 소개를 생성한다.")
+    void subsequentUnlockCharges() {
+        long memberId = 1L;
+        long targetMemberId = 3L;
+        givenValidTarget(memberId, targetMemberId);
+        when(personalityIntroductionRedisRepository.findOpenState(memberId))
+            .thenReturn(Optional.of(new PersonalityIntroductionOpenState(TYPE, List.of(2L, 3L, 4L))));
+        when(personalityIntroductionRedisRepository.findUnlockedMemberIds(memberId)).thenReturn(Set.of(2L));
+
+        try (MockedStatic<MemberIntroduction> mocked = mockStatic(MemberIntroduction.class)) {
+            MemberIntroduction introduction = mock(MemberIntroduction.class);
+            mocked.when(() -> MemberIntroduction.of(memberId, targetMemberId, IntroductionType.PERSONALITY))
+                .thenReturn(introduction);
+
+            personalityIntroductionUnlockService.unlock(memberId, TYPE, targetMemberId);
+
+            mocked.verify(() -> MemberIntroduction.of(memberId, targetMemberId, IntroductionType.PERSONALITY));
+            mocked.verify(() -> MemberIntroduction.ofWithoutCharge(anyLong(), anyLong(), any()), never());
+            verify(memberIntroductionCommandRepository).save(introduction);
+            verify(personalityIntroductionRedisRepository).addUnlockedMemberId(memberId, targetMemberId);
+        }
+    }
+
+    private void givenValidTarget(long memberId, long targetMemberId) {
+        Member target = mock(Member.class);
+        when(target.isActive()).thenReturn(true);
+        when(memberCommandRepository.findById(targetMemberId)).thenReturn(Optional.of(target));
+        when(blockRepository.existsByBlockerIdAndBlockedId(memberId, targetMemberId)).thenReturn(false);
+        when(blockRepository.existsByBlockerIdAndBlockedId(targetMemberId, memberId)).thenReturn(false);
+    }
+}

--- a/src/test/java/deepple/deepple/member/query/introduction/application/PersonalityIntroductionQueryServiceTest.java
+++ b/src/test/java/deepple/deepple/member/query/introduction/application/PersonalityIntroductionQueryServiceTest.java
@@ -1,0 +1,122 @@
+package deepple.deepple.member.query.introduction.application;
+
+import deepple.deepple.datingexam.application.provided.PersonalityTypeMemberFinder;
+import deepple.deepple.datingexam.domain.AnswerPersonalityType;
+import deepple.deepple.member.command.application.introduction.exception.PersonalityIntroductionAlreadyOpenedException;
+import deepple.deepple.member.query.introduction.intra.IntroductionQueryRepository;
+import deepple.deepple.member.query.introduction.intra.PersonalityIntroductionOpenState;
+import deepple.deepple.member.query.introduction.intra.PersonalityIntroductionRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalityIntroductionQueryServiceTest {
+
+    private static final AnswerPersonalityType TYPE = AnswerPersonalityType.STIMULATING_ADVENTURER;
+
+    @InjectMocks
+    private PersonalityIntroductionQueryService personalityIntroductionQueryService;
+
+    @Mock
+    private PersonalityTypeMemberFinder personalityTypeMemberFinder;
+    @Mock
+    private IntroductionQueryService introductionQueryService;
+    @Mock
+    private IntroductionQueryRepository introductionQueryRepository;
+    @Mock
+    private PersonalityIntroductionRedisRepository personalityIntroductionRedisRepository;
+
+    @Test
+    @DisplayName("같은 유형이 이미 열려 있으면 후보를 재계산하지 않고 고정된 목록을 반환한다.")
+    void returnsFrozenListWhenSameTypeOpened() {
+        long memberId = 1L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId))
+            .thenReturn(Optional.of(new PersonalityIntroductionOpenState(TYPE, List.of(2L, 3L, 4L))));
+
+        personalityIntroductionQueryService.open(memberId, TYPE);
+
+        verify(introductionQueryService).findMemberIntroductionProfileViews(eq(memberId), eq(Set.of(2L, 3L, 4L)));
+        verify(personalityTypeMemberFinder, never()).findMemberIdsByDominantType(anyLong(), any());
+        verify(personalityIntroductionRedisRepository, never()).saveOpenState(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("다른 유형이 이미 열려 있으면 예외를 던진다.")
+    void throwsWhenDifferentTypeOpened() {
+        long memberId = 1L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId))
+            .thenReturn(Optional.of(new PersonalityIntroductionOpenState(AnswerPersonalityType.RATIONAL_REALIST,
+                List.of(2L, 3L, 4L))));
+
+        assertThatThrownBy(() -> personalityIntroductionQueryService.open(memberId, TYPE))
+            .isInstanceOf(PersonalityIntroductionAlreadyOpenedException.class);
+    }
+
+    @Test
+    @DisplayName("오픈되지 않은 상태에서 후보가 있으면 최신순 최대 3명을 저장하고 반환한다.")
+    void savesAndReturnsWhenNotOpened() {
+        long memberId = 1L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId)).thenReturn(Optional.empty());
+        when(personalityTypeMemberFinder.findMemberIdsByDominantType(memberId, TYPE))
+            .thenReturn(List.of(10L, 9L, 8L, 7L));
+        givenNoExclusions(memberId);
+
+        personalityIntroductionQueryService.open(memberId, TYPE);
+
+        verify(personalityIntroductionRedisRepository)
+            .saveOpenState(eq(memberId), eq(new PersonalityIntroductionOpenState(TYPE, List.of(10L, 9L, 8L))));
+        verify(introductionQueryService).findMemberIntroductionProfileViews(eq(memberId), eq(Set.of(10L, 9L, 8L)));
+    }
+
+    @Test
+    @DisplayName("후보가 0명이면 오픈을 소진하지 않고(저장 X) 빈 목록을 반환한다.")
+    void emptyDoesNotConsumeOpen() {
+        long memberId = 1L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId)).thenReturn(Optional.empty());
+        when(personalityTypeMemberFinder.findMemberIdsByDominantType(memberId, TYPE)).thenReturn(List.of());
+        givenNoExclusions(memberId);
+
+        assertThat(personalityIntroductionQueryService.open(memberId, TYPE)).isEmpty();
+
+        verify(personalityIntroductionRedisRepository, never()).saveOpenState(anyLong(), any());
+        verify(introductionQueryService, never()).findMemberIntroductionProfileViews(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("이미 소개/매칭된 상대는 제외한 뒤 최대 3명을 선별한다.")
+    void excludesAlreadyIntroduced() {
+        long memberId = 1L;
+        when(personalityIntroductionRedisRepository.findOpenState(memberId)).thenReturn(Optional.empty());
+        when(personalityTypeMemberFinder.findMemberIdsByDominantType(memberId, TYPE))
+            .thenReturn(List.of(10L, 9L, 8L, 7L));
+        when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(Set.of());
+        when(introductionQueryRepository.findAllMatchRequestingMemberId(memberId)).thenReturn(Set.of());
+        when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(Set.of(9L));
+
+        personalityIntroductionQueryService.open(memberId, TYPE);
+
+        verify(personalityIntroductionRedisRepository)
+            .saveOpenState(eq(memberId), eq(new PersonalityIntroductionOpenState(TYPE, List.of(10L, 8L, 7L))));
+    }
+
+    private void givenNoExclusions(long memberId) {
+        when(introductionQueryRepository.findAllMatchRequestedMemberId(memberId)).thenReturn(Set.of());
+        when(introductionQueryRepository.findAllMatchRequestingMemberId(memberId)).thenReturn(Set.of());
+        when(introductionQueryRepository.findAllIntroducedMemberId(memberId)).thenReturn(Set.of());
+    }
+}


### PR DESCRIPTION
## 개요
`GET /member/introduction/{personalityType}` 유형별 이상형 조회 + 순번별 하트 과금 언락 API를 추가합니다.

> ⚠️ 이 PR은 #453(가치관 유형 6종 확장)에 의존하여 `feat/453` 브랜치를 base로 하는 stacked PR입니다. #453(PR #456) 머지 후 base를 develop으로 변경 예정입니다.

## 주요 동작
- `GET /member/introduction/{personalityType}`: 선택 유형의 이성 최대 3명(최신 가입순) 조회
  - 하루 1회 오픈, 24h 롤링(Redis)로 고정 목록 유지, 다른 유형 오픈 차단(409)
  - 후보 0명이면 오픈 미소진(빈 목록 반환) — "0명이면 팝업만 닫힘" 플로우와 일치
  - 반대성별·프로필 공개·ACTIVE·차단 제외 + 이미 소개/매칭된 상대 제외
- `POST /member/introduction/{personalityType}/{targetMemberId}`: 상세 언락
  - 해당 유형 첫 언락 무료(하트 이벤트 미발행), 이후 `INTRODUCTION` 하트 차감(남10/여4)
  - 이미 언락/소개된 대상은 멱등 처리

## 구현
- **datingexam**: `PersonalityTypeMemberFinder` 포트 + QueryDSL 구현 (기존 `SoulmateFinder` 패턴)
- **member/query**: `PersonalityIntroductionQueryService` + `PersonalityIntroductionRedisRepository`(24h 롤링)
- **member/command**: `PersonalityIntroductionUnlockService`, `MemberIntroduction.ofWithoutCharge`(무과금 팩토리)
- **enum**: `IntroductionType.PERSONALITY`, `TransactionSubtype.PERSONALITY`

## 설계 문서
`docs/superpowers/specs/2026-07-20-member-personality-type-introduction-design.md`

## 테스트
- 오픈 게이트 / 0명 미소진 / 제외·최대 3명 (QueryService 단위)
- 첫 언락 무료 vs 이후 과금 / 멱등 / 검증 (UnlockService 단위)
- 유형·성별·공개·활성·차단·최신순 필터 (Repository @DataJpaTest)

Closes #454